### PR TITLE
Add receiver base class, SBus and Crsf derived classes and universal normalisation of data

### DIFF
--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -1,0 +1,313 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   Crsf.cpp
+* @brief  This class handles communications with a CRSF/ELRS RC receiver.
+*/
+
+#include "Crsf.hpp"
+#include "Utilities.hpp"
+
+
+/**
+* @brief    CRSF constructor.
+* @param    uart - Pointer to hardware serial port.
+* @param    rxPin - RX pin number.
+* @param    txPin - TX pin number.
+*/
+Crsf::Crsf(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin)
+{
+  m_uart = uart;
+  m_uart->begin(CRSF_BAUD, SERIAL_8N1, rxPin, txPin, false);
+  m_uart->flush();
+}
+
+
+/**
+* @brief    Decodes the CRSF serial stream into usable channel and flag data.
+* @return   Returns true when new data is available.
+*/
+bool
+Crsf::getDemands()
+{
+  uint32_t currentByte;
+  uint32_t rxCount = 0U;
+
+  // We loop for a maximum of MAX_BYTES_PER_LOOP bytes then get out of here to avoid blocking main loop.
+  while (m_uart->available() && (rxCount < MAX_BYTES_PER_LOOP))
+  {
+    currentByte = m_uart->read();
+    rxCount++;
+
+    // State 0: Looking for sync byte (device address)
+    if (0U == m_bufferIndex)
+    {
+      if ((currentByte == CRSF_ADDRESS_FLIGHT_CONTROLLER) ||
+          (currentByte == CRSF_ADDRESS_ALTERNATIVE))
+      {
+        m_buffer[m_bufferIndex] = currentByte;
+        m_bufferIndex++;
+      }
+    }
+    // State 1: Get frame length
+    else if (1U == m_bufferIndex)
+    {
+      // Frame length includes type + payload + crc, should be reasonable
+      if ((currentByte >= 2U) && (currentByte <= (CRSF_MAX_FRAME_SIZE - 2U)))
+      {
+        m_buffer[m_bufferIndex] = currentByte;
+        m_bufferIndex++;
+      }
+      else
+      {
+        // Invalid length, reset state machine
+        m_bufferIndex = 0U;
+      }
+    }
+    // State 2+: Collect frame data
+    else
+    {
+      m_buffer[m_bufferIndex] = currentByte;
+      m_bufferIndex++;
+      
+      // Check if we have complete frame (ADDR + LEN + frame_length bytes)
+      uint32_t frameLength = m_buffer[CRSF_LENGTH_OFFSET];
+      if (m_bufferIndex >= (frameLength + 2U))
+      {
+        // Validate CRC
+        uint32_t crcIndex = frameLength + 1U;
+        uint32_t calculatedCrc = calculateCrc(&m_buffer[CRSF_FRAMETYPE_OFFSET], frameLength - 1U);
+        
+        if (calculatedCrc == m_buffer[crcIndex])
+        {
+          // Valid frame - process based on type
+          uint32_t frameType = m_buffer[CRSF_FRAMETYPE_OFFSET];
+          const uint32_t *payload = &m_buffer[CRSF_PAYLOAD_OFFSET];
+          uint32_t payloadLength = m_buffer[CRSF_LENGTH_OFFSET];
+          
+          if (CRSF_FRAMETYPE_RC_CHANNELS == frameType)
+          {
+            parseRcChannels(payload, payloadLength);
+            
+            // Reset communications timer
+            lossOfCommsTimer.set(COMMS_TIME_OUT_PERIOD);
+            m_rxData.lostComms = false;
+
+            if constexpr(Config::DEBUG_RX)
+            {
+              printData();
+            }
+
+            // Reset buffer for next frame
+            m_bufferIndex = 0U;
+            
+            return true;
+          }
+          else if (CRSF_FRAMETYPE_LINK_STATS == frameType)
+          {
+            parseLinkStatistics(payload, payloadLength);
+          }
+          else
+          {
+            // Unknown frame type - ignore
+          }
+        }
+        
+        // Reset buffer for next frame
+        m_bufferIndex = 0U;
+      }
+      
+      // Prevent buffer overflow
+      if (m_bufferIndex >= CRSF_MAX_FRAME_SIZE)
+      {
+        m_bufferIndex = 0U;
+      }
+    }
+  }
+
+  if (CTimer::State::EXPIRED == lossOfCommsTimer.getState())
+  {
+    m_rxData.lostComms = true;
+  }
+
+  return false;
+}
+
+
+/**
+* @brief    Parses and normalises RC channels from CRSF payload.
+* @param    payload - Pointer to RC channels payload (22 bytes).
+* @param    payloadLength - Length of payload.
+*/
+void
+Crsf::parseRcChannels(const uint32_t *payload, uint32_t payloadLength)
+{
+  uint32_t rawChannels[NUM_CRSF_CH];
+
+  // Verify we have enough data for 16 channels (22 bytes)
+  if (payloadLength < CRSF_RC_FRAME_SIZE)
+  {
+    return;
+  }
+
+  // Unpack 11-bit channels from packed byte array
+  // CRSF channel packing is little-endian, LSB first
+  rawChannels[0]  = ((payload[0]       | (payload[1]  << 8U))                           & 0x07FFU);
+  rawChannels[1]  = (((payload[1] >> 3U) | (payload[2]  << 5U))                         & 0x07FFU);
+  rawChannels[2]  = (((payload[2] >> 6U) | (payload[3]  << 2U) | (payload[4] << 10U))  & 0x07FFU);
+  rawChannels[3]  = (((payload[4] >> 1U) | (payload[5]  << 7U))                         & 0x07FFU);
+  rawChannels[4]  = (((payload[5] >> 4U) | (payload[6]  << 4U))                         & 0x07FFU);
+  rawChannels[5]  = (((payload[6] >> 7U) | (payload[7]  << 1U) | (payload[8] << 9U))   & 0x07FFU);
+  rawChannels[6]  = (((payload[8] >> 2U) | (payload[9]  << 6U))                         & 0x07FFU);
+  rawChannels[7]  = (((payload[9] >> 5U) | (payload[10] << 3U))                         & 0x07FFU);
+  rawChannels[8]  = ((payload[11]      | (payload[12] << 8U))                           & 0x07FFU);
+  rawChannels[9]  = (((payload[12] >> 3U) | (payload[13] << 5U))                        & 0x07FFU);
+  rawChannels[10] = (((payload[13] >> 6U) | (payload[14] << 2U) | (payload[15] << 10U)) & 0x07FFU);
+  rawChannels[11] = (((payload[15] >> 1U) | (payload[16] << 7U))                        & 0x07FFU);
+  rawChannels[12] = (((payload[16] >> 4U) | (payload[17] << 4U))                        & 0x07FFU);
+  rawChannels[13] = (((payload[17] >> 7U) | (payload[18] << 1U) | (payload[19] << 9U))  & 0x07FFU);
+  rawChannels[14] = (((payload[19] >> 2U) | (payload[20] << 6U))                        & 0x07FFU);
+  rawChannels[15] = (((payload[20] >> 5U) | (payload[21] << 3U))                        & 0x07FFU);
+
+  // Normalise all channels to -1024/+1024 range
+  for (uint32_t i = 0U; i < NUM_CRSF_CH; i++)
+  {
+    m_rxData.ch[i] = map32(rawChannels[i], MIN_CRSF_US, MAX_CRSF_US, MIN_NORMALISED, MAX_NORMALISED);
+  }
+
+  // Multi-level failsafe detection
+  m_rxData.failsafe = m_rxData.lostComms || (m_crsfLinkStats.linkQuality < FAILSAFE_LQ_THRESHOLD);
+}
+
+
+/**
+* @brief    Parses link statistics from CRSF payload.
+* @param    payload - Pointer to link statistics payload.
+* @param    payloadLength - Length of payload.
+*/
+void
+Crsf::parseLinkStatistics(const uint32_t *payload, uint32_t payloadLength)
+{
+  // Verify we have enough data for link statistics (10 bytes minimum)
+  if (payloadLength < CRSF_LINK_FRAME_SIZE)
+  {
+    return;
+  }
+
+  // Store uplink (receiver to transmitter) statistics
+  m_crsfLinkStats.rssiDbm = static_cast<int8_t>(payload[0]);
+  m_crsfLinkStats.linkQuality = static_cast<uint8_t>(payload[2]);
+  m_crsfLinkStats.snrDb = static_cast<int8_t>(payload[3]);
+  m_crsfLinkStats.txPower = static_cast<uint8_t>(payload[6]);
+}
+
+
+/**
+* @brief    Calculate CRC8 for a single byte (DVB-S2 polynomial).
+* @param    crc - Current CRC value.
+* @param    a - Byte to process.
+* @return   Updated CRC8 value.
+*/
+uint32_t
+Crsf::crc8_dvb_s2(uint32_t crc, uint32_t a) const
+{
+  crc ^= a;
+  for (uint32_t i = 0U; i < 8U; i++)
+  {
+    if ((crc & 0x80U) != 0U)
+    {
+      crc = (crc << 1U) ^ 0xD5U;
+    }
+    else
+    {
+      crc = crc << 1U;
+    }
+  }
+  return crc;
+}
+
+
+/**
+* @brief    Calculate CRC8 for a data buffer.
+* @param    data - Pointer to data buffer.
+* @param    length - Length of data.
+* @return   CRC8 value.
+*/
+uint32_t
+Crsf::calculateCrc(const uint32_t *data, uint32_t length) const
+{
+  uint32_t crc = 0U;
+  for (uint32_t i = 0U; i < length; i++)
+  {
+    crc = crc8_dvb_s2(crc, data[i]);
+  }
+  return crc;
+}
+
+
+/**
+* @brief    Returns the most recent receiver data.
+* @return   RxPacket containing failsafe, communication status, and normalised channel data.
+*/
+const RxBase::RxPacket
+Crsf::getData() const
+{
+  return m_rxData;
+}
+
+
+/**
+* @brief    Check if communications have been lost.
+* @return   true when CRSF comms has been lost, false otherwise.
+*/
+const bool
+Crsf::hasLostCommunications() const
+{
+  return m_rxData.lostComms;
+}
+
+
+/**
+* @brief    Returns the CRSF-specific link statistics.
+* @return   CrsfLinkStats structure containing link quality data.
+*/
+Crsf::CrsfLinkStats
+Crsf::getLinkStats() const
+{
+  return m_crsfLinkStats;
+}
+
+
+/**
+* @brief    Prints CRSF data to console for debugging.
+*/
+void
+Crsf::printData(void)
+{
+  // Display the received normalised data
+  for (uint32_t i = 0U; i < NUM_CRSF_CH; i++)
+  {
+    Serial.print(m_rxData.ch[i]);
+    Serial.print("\t");
+  }
+  // Display failsafe and communications status
+  Serial.print(m_rxData.failsafe);
+  Serial.print("\t");
+  Serial.println(m_rxData.lostComms);
+}

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -300,6 +300,17 @@ Crsf::getLinkStats() const
 void
 Crsf::printData(void)
 {
+  static uint32_t lastPrintTime = 0U;
+  uint32_t now = micros();
+  uint32_t delta = now - lastPrintTime;
+  lastPrintTime = now;
+
+  // Display update time delta in microseconds
+  uint32_t hz = (delta > 0U) ? (1000000U / delta) : 0U;
+  Serial.print("Hz=");
+  Serial.print(hz, 1);
+  Serial.print("\t");
+  
   // Display the received normalised data
   for (uint32_t i = 0U; i < NUM_CRSF_CH; i++)
   {

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -93,13 +93,13 @@ Crsf::getDemands()
         // Validate CRC
         uint32_t crcIndex = frameLength + 1U;
         uint32_t calculatedCrc = calculateCrc(&m_buffer[CRSF_FRAMETYPE_OFFSET], frameLength - 1U);
-        
+
         if (calculatedCrc == m_buffer[crcIndex])
         {
           // Valid frame - process based on type
           uint32_t frameType = m_buffer[CRSF_FRAMETYPE_OFFSET];
-          const uint32_t *payload = &m_buffer[CRSF_PAYLOAD_OFFSET];
-          uint32_t payloadLength = m_buffer[CRSF_LENGTH_OFFSET];
+          const uint8_t *payload = &m_buffer[CRSF_PAYLOAD_OFFSET];
+          uint8_t payloadLength = m_buffer[CRSF_LENGTH_OFFSET];
           
           if (CRSF_FRAMETYPE_RC_CHANNELS == frameType)
           {
@@ -156,7 +156,7 @@ Crsf::getDemands()
 * @param    payloadLength - Length of payload.
 */
 void
-Crsf::parseRcChannels(const uint32_t *payload, uint32_t payloadLength)
+Crsf::parseRcChannels(const uint8_t *payload, uint8_t payloadLength)
 {
   uint32_t rawChannels[NUM_CRSF_CH];
 
@@ -202,7 +202,7 @@ Crsf::parseRcChannels(const uint32_t *payload, uint32_t payloadLength)
 * @param    payloadLength - Length of payload.
 */
 void
-Crsf::parseLinkStatistics(const uint32_t *payload, uint32_t payloadLength)
+Crsf::parseLinkStatistics(const uint8_t *payload, uint8_t payloadLength)
 {
   // Verify we have enough data for link statistics (10 bytes minimum)
   if (payloadLength < CRSF_LINK_FRAME_SIZE)
@@ -224,8 +224,8 @@ Crsf::parseLinkStatistics(const uint32_t *payload, uint32_t payloadLength)
 * @param    a - Byte to process.
 * @return   Updated CRC8 value.
 */
-uint32_t
-Crsf::crc8_dvb_s2(uint32_t crc, uint32_t a) const
+uint8_t
+Crsf::crc8_dvb_s2(uint8_t crc, uint8_t a) const
 {
   crc ^= a;
   for (uint32_t i = 0U; i < 8U; i++)
@@ -249,8 +249,8 @@ Crsf::crc8_dvb_s2(uint32_t crc, uint32_t a) const
 * @param    length - Length of data.
 * @return   CRC8 value.
 */
-uint32_t
-Crsf::calculateCrc(const uint32_t *data, uint32_t length) const
+uint8_t
+Crsf::calculateCrc(const uint8_t *data, uint8_t length) const
 {
   uint32_t crc = 0U;
   for (uint32_t i = 0U; i < length; i++)

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -1,0 +1,179 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   Crsf.hpp
+* @brief  This class handles communications with a CRSF/ELRS RC receiver.
+*/
+
+#pragma once
+
+#include <inttypes.h>
+#include <HardwareSerial.h>
+#include <Arduino.h>
+#include "Timer.hpp"
+#include "Config.hpp"
+#include "RxBase.hpp"
+
+
+/**
+ * @class Crsf
+ * @brief CRSF protocol decoder implementation derived from RxBase.
+ */
+class Crsf : public RxBase
+{
+  public:
+    static constexpr uint32_t MIN_CRSF_US        = 172U;
+    static constexpr uint32_t MID_CRSF_US        = 992U;
+    static constexpr uint32_t MAX_CRSF_US        = 1811U;
+
+    /**
+     * @brief Channel mapping for CRSF protocol (AETR ordering).
+     * Maps standard channel names to physical CRSF channel positions.
+     * CRSF native ordering: Aileron, Elevator, Throttle, Rudder
+     */
+    static constexpr uint32_t CHANNEL_MAP[9] = 
+    {
+      2U,  // THROTTLE
+      0U,  // ROLL (Aileron)
+      1U,  // PITCH (Elevator)
+      3U,  // YAW (Rudder)
+      4U,  // ARM
+      5U,  // MODE
+      6U,  // AUX1
+      7U,  // AUX2
+      8U   // AUX3
+    };
+
+    /**
+     * @struct CrsfLinkStats
+     * @brief CRSF-specific link quality statistics.
+     */
+    struct CrsfLinkStats
+    {
+      uint8_t linkQuality;  // Link quality percentage (0-100)
+      int8_t rssiDbm;       // RSSI in dBm (-128 to 0)
+      uint8_t txPower;      // TX power index
+      int8_t snrDb;         // SNR in dB
+    };
+    
+    /**
+     * @brief Constructor for CRSF receiver.
+     * @param uart Pointer to hardware serial port.
+     * @param rxPin RX pin number.
+     * @param txPin TX pin number.
+     */
+    Crsf(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin);
+
+    /**
+     * @brief Get new data from CRSF receiver.
+     * @return true when new data is available, false otherwise.
+     */
+    bool getDemands() override;
+
+    /**
+     * @brief Print receiver data to console for debugging.
+     */
+    void printData();
+
+    /**
+     * @brief Get receiver data packet.
+     * @return RxPacket containing failsafe status, communication status, and normalised channel data.
+     */
+    const RxPacket getData() const override;
+
+    /**
+     * @brief Check if communications have been lost.
+     * @return true if communications lost, false otherwise.
+     */
+    const bool hasLostCommunications() const override;
+
+    /**
+     * @brief Get channel index from channel name.
+     * @param name The channel name enum.
+     * @return Channel index (0-based).
+     */
+    constexpr uint32_t getChannelIndex(ChannelName name) const override
+    {
+      return CHANNEL_MAP[static_cast<uint32_t>(name)];
+    }
+
+    /**
+     * @brief Get CRSF-specific link statistics.
+     * @return CrsfLinkStats structure containing link quality data.
+     */
+    CrsfLinkStats getLinkStats() const;
+
+  private:
+    static constexpr uint32_t CRSF_BAUD                 = 420000U;
+    static constexpr uint32_t CRSF_MAX_FRAME_SIZE       = 64U;
+    static constexpr uint32_t CRSF_PAYLOAD_OFFSET       = 3U;
+    static constexpr uint32_t CRSF_FRAMETYPE_OFFSET     = 2U;
+    static constexpr uint32_t CRSF_LENGTH_OFFSET        = 1U;
+    static constexpr uint32_t NUM_CRSF_CH               = 16U;
+    static constexpr uint32_t MAX_BYTES_PER_LOOP        = 6U;
+    static constexpr uint32_t CRSF_RC_FRAME_SIZE        = 22U;
+    static constexpr uint32_t CRSF_LINK_FRAME_SIZE      = 12U;
+    static constexpr uint64_t COMMS_TIME_OUT_PERIOD     = 100U;
+    static constexpr uint8_t  FAILSAFE_LQ_THRESHOLD     = 20U;
+    
+    // CRSF Device Addresses
+    static constexpr uint8_t CRSF_ADDRESS_FLIGHT_CONTROLLER = 0xC8U;
+    static constexpr uint8_t CRSF_ADDRESS_ALTERNATIVE       = 0xECU;
+    
+    // CRSF Frame Types
+    static constexpr uint8_t CRSF_FRAMETYPE_RC_CHANNELS = 0x16U;
+    static constexpr uint8_t CRSF_FRAMETYPE_LINK_STATS  = 0x14U;
+
+    HardwareSerial *m_uart;
+    uint32_t m_bufferIndex = 0U;
+    uint32_t m_buffer[CRSF_MAX_FRAME_SIZE] = {};
+    CrsfLinkStats m_crsfLinkStats = {0U, -128, 0U, -128};
+
+    CTimer lossOfCommsTimer = CTimer(0);
+
+    /**
+     * @brief Parse RC channels from CRSF payload.
+     * @param payload Pointer to RC channels payload (22 bytes).
+     * @param payloadLength Length of payload.
+     */
+    void parseRcChannels(const uint32_t *payload, uint32_t payloadLength);
+
+    /**
+     * @brief Parse link statistics from CRSF payload.
+     * @param payload Pointer to link statistics payload.
+     * @param payloadLength Length of payload.
+     */
+    void parseLinkStatistics(const uint32_t *payload, uint32_t payloadLength);
+
+    /**
+     * @brief Calculate CRC8 for a single byte (DVB-S2 polynomial).
+     * @param crc Current CRC value.
+     * @param a Byte to process.
+     * @return Updated CRC8 value.
+     */
+    uint32_t crc8_dvb_s2(uint32_t crc, uint32_t a) const;
+
+    /**
+     * @brief Calculate CRC8 for a data buffer.
+     * @param data Pointer to data buffer.
+     * @param length Length of data.
+     * @return CRC8 value.
+     */
+    uint32_t calculateCrc(const uint32_t *data, uint32_t length) const;
+};

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -108,7 +108,7 @@ class Crsf : public RxBase
      * @param name The channel name enum.
      * @return Channel index (0-based).
      */
-    constexpr uint32_t getChannelIndex(ChannelName name) const override
+    uint32_t getChannelIndex(ChannelName name) const override
     {
       return CHANNEL_MAP[static_cast<uint32_t>(name)];
     }
@@ -141,8 +141,8 @@ class Crsf : public RxBase
     static constexpr uint8_t CRSF_FRAMETYPE_LINK_STATS  = 0x14U;
 
     HardwareSerial *m_uart;
-    uint32_t m_bufferIndex = 0U;
-    uint32_t m_buffer[CRSF_MAX_FRAME_SIZE] = {};
+    uint8_t m_bufferIndex = 0U;
+    uint8_t m_buffer[CRSF_MAX_FRAME_SIZE] = {};
     CrsfLinkStats m_crsfLinkStats = {0U, -128, 0U, -128};
 
     CTimer lossOfCommsTimer = CTimer(0);
@@ -152,14 +152,14 @@ class Crsf : public RxBase
      * @param payload Pointer to RC channels payload (22 bytes).
      * @param payloadLength Length of payload.
      */
-    void parseRcChannels(const uint32_t *payload, uint32_t payloadLength);
+    void parseRcChannels(const uint8_t *payload, uint8_t payloadLength);
 
     /**
      * @brief Parse link statistics from CRSF payload.
      * @param payload Pointer to link statistics payload.
      * @param payloadLength Length of payload.
      */
-    void parseLinkStatistics(const uint32_t *payload, uint32_t payloadLength);
+    void parseLinkStatistics(const uint8_t *payload, uint8_t payloadLength);
 
     /**
      * @brief Calculate CRC8 for a single byte (DVB-S2 polynomial).
@@ -167,7 +167,7 @@ class Crsf : public RxBase
      * @param a Byte to process.
      * @return Updated CRC8 value.
      */
-    uint32_t crc8_dvb_s2(uint32_t crc, uint32_t a) const;
+    uint8_t crc8_dvb_s2(uint8_t crc, uint8_t a) const;
 
     /**
      * @brief Calculate CRC8 for a data buffer.
@@ -175,5 +175,5 @@ class Crsf : public RxBase
      * @param length Length of data.
      * @return CRC8 value.
      */
-    uint32_t calculateCrc(const uint32_t *data, uint32_t length) const;
+    uint8_t calculateCrc(const uint8_t *data, uint8_t length) const;
 };

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -126,7 +126,7 @@ class Crsf : public RxBase
     static constexpr uint32_t CRSF_FRAMETYPE_OFFSET     = 2U;
     static constexpr uint32_t CRSF_LENGTH_OFFSET        = 1U;
     static constexpr uint32_t NUM_CRSF_CH               = 16U;
-    static constexpr uint32_t MAX_BYTES_PER_LOOP        = 6U;
+    static constexpr uint32_t MAX_BYTES_PER_LOOP        = 10U;
     static constexpr uint32_t CRSF_RC_FRAME_SIZE        = 22U;
     static constexpr uint32_t CRSF_LINK_FRAME_SIZE      = 12U;
     static constexpr uint64_t COMMS_TIME_OUT_PERIOD     = 100U;

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -169,8 +169,8 @@ void
 DemandProcessor::decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState)
 {
   FlightState demandedFlightState = *flightState;
-  m_demand.armed = RxBase::isSwitchHigh(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::ARM)]);
-  m_throttleHigh = (RxBase::LOW_THROTTLE_NORM < m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::THROTTLE)]);
+  m_demand.armed = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::ARM));
+  m_throttleHigh = (RxBase::LOW_THROTTLE_NORM < radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::THROTTLE));
 
   if (FlightState::CALIBRATE == demandedFlightState)
   {
@@ -247,7 +247,7 @@ DemandProcessor::throttleIsHigh()
 bool
 DemandProcessor::wifiApDemanded()
 {
-  return ((!m_demand.armed) && RxBase::isSwitchHigh(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::THROTTLE)]));
+  return ((!m_demand.armed) && RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::THROTTLE)));
 }
 
 
@@ -271,7 +271,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
 {
   if constexpr(Config::USE_PROP_HANG_MODE)
   {
-    m_demand.propHang = RxBase::isSwitchHigh(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::AUX3)]);
+    m_demand.propHang = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::AUX3));
 
     if (m_demand.propHang)
     {
@@ -279,7 +279,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
     }
   }
 
-  const RxBase::SwitchPosition modeSwitchPosition = RxBase::getSwitch3Position(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::MODE)]);
+  const RxBase::SwitchPosition modeSwitchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::MODE));
 
   switch (modeSwitchPosition)
   {
@@ -315,7 +315,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
 DemandProcessor::FlightState
 DemandProcessor::getDemandedFlightModeMultiCopter()
 {
-  RxBase::SwitchPosition switchPosition = RxBase::getSwitch3Position(static_cast<uint32_t>(RxBase::ChannelName::MODE));
+  RxBase::SwitchPosition switchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::MODE));
 
   switch (switchPosition)
   {
@@ -342,7 +342,7 @@ DemandProcessor::getDemandedFlightModeMultiCopter()
 bool
 DemandProcessor::headingHoldActive()
 {
-  m_demand.headingHold = RxBase::isSwitchHigh(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::AUX2)]);
+  m_demand.headingHold = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::AUX2));
   return m_demand.headingHold;
 }
 

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -26,31 +26,50 @@
 
 /**
 * @brief    DemandProcessor constructor   
-*/  
+*/
 DemandProcessor::DemandProcessor()
 {
-  m_sBus = radioCtrl.getData();   //Copy across initial Sbus data state i.e. failsafe flag state
+  // Add instantiation code here for new receiver protocols
+  if constexpr (Config::RECEIVER_TYPE == RxBase::ReceiverType::SBUS)
+  {
+    radioCtrl = new SBus(Config::RECEIVER_UART, Config::RECEIVER_RX, Config::RECEIVER_TX);
+  } else if constexpr (Config::RECEIVER_TYPE == RxBase::ReceiverType::CRSF)
+  {
+    radioCtrl = new Crsf(Config::RECEIVER_UART, Config::RECEIVER_RX, Config::RECEIVER_TX);
+  }
+
+
+  m_normalisedData = radioCtrl->getData();  //Copy across initial Sbus data state i.e. failsafe flag state
 }
 
+
+/**
+* @brief    DemandProcessor destructor   
+*/
+DemandProcessor::~DemandProcessor()
+{
+  delete radioCtrl;
+  radioCtrl = nullptr;
+}
 
 /**
 * @brief    Processes RC data to determine operating mode and any drive demands.
 * @param    flightState   Pointer to the current flight state.
 * @param    lastFlightState   Pointer to the previous flight state.
 * @param    modelCategory Used as multicopters must not have pass through state
-*/  
+*/
 void
-DemandProcessor::process(FlightState* const flightState, 
-                          FlightState* const lastFlightState, 
-                          FileSystem::Rates const * const rates, 
-                          FileSystem::MaxAngle const * const maxAngle)
-{ 
-  if (radioCtrl.getDemands())           //Rx sbus processing
+DemandProcessor::process(FlightState* const flightState,
+                         FlightState* const lastFlightState,
+                         FileSystem::Rates const * const rates,
+                         FileSystem::MaxAngle const * const maxAngle)
+{
+  if (radioCtrl->getDemands())  //Rx sbus processing
   {
     //New sbus packet received so process it
-    m_sBus = radioCtrl.getData();  
+    m_normalisedData = radioCtrl->getData();
     decodeOperatingMode(flightState, lastFlightState);
-    docodeStickPositions(flightState, rates, maxAngle);   
+    decodeStickPositions(flightState, rates, maxAngle);
   }
   else
   {
@@ -62,81 +81,81 @@ DemandProcessor::process(FlightState* const flightState,
 /**
 * @brief    Decode transmitter stick positions into meaningful demands.
 * @param    flightState   Pointer to the current flight state.
-*/ 
+*/
 void
-DemandProcessor::docodeStickPositions(FlightState const * const flightState, FileSystem::Rates const * const rates, FileSystem::MaxAngle const * const maxAngle)
+DemandProcessor::decodeStickPositions(FlightState const* const flightState, FileSystem::Rates const* const rates, FileSystem::MaxAngle const* const maxAngle)
 {
-  //Normailse stick commands to signed values that we can work with
-  m_demand.pitch = static_cast<int32_t>(m_sBus.ch[static_cast<uint32_t>(SBus::ChannelMap::PITCH)] - SBus::MID_SBUS_US);
+  //Normalise stick commands to signed values that we can work with
+  m_demand.pitch = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::PITCH)]);
 
-  if (Config::TX_DEADBAND_US > abs(m_demand.pitch))
+  if (Config::TX_DEADBAND_NORM > abs(m_demand.pitch))
   {
     m_demand.pitch = 0;
   }
 
-  m_demand.roll = static_cast<int32_t>(m_sBus.ch[static_cast<uint32_t>(SBus::ChannelMap::ROLL)] - SBus::MID_SBUS_US);
+  m_demand.roll = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::ROLL)]);
 
-  if (Config::TX_DEADBAND_US > abs(m_demand.roll))
+  if (Config::TX_DEADBAND_NORM > abs(m_demand.roll))
   {
     m_demand.roll = 0;
   }
 
-  m_demand.yaw = static_cast<int32_t>(m_sBus.ch[static_cast<uint32_t>(SBus::ChannelMap::YAW)] - SBus::MID_SBUS_US);
+  m_demand.yaw = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::YAW)]);
 
-  if (Config::TX_DEADBAND_US > abs(m_demand.yaw))
+  if (Config::TX_DEADBAND_NORM > abs(m_demand.yaw))
   {
     m_demand.yaw = 0;
   }
 
-  m_demand.throttle = static_cast<int32_t>(m_sBus.ch[static_cast<uint32_t>(SBus::ChannelMap::THROTTLE)] - SBus::MID_SBUS_US);
-  m_demand.flaps = static_cast<int32_t>(m_sBus.ch[static_cast<uint32_t>(SBus::ChannelMap::AUX1)] - SBus::MID_SBUS_US);
+  m_demand.throttle = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::THROTTLE)]);
+  m_demand.flaps = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::AUX1)]);
 
   switch (*flightState)
   {
-    case FlightState::ACRO_TRAINER:
-      //Acro trainer uses degrees per sec, when levelling the angle demands are zero.
-      //Intentional fall through
-    case FlightState::RATE:
-      //Map control inputs to degrees per second.      
-      m_demand.pitch = map32(m_demand.pitch, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -rates->pitch, rates->pitch);
-      m_demand.roll = map32(m_demand.roll, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -rates->roll, rates->roll);      
-      m_demand.yaw = map32(m_demand.yaw, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -rates->yaw,  rates->yaw);
-      break;
-    
-    case FlightState::SELF_LEVELLED:
-      //Map control inputs to degrees.
-      m_demand.pitch = map32(m_demand.pitch, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -maxAngle->pitch, maxAngle->pitch);
-      m_demand.roll = map32(m_demand.roll, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -maxAngle->roll, maxAngle->roll); 
-      //Yaw still works in degrees per second.     
-      m_demand.yaw = map32(m_demand.yaw, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -rates->yaw, rates->yaw);
-      break;
+  case FlightState::ACRO_TRAINER:
+    //Acro trainer uses degrees per sec, when levelling the angle demands are zero.
+    //Intentional fall through
+  case FlightState::RATE:
+    //Map control inputs to degrees per second.
+    m_demand.pitch = map32(m_demand.pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -rates->pitch, rates->pitch);
+    m_demand.roll = map32(m_demand.roll, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -rates->roll, rates->roll);
+    m_demand.yaw = map32(m_demand.yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -rates->yaw, rates->yaw);
+    break;
 
-    case FlightState::PROP_HANG: 
-      //Map control inputs to degrees.
-      m_demand.pitch = map32(m_demand.pitch, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -maxAngle->pitch, maxAngle->pitch);
-      if constexpr(Config::PROP_HANG_TAIL_SITTER_MODE)
-      {
-        //Roll works in rate mode
-        m_demand.roll = map32(m_demand.roll, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -maxAngle->roll, maxAngle->roll); 
-        //Yaw set to max roll angle     
-        m_demand.yaw = map32(m_demand.yaw, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -rates->roll, rates->roll);
-      }
-      else
-      {
-        //Roll works in rate mode
-        m_demand.roll = map32(m_demand.roll, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -rates->roll, rates->roll); 
-        //Yaw set to max roll angle     
-        m_demand.yaw = map32(m_demand.yaw, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -maxAngle->roll, maxAngle->roll);
-      }
-      break;
-    
-    case FlightState::FAILSAFE:
-      m_demand = DEFAULT_DEMANDS;
-      break;
+  case FlightState::SELF_LEVELLED:
+    //Map control inputs to degrees.
+    m_demand.pitch = map32(m_demand.pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -maxAngle->pitch, maxAngle->pitch);
+    m_demand.roll = map32(m_demand.roll, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -maxAngle->roll, maxAngle->roll);
+    //Yaw still works in degrees per second.
+    m_demand.yaw = map32(m_demand.yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -rates->yaw, rates->yaw);
+    break;
 
-    default:
-      //Assume pass through for all other states.
-      break;
+  case FlightState::PROP_HANG:
+    //Map control inputs to degrees.
+    m_demand.pitch = map32(m_demand.pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -maxAngle->pitch, maxAngle->pitch);
+    if constexpr (Config::PROP_HANG_TAIL_SITTER_MODE)
+    {
+      //Roll works in rate mode
+      m_demand.roll = map32(m_demand.roll, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -maxAngle->roll, maxAngle->roll);
+      //Yaw set to max roll angle
+      m_demand.yaw = map32(m_demand.yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -rates->roll, rates->roll);
+    }
+    else
+    {
+      //Roll works in rate mode
+      m_demand.roll = map32(m_demand.roll, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -rates->roll, rates->roll);
+      //Yaw set to max roll angle
+      m_demand.yaw = map32(m_demand.yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -maxAngle->roll, maxAngle->roll);
+    }
+    break;
+
+  case FlightState::FAILSAFE:
+    m_demand = DEFAULT_DEMANDS;
+    break;
+
+  default:
+    //Assume pass through for all other states.
+    break;
   }
 }
 
@@ -145,29 +164,29 @@ DemandProcessor::docodeStickPositions(FlightState const * const flightState, Fil
 * @brief  Determines what state the radio control system is in  
 * @param    flightState   Pointer to the current flight state.
 * @param    lastFlightState   Pointer to the previous flight state.
-*/  
+*/
 void
 DemandProcessor::decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState)
 {
   FlightState demandedFlightState = *flightState;
-  m_demand.armed = (SBus::MID_SBUS_US < m_sBus.ch[static_cast<uint32_t>(SBus::ChannelMap::ARM)]) ? true : false;
-  m_throttleHigh = (SBus::LOW_THROTTLE_SBUS_US < m_sBus.ch[static_cast<uint32_t>(SBus::ChannelMap::THROTTLE)]) ? true : false;
+  m_demand.armed = RxBase::isSwitchHigh(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::ARM)]);
+  m_throttleHigh = (RxBase::LOW_THROTTLE_NORM < m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::THROTTLE)]);
 
   if (FlightState::CALIBRATE == demandedFlightState)
   {
     ; //Let calibration complete
   }
-  else if (radioCtrl.hasLostCommunications() || m_sBus.failsafe)
+  else if (radioCtrl->hasLostCommunications() || m_normalisedData.failsafe)
   {
     demandedFlightState = FlightState::FAILSAFE;
   }
-  else if (((FlightState::FAILSAFE == *lastFlightState) 
+  else if (((FlightState::FAILSAFE == *lastFlightState)
           || (FlightState::CALIBRATE == *lastFlightState) 
-          || (FlightState::WAITING_TO_DISARM == *flightState)) 
-          && m_demand.armed)
+          || (FlightState::WAITING_TO_DISARM == *flightState))
+           && m_demand.armed)
   {
     //Failsafe set, or no longer set but Tx armed when exiting failsafe
-    demandedFlightState = FlightState::WAITING_TO_DISARM;  
+    demandedFlightState = FlightState::WAITING_TO_DISARM;
   }
   else if (m_demand.armed)
   {
@@ -183,7 +202,7 @@ DemandProcessor::decodeOperatingMode(FlightState* const flightState, FlightState
     }
 
     //If throttle is high and last state not a normal flight mode then wait to disarm, otherwise allow demanded flight state
-    demandedFlightState = (m_throttleHigh && (*lastFlightState > FlightState::PROP_HANG)) ? FlightState::WAITING_TO_DISARM : demandedFlightMode;       
+    demandedFlightState = (m_throttleHigh && (*lastFlightState > FlightState::PROP_HANG)) ? FlightState::WAITING_TO_DISARM : demandedFlightMode;
   }
   else if (wifiApDemanded())
   {
@@ -213,7 +232,7 @@ DemandProcessor::decodeOperatingMode(FlightState* const flightState, FlightState
 /**
 * @brief  Determines if the throttle is not low.  
 * @return True when throttle is high.
-*/  
+*/
 bool
 DemandProcessor::throttleIsHigh()
 {
@@ -224,18 +243,18 @@ DemandProcessor::throttleIsHigh()
 /**
 * @brief  Determines if wifi configurator mode is being demanded 
 * @return True when disamred and throttle is high.
-*/ 
+*/
 bool
 DemandProcessor::wifiApDemanded()
 {
-  return ((!m_demand.armed) && (SwitchPosition::IS_HIGH == get2PosSwitch(static_cast<uint32_t>(SBus::ChannelMap::THROTTLE)))) ? true : false;
+  return ((!m_demand.armed) && RxBase::isSwitchHigh(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::THROTTLE)]));
 }
 
 
 /**
 * @brief    Indicates the RC demanded state of the arming switch.
 * @return   True when Tx is armed.
-*/  
+*/
 bool
 DemandProcessor::isArmed()
 {
@@ -246,45 +265,45 @@ DemandProcessor::isArmed()
 /**
 * @brief    Determines the RC demanded flight mode for fixed wing aircraft.  
 * @return   FlightState   The demanded flight state.
-*/  
+*/
 DemandProcessor::FlightState
 DemandProcessor::getDemandedFlightModeFixedWing()
 {
   if constexpr(Config::USE_PROP_HANG_MODE)
   {
-    m_demand.propHang = (SwitchPosition::IS_HIGH == get2PosSwitch(static_cast<uint32_t>(SBus::ChannelMap::AUX3))) ? true : false;
-    
+    m_demand.propHang = RxBase::isSwitchHigh(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::AUX3)]);
+
     if (m_demand.propHang)
     {
       return FlightState::PROP_HANG;
     }
   }
-  
-  const SwitchPosition modeSwitchPosition = get3PosSwitch(static_cast<uint32_t>(SBus::ChannelMap::MODE));
+
+  const RxBase::SwitchPosition modeSwitchPosition = RxBase::getSwitch3Position(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::MODE)]);
 
   switch (modeSwitchPosition)
   {
-    case SwitchPosition::IS_HIGH:
-      {
-        if constexpr(Config::USE_ACRO_TRAINER)
-        {
-          return FlightState::ACRO_TRAINER;
-        }
-        else
-        {
-          return FlightState::SELF_LEVELLED;
-        }
-      }
-      break;
+  case RxBase::SwitchPosition::SW_HIGH:
+  {
+    if constexpr (Config::USE_ACRO_TRAINER)
+    {
+      return FlightState::ACRO_TRAINER;
+    }
+    else
+    {
+      return FlightState::SELF_LEVELLED;
+    }
+  }
+  break;
 
-    case SwitchPosition::IS_MIDDLE:
-      return FlightState::RATE;
-      break;  
-    
-    default:  //Intentional fall through
-    case SwitchPosition::IS_LOW:  
-      return FlightState::PASS_THROUGH;
-      break;  
+  case RxBase::SwitchPosition::SW_MID:
+    return FlightState::RATE;
+    break;
+
+  default:  //Intentional fall through
+  case RxBase::SwitchPosition::SW_LOW:
+    return FlightState::PASS_THROUGH;
+    break;
   }
 }
 
@@ -292,26 +311,26 @@ DemandProcessor::getDemandedFlightModeFixedWing()
 /**
 * @brief    Determines the RC demanded flight mode for multicopter aircraft.  
 * @return   FlightState   The demanded flight state.
-*/  
+*/
 DemandProcessor::FlightState
 DemandProcessor::getDemandedFlightModeMultiCopter()
 {
-  SwitchPosition switchPosition = get3PosSwitch(static_cast<uint32_t>(SBus::ChannelMap::MODE));
+  RxBase::SwitchPosition switchPosition = RxBase::getSwitch3Position(static_cast<uint32_t>(RxBase::ChannelName::MODE));
 
   switch (switchPosition)
   {
-    case SwitchPosition::IS_HIGH:
-      return FlightState::SELF_LEVELLED;
-      break;
+  case RxBase::SwitchPosition::SW_HIGH:
+    return FlightState::SELF_LEVELLED;
+    break;
 
-    case SwitchPosition::IS_MIDDLE:
-      return FlightState::ACRO_TRAINER;
-      break; 
+  case RxBase::SwitchPosition::SW_MID:
+    return FlightState::ACRO_TRAINER;
+    break;
 
-    default:  //Intentional fall through
-    case SwitchPosition::IS_LOW:
-      return FlightState::RATE;
-      break;  
+  default:  //Intentional fall through
+  case RxBase::SwitchPosition::SW_LOW:
+    return FlightState::RATE;
+    break;
   }
 }
 
@@ -319,11 +338,11 @@ DemandProcessor::getDemandedFlightModeMultiCopter()
 /**
 * @brief    Gets the heading hold demand.    
 * @return   True when switch is high.
-*/ 
+*/
 bool
 DemandProcessor::headingHoldActive()
 {
-  m_demand.headingHold = (SBus::MID_SBUS_US < m_sBus.ch[static_cast<uint32_t>(SBus::ChannelMap::AUX2)]) ? true : false;
+  m_demand.headingHold = RxBase::isSwitchHigh(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::AUX2)]);
   return m_demand.headingHold;
 }
 
@@ -331,7 +350,7 @@ DemandProcessor::headingHoldActive()
 /**
 * @brief    Gets the prop hanging mode demand.    
 * @return   True when switch is high.
-*/ 
+*/
 bool
 DemandProcessor::propHangActive()
 {
@@ -342,77 +361,43 @@ DemandProcessor::propHangActive()
 /**
 * @brief    Indicates the failsafe state.    
 * @return   Returns true if Rx has entered failsafe
-*/  
-bool 
+*/
+bool
 DemandProcessor::inFailsafeState()
 {
-  return m_sBus.failsafe;
-}
-
-
-/**
-* @brief    Returns the position of a Tx 2 position switch.   
-* @return   SwitchPosition - HIGH or LOW.
-*/  
-DemandProcessor::SwitchPosition 
-DemandProcessor::get2PosSwitch(uint32_t aChannel)
-{
-  return (SBus::SWITCH_HIGH_SBUS_US < m_sBus.ch[aChannel]) ? SwitchPosition::IS_HIGH : SwitchPosition::IS_LOW;
-}
-
-
-/**
-* @brief    Returns the position of a Tx 3 position switch.   
-* @return   SwitchPosition - HIGH, MIDDLE, or LOW.
-*/  
-DemandProcessor::SwitchPosition 
-DemandProcessor::get3PosSwitch(uint32_t aChannel)
-{
-  if (SBus::SWITCH_HIGH_SBUS_US < m_sBus.ch[aChannel])
-  {
-    return SwitchPosition::IS_HIGH;
-  }
-  else 
-  {
-    if (SBus::SWITCH_LOW_SBUS_US > m_sBus.ch[aChannel])
-    {
-      return SwitchPosition::IS_LOW;
-    }
-  }
-
-  return SwitchPosition::IS_MIDDLE;
+  return m_normalisedData.failsafe;
 }
 
 
 /**
 * @brief    Prints DemandProcessor data to console for debugging purposes.
-*/  
-void 
+*/
+void
 DemandProcessor::printData()
 {
   Serial.print("pitch: ");
   Serial.print(m_demand.pitch);
   Serial.print("\t roll: ");
   Serial.print(m_demand.roll);
-  Serial.print("\t yaw: ");  
+  Serial.print("\t yaw: ");
   Serial.print(m_demand.yaw);
   Serial.print("\t throttle: ");
   Serial.print(m_demand.throttle);
   Serial.print("\t flaps: ");
   Serial.print(m_demand.flaps);
   Serial.print("\t armed: ");
-  Serial.print(m_demand.armed); 
+  Serial.print(m_demand.armed);
   Serial.print("\t mode: ");
-  Serial.print(static_cast<uint32_t>(getDemandedFlightModeFixedWing()));  
+  Serial.print(static_cast<uint32_t>(getDemandedFlightModeFixedWing()));
   if constexpr(Config::USE_HEADING_HOLD)
   {
     Serial.print("\t Heading: ");
-    Serial.print(m_demand.headingHold); 
-  } 
+    Serial.print(m_demand.headingHold);
+  }
   if constexpr(Config::USE_PROP_HANG_MODE)
   {
     Serial.print("\t PropHang: ");
-    Serial.println(m_demand.propHang); 
+    Serial.println(m_demand.propHang);
   }
   Serial.println();
 }

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -86,29 +86,29 @@ void
 DemandProcessor::decodeStickPositions(FlightState const* const flightState, FileSystem::Rates const* const rates, FileSystem::MaxAngle const* const maxAngle)
 {
   //Normalise stick commands to signed values that we can work with
-  m_demand.pitch = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::PITCH)]);
+  m_demand.pitch = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::PITCH);
 
   if (Config::TX_DEADBAND_NORM > abs(m_demand.pitch))
   {
     m_demand.pitch = 0;
   }
 
-  m_demand.roll = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::ROLL)]);
+  m_demand.roll = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::ROLL);
 
   if (Config::TX_DEADBAND_NORM > abs(m_demand.roll))
   {
     m_demand.roll = 0;
   }
 
-  m_demand.yaw = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::YAW)]);
+  m_demand.yaw = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::YAW);
 
   if (Config::TX_DEADBAND_NORM > abs(m_demand.yaw))
   {
     m_demand.yaw = 0;
   }
 
-  m_demand.throttle = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::THROTTLE)]);
-  m_demand.flaps = static_cast<int32_t>(m_normalisedData.ch[static_cast<uint32_t>(RxBase::ChannelName::AUX1)]);
+  m_demand.throttle = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::THROTTLE);
+  m_demand.flaps = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::AUX1);
 
   switch (*flightState)
   {

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -25,7 +25,9 @@
 #include <cstdint>
 #include <Arduino.h>
 #include "Utilities.hpp"
+#include "RxBase.hpp"
 #include "SBus.hpp"
+#include "Crsf.hpp"
 #include "Config.hpp"
 #include "Configurator.hpp"
 
@@ -34,88 +36,80 @@
 * @class  DemandProcessor
 * @note   Inherits Utilities class.
 */
- 
+
 class DemandProcessor : public Utilities
 {
-  public:
-    enum class FlightState : uint8_t
-    {
-      //Note: Changing the order of these will have bad consequences
-      PASS_THROUGH = 0U,    
-      RATE,
-      SELF_LEVELLED,
-      ACRO_TRAINER,
-      PROP_HANG,
-      WAITING_TO_DISARM,
-      AP_WIFI,
-      FAULTED,
-      CALIBRATE,
-      DISARMED,
-      FAILSAFE,   
-      
-    };
+public:
+  enum class FlightState : uint8_t
+  {
+    //Note: Changing the order of these will have bad consequences
+    PASS_THROUGH = 0U,
+    RATE,
+    SELF_LEVELLED,
+    ACRO_TRAINER,
+    PROP_HANG,
+    WAITING_TO_DISARM,
+    AP_WIFI,
+    FAULTED,
+    CALIBRATE,
+    DISARMED,
+    FAILSAFE,
 
-    enum class SwitchPosition : uint32_t
-    {
-      IS_HIGH = 0U,
-      IS_MIDDLE,
-      IS_LOW,
-    };
+  };
 
-    struct Demands
-    {
-      int32_t pitch;
-      int32_t roll;
-      int32_t yaw;
-      int32_t throttle;
-      int32_t flaps;
-      bool armed;
-      bool headingHold;
-      bool propHang; 
-    };
+  struct Demands
+  {
+    int32_t pitch;
+    int32_t roll;
+    int32_t yaw;
+    int32_t throttle;
+    int32_t flaps;
+    bool armed;
+    bool headingHold;
+    bool propHang;
+  };
 
-    //Constants
-    static constexpr Demands DEFAULT_DEMANDS = {
-          //Used to force outputs to known states 
-          SBus::MID_NORMALISED_US,  //pitch
-          SBus::MID_NORMALISED_US,  //Roll
-          SBus::MID_NORMALISED_US,  //Yaw
-          SBus::MIN_NORMALISED_US,  //Throttle
-          SBus::MIN_NORMALISED_US,  //Flaps
-          false,                    //Armed
-          false,                    //Heading Hold
-          false,                    //Prop Hang
-          };
+  //Constants
+  static constexpr Demands DEFAULT_DEMANDS = {
+      //Used to force outputs to known states
+      RxBase::MID_NORMALISED,   //pitch
+      RxBase::MID_NORMALISED,   //Roll
+      RxBase::MID_NORMALISED,   //Yaw
+      RxBase::MIN_NORMALISED,   //Throttle
+      RxBase::MIN_NORMALISED,   //Flaps
+      false,                    //Armed
+      false,                    //Heading Hold
+      false,                    //Prop Hang
+  };
 
-    DemandProcessor();
-    void process(FlightState* const flightState, 
-                  FlightState* const lastFlightState, 
-                  FileSystem::Rates const * const rates, 
-                  FileSystem::MaxAngle const * const maxAngle);
-    bool inFailsafeState();
-    bool inNeedToDisarmState();
-    FlightState getOperatingMode();
-    void printData();
-    FlightState getDemandedFlightModeFixedWing();
-    FlightState getDemandedFlightModeMultiCopter();
-    bool isArmed();
-    bool throttleIsHigh();
-    bool headingHoldActive(); 
-    bool propHangActive();   
-    Demands const * const getDemands() const {return &m_demand;};
+  DemandProcessor();
+  ~DemandProcessor();
+  void process(FlightState* const flightState,
+                FlightState* const lastFlightState,
+                FileSystem::Rates const * const rates,
+                FileSystem::MaxAngle const * const maxAngle);
+  bool inFailsafeState();
+  bool inNeedToDisarmState();
+  FlightState getOperatingMode();
+  void printData();
+  FlightState getDemandedFlightModeFixedWing();
+  FlightState getDemandedFlightModeMultiCopter();
+  bool isArmed();
+  bool throttleIsHigh();
+  bool headingHoldActive();
+  bool propHangActive();
+  Demands const * const getDemands() const {return &m_demand;};
 
-  private:
-    void decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState);
-    SwitchPosition get2PosSwitch(uint32_t aChannel);
-    SwitchPosition get3PosSwitch(uint32_t aChannel);
-    void docodeStickPositions(FlightState const * const flightState, FileSystem::Rates const * const rates, FileSystem::MaxAngle const * const maxAngle);   
-    bool wifiApDemanded();    
+private:
+  void decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState);
+  void decodeStickPositions(FlightState const* const flightState, FileSystem::Rates const* const rates, FileSystem::MaxAngle const* const maxAngle);
+  bool wifiApDemanded();
 
-    //Variables
-    SBus::SbusPacket m_sBus = {0};
-    Demands m_demand = DEFAULT_DEMANDS;
-    bool m_throttleHigh = false;
+  //Variables
+  RxBase::RxPacket m_normalisedData = {0};
+  Demands m_demand = DEFAULT_DEMANDS;
+  bool m_throttleHigh = false;
 
-    //Objects
-    SBus radioCtrl = SBus(Config::SBUS_UART, Config::SBUS_RX, Config::SBUS_TX);
+  //Objects
+  RxBase* radioCtrl = nullptr;
 };

--- a/PlainFlightController/FlightControl.hpp
+++ b/PlainFlightController/FlightControl.hpp
@@ -31,7 +31,7 @@
 #include "PIDF.hpp"
 #include "IMU.hpp"
 #include "Config.hpp"
-#include "SBus.hpp"
+#include "RxBase.hpp"
 #include "Configurator.hpp"
 #include "FileSystem.hpp"
 #include "ModelTypes.hpp"

--- a/PlainFlightController/LED.hpp
+++ b/PlainFlightController/LED.hpp
@@ -193,9 +193,9 @@ class LedNeopixel : public Led
 
     virtual void setLed() override
     {
-      neopixelWrite(m_ledPin, 
-                      sequences[m_playSequence].led[m_idx].colour.red, 
-                      sequences[m_playSequence].led[m_idx].colour.green,
-                      sequences[m_playSequence].led[m_idx].colour.blue);
+      rgbLedWrite(m_ledPin, 
+                  sequences[m_playSequence].led[m_idx].colour.red, 
+                  sequences[m_playSequence].led[m_idx].colour.green,
+                  sequences[m_playSequence].led[m_idx].colour.blue);
     }
 };

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -584,8 +584,8 @@ public:
     }
 
     // constraint add to prevent overflow
-    const int32_t rollMinusFlap = constrain(demands->roll + negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
-    const int32_t rollPlusFlap = constrain(demands->roll - negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollMinusFlap = constrain(demands->roll - negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollPlusFlap = constrain(demands->roll + negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
     const uint32_t leftAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
@@ -610,7 +610,7 @@ public:
 
     // constraint add to prevent overflow
     const int32_t rollMinusFlap = constrain(demands->roll - negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    const int32_t rollPlusFlap = constrain(demands->yaw + negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t rollPlusFlap = constrain(demands->roll + negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
     const uint32_t leftAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t pitchTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
@@ -712,8 +712,8 @@ public:
       negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, RxBase::MID_NORMALISED, RxBase::MAX_NORMALISED);
     }
     // constraint add to prevent overflow
-    const int32_t rollMinusFlap = constrain(demands->roll + negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
-    const int32_t rollPlusFlap = constrain(demands->roll - negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollMinusFlap = constrain(demands->roll - negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollPlusFlap = constrain(demands->roll + negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
     const uint32_t leftAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
@@ -1204,7 +1204,7 @@ public:
       const int32_t modifiedThrottle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
       //Convert demands to timer ticks - constraint add to prevent overflow
       const int32_t modThrottlePlusYaw = constrain(modifiedThrottle + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-      const int32_t modThrottleMinusYaw = constrain(demands->roll - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
       const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
       const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
       writeMotors(motor1, motor2);
@@ -1529,7 +1529,7 @@ public:
   static constexpr uint8_t MOTOR_1_PIN    = D0;
   static constexpr uint8_t MOTOR_2_PIN    = D1;
   static constexpr uint8_t MOTOR_3_PIN    = D2;
-  static constexpr uint8_t MOTOR_4_PIN    = D3;  //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
+  static constexpr uint8_t MOTOR_4_PIN    = D3; //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
   static constexpr uint8_t SERVO_1_PIN    = D8;
   static constexpr uint8_t SERVO_2_PIN    = D9;
 
@@ -1726,24 +1726,24 @@ public:
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
     //When disarmed - constraint add to prevent overflow
-    const int32_t rollYaw   = constrain(demands->roll  + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
-    const int32_t pitchYaw  = constrain(demands->pitch + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
-    const uint32_t servo1 = mapNormalisedServoToTimerTicks(rollYaw)  + (trim->servo1 * getTrimMultiplier());
-    const uint32_t servo2 = mapNormalisedServoToTimerTicks(pitchYaw) + (trim->servo2 * getTrimMultiplier());
-    const uint32_t servo3 = mapNormalisedServoToTimerTicks(rollYaw)  + (trim->servo3 * getTrimMultiplier());
-    const uint32_t servo4 = mapNormalisedServoToTimerTicks(pitchYaw) + (trim->servo4 * getTrimMultiplier());    
+    const int32_t rollPlusYaw   = constrain(demands->roll  + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t pitchPlusYaw  = constrain(demands->pitch + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t servo1 = mapNormalisedServoToTimerTicks(rollPlusYaw)  + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapNormalisedServoToTimerTicks(pitchPlusYaw) + (trim->servo2 * getTrimMultiplier());
+    const uint32_t servo3 = mapNormalisedServoToTimerTicks(rollPlusYaw)  + (trim->servo3 * getTrimMultiplier());
+    const uint32_t servo4 = mapNormalisedServoToTimerTicks(pitchPlusYaw) + (trim->servo4 * getTrimMultiplier());    
     writeServos(servo1, servo2, servo3, servo4);
   }
 
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
     //When armed - constraint add to prevent overflow
-    const int32_t rollYaw   = constrain(demands->roll  + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    const int32_t pitchYaw  = constrain(demands->pitch + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    const uint32_t servo1 = mapRateServoToTimerTicks(rollYaw)  + (trim->servo1 * getTrimMultiplier());
-    const uint32_t servo2 = mapRateServoToTimerTicks(pitchYaw) + (trim->servo2 * getTrimMultiplier());
-    const uint32_t servo3 = mapRateServoToTimerTicks(rollYaw)  + (trim->servo3 * getTrimMultiplier());
-    const uint32_t servo4 = mapRateServoToTimerTicks(pitchYaw) + (trim->servo4 * getTrimMultiplier());    
+    const int32_t rollPlusYaw   = constrain(demands->roll  + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t pitchPlusYaw  = constrain(demands->pitch + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t servo1 = mapRateServoToTimerTicks(rollPlusYaw)  + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapRateServoToTimerTicks(pitchPlusYaw) + (trim->servo2 * getTrimMultiplier());
+    const uint32_t servo3 = mapRateServoToTimerTicks(rollPlusYaw)  + (trim->servo3 * getTrimMultiplier());
+    const uint32_t servo4 = mapRateServoToTimerTicks(pitchPlusYaw) + (trim->servo4 * getTrimMultiplier());    
     writeServos(servo1, servo2, servo3, servo4);
   }
 };

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -23,7 +23,7 @@
 #pragma once
 
 #include "LedcServo.hpp"
-#include "SBus.hpp"
+#include "RxBase.hpp"
 #include "Utilities.hpp"
 #include "PIDF.hpp"
 #include "Config.hpp"
@@ -35,360 +35,360 @@
 * @note     Purposely limited to 4 motors and 4 servos as this covers most model types.
 * @note     Can be modified to use up to 8 servos, or 8 motors. Other combinations can be made.
 * @note     If using different refresh rates for motors/servos then you must use even numbers as LEDc timers are shared between two channels i.e 0-1, 2-3, 4-5, 6-7. 
-*/ 
+*/
 class ModelBase : public Utilities
 {
-  public:
-    static constexpr uint8_t MAX_MOTORS = 4U;   //Must be even number as LEDc module shares 1 timer between 2 channels
-    static constexpr uint8_t MAX_SERVOS = 4U;   //Must be even number as LEDc module shares 1 timer between 2 channels
-    static constexpr uint8_t MAX_LEDC_CHANNELS = 8U;  //ESP32S3 has 8 PWM channels that operate in frequency pairs.
+public:
+  static constexpr uint8_t MAX_MOTORS = 4U;   //Must be even number as LEDc module shares 1 timer between 2 channels
+  static constexpr uint8_t MAX_SERVOS = 4U;   //Must be even number as LEDc module shares 1 timer between 2 channels
+  static constexpr uint8_t MAX_LEDC_CHANNELS = 8U;  //ESP32S3 has 8 PWM channels that operate in frequency pairs.
 
-    //Structure used to define model type and actuators required.
-    struct ModelConfig 
-    {
-      uint8_t motorPins[MAX_MOTORS];
-      uint8_t servoPins[MAX_SERVOS];
-      LedcServo::RefreshRate motorRefresh;
-      LedcServo::RefreshRate servoRefresh;
-      uint8_t numberMotors;
-      uint8_t numberServos;
-    };
+  //Structure used to define model type and actuators required.
+  struct ModelConfig
+  {
+    uint8_t motorPins[MAX_MOTORS];
+    uint8_t servoPins[MAX_SERVOS];
+    LedcServo::RefreshRate motorRefresh;
+    LedcServo::RefreshRate servoRefresh;
+    uint8_t numberMotors;
+    uint8_t numberServos;
+  };
 
-    ModelBase(ModelConfig modelConfig) : m_modelConfig(modelConfig)
-    {
-      assert((m_modelConfig.numberMotors <= MAX_MOTORS));  //Ensure not more that max number of motor channels not exceeded.
-      assert((m_modelConfig.numberServos <= MAX_SERVOS));  //Ensure not more that max number of servo channels not exceeded.
-      //Ensure not more that max number of LEDc channels have been decalred... 
-      //...Obviously the 2 asserts above would negate the need for the below, but just incase somebody tries to modify code beyond ESP32S3 HW limits.
-      assert((m_modelConfig.numberMotors + m_modelConfig.numberServos) <= MAX_LEDC_CHANNELS);  
+  ModelBase(ModelConfig modelConfig) : m_modelConfig(modelConfig)
+  {
+    assert((m_modelConfig.numberMotors <= MAX_MOTORS));  //Ensure not more that max number of motor channels not exceeded.
+    assert((m_modelConfig.numberServos <= MAX_SERVOS));  //Ensure not more that max number of servo channels not exceeded.
+    //Ensure not more that max number of LEDc channels have been decalred...
+    //...Obviously the 2 asserts above would negate the need for the below, but just incase somebody tries to modify code beyond ESP32S3 HW limits.
+    assert((m_modelConfig.numberMotors + m_modelConfig.numberServos) <= MAX_LEDC_CHANNELS);
 
-      m_minServoTimerTicks = static_cast<int32_t>(servo[0].getMinTimerTicks());//All servos will be the same refresh rate
-      m_maxServoTimerTicks = static_cast<int32_t>(servo[0].getMaxTimerTicks());
-      m_minMotorTimerTicks = static_cast<int32_t>(motor[0].getMinTimerTicks());//And/or all motors will be the same reshresh rate
-      m_maxMotorTimerTicks = static_cast<int32_t>(motor[0].getMaxTimerTicks());
-    }
+    m_minServoTimerTicks = static_cast<int32_t>(servo[0].getMinTimerTicks());//All servos will be the same refresh rate
+    m_maxServoTimerTicks = static_cast<int32_t>(servo[0].getMaxTimerTicks());
+    m_minMotorTimerTicks = static_cast<int32_t>(motor[0].getMinTimerTicks());//And/or all motors will be the same reshresh rate
+    m_maxMotorTimerTicks = static_cast<int32_t>(motor[0].getMaxTimerTicks());
+  }
 
-    ~ModelBase(){};
+  ~ModelBase(){};
 
-    /**
+  /**
     * @brief  Initialises servos and motors
     */
-    virtual void begin()
+  virtual void begin()
+  {
+    for (uint32_t i=0; i<m_modelConfig.numberServos; i++)
     {
-      for (uint32_t i=0; i<m_modelConfig.numberServos; i++)
+      servo[i].begin();
+    }
+
+    for (uint32_t i=0; i<m_modelConfig.numberMotors; i++)
+    {
+      motor[i].begin();
+    }
+
+    if constexpr(Config::CALIBRATE_ESC)
+    {
+      for (uint32_t i=0; i<m_modelConfig.numberMotors; i++)
       {
-        servo[i].begin();
+        motor[i].setTimerTicks(motor[i].getMaxTimerTicks());
       }
+
+      delay(LedcServo::CALIBRATE_ESC_DELAY);
 
       for (uint32_t i=0; i<m_modelConfig.numberMotors; i++)
       {
-        motor[i].begin();
+        motor[i].setTimerTicks(motor[i].getMinTimerTicks());
       }
 
-      if constexpr(Config::CALIBRATE_ESC)
-      {
-        for (uint32_t i=0; i<m_modelConfig.numberMotors; i++)
-        {
-          motor[i].setTimerTicks(motor[i].getMaxTimerTicks());
-        }
-        
-        delay(LedcServo::CALIBRATE_ESC_DELAY);
-        
-        for (uint32_t i=0; i<m_modelConfig.numberMotors; i++)
-        {
-          motor[i].setTimerTicks(motor[i].getMinTimerTicks());
-        }
-
-        Serial.println("Calibration complete. Disable CALIBRATE_ESC setting in Config.hpp.");
-        while(1);
-      }
+      Serial.println("Calibration complete. Disable CALIBRATE_ESC setting in Config.hpp.");
+      while(1);
     }
+  }
 
-//TODO - the following should be pure virtual as we could write to uninitialised LEDc channels !!
+  //TODO - the following should be pure virtual as we could write to uninitialised LEDc channels !!
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The RC demands
     * @param  trim - The saved servo trim values
     * @note   Cannot be pure virtual as some multicopters do not have servos.
-    */    
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim){}
+    */
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim){}
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The RC demands
     * @param  trim - The saved servo trim values
     * @note   Cannot be pure virtual as some multicopters do not have servos.
-    */   
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim){}
+    */
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim){}
 
-    /**
+  /**
     * @brief  Motor mixer pure virtual - can be overriden.
     * @param  demands - The RC demands 
-    */    
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) = 0;
+    */
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) = 0;
 
-    /**
+  /**
     * @brief  Motor mixer pure virtual - must be overriden.
     * @param  demands - The RC demands
-    */  
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) = 0;  
+    */
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) = 0;
 
-    /**
+  /**
     * @brief  This multiplier allows servo trim values to be constant across all RefreshRate's.
-    */    
-    int32_t getTrimMultiplier() const {return servo[0].getTrimMultiplier();} 
+    */
+  int32_t getTrimMultiplier() const {return servo[0].getTrimMultiplier();}
 
-  private:
-     //Variables
-    int32_t m_minServoTimerTicks;
-    int32_t m_maxServoTimerTicks;
-    int32_t m_minMotorTimerTicks;
-    int32_t m_maxMotorTimerTicks;
-    ModelConfig m_modelConfig;
-    uint64_t m_motorDebugUpdateTime = 0U;
-    uint64_t m_servoDebugUpdateTime = 0U;
+private:
+  //Variables
+  int32_t m_minServoTimerTicks;
+  int32_t m_maxServoTimerTicks;
+  int32_t m_minMotorTimerTicks;
+  int32_t m_maxMotorTimerTicks;
+  ModelConfig m_modelConfig;
+  uint64_t m_motorDebugUpdateTime = 0U;
+  uint64_t m_servoDebugUpdateTime = 0U;
 
-    //Objects
-    LedcServo servo[MAX_SERVOS] = 
-    {
-      LedcServo(m_modelConfig.servoPins[0], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS),
-      LedcServo(m_modelConfig.servoPins[1], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS),
-      LedcServo(m_modelConfig.servoPins[2], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS),
-      LedcServo(m_modelConfig.servoPins[3], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS),
-    };
-
-    LedcServo motor[MAX_MOTORS] = 
-    {
-      LedcServo(m_modelConfig.motorPins[0], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS),
-      LedcServo(m_modelConfig.motorPins[1], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS),
-      LedcServo(m_modelConfig.motorPins[2], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS),
-      LedcServo(m_modelConfig.motorPins[3], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS),
-    };
-
-    void debugServos(const uint32_t servo1, const uint32_t servo2, const uint32_t servo3, const uint32_t servo4)
-    {
-      const uint64_t nowTime = millis();  
-
-      if (m_servoDebugUpdateTime <= nowTime)
+  //Objects
+  LedcServo servo[MAX_SERVOS] =
       {
-        Serial.print("servo1: ");
-        Serial.print(servo1);
-        Serial.print(", servo2: ");
-        Serial.print(servo2);
-        Serial.print(", servo3: ");
-        Serial.print(servo3);
-        Serial.print(", servo4: ");
-        Serial.print(servo4);
-        Serial.println();
-        m_servoDebugUpdateTime = nowTime + 100U;
-      }
-    }
+          LedcServo(m_modelConfig.servoPins[0], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS),
+          LedcServo(m_modelConfig.servoPins[1], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS),
+          LedcServo(m_modelConfig.servoPins[2], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS),
+          LedcServo(m_modelConfig.servoPins[3], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS),
+      };
 
-    void debugMotors(const uint32_t motor1, const uint32_t motor2, const uint32_t motor3, const uint32_t motor4)
-    {
-      const uint64_t nowTime = millis();  
-
-      if (m_motorDebugUpdateTime <= nowTime)
+  LedcServo motor[MAX_MOTORS] =
       {
-        Serial.print("motor1: ");
-        Serial.print(motor1);
-        Serial.print(", motor2: ");
-        Serial.print(motor2);
-        Serial.print(", motor3: ");
-        Serial.print(motor3);
-        Serial.print(", motor4: ");
-        Serial.print(motor4);
-        Serial.println();
-        m_motorDebugUpdateTime = nowTime + 100U;
-      }
-    }
+          LedcServo(m_modelConfig.motorPins[0], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS),
+          LedcServo(m_modelConfig.motorPins[1], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS),
+          LedcServo(m_modelConfig.motorPins[2], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS),
+          LedcServo(m_modelConfig.motorPins[3], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS),
+      };
 
-  protected:   
-    static constexpr int32_t IDLE_UP      = SBus::MIN_NORMALISED_US + Config::IDLE_UP_VALUE;
-    static constexpr int32_t MIN_THROTTLE = SBus::MIN_NORMALISED_US + Config::MIN_THROTTLE_VALUE;
-  
-    enum class Actuator : uint32_t
+  void debugServos(const uint32_t servo1, const uint32_t servo2, const uint32_t servo3, const uint32_t servo4)
+  {
+    const uint64_t nowTime = millis();
+
+    if (m_servoDebugUpdateTime <= nowTime)
     {
-      CHANNEL_1 = 0U,
-      CHANNEL_2,
-      CHANNEL_3,
-      CHANNEL_4,
-    };
+      Serial.print("servo1: ");
+      Serial.print(servo1);
+      Serial.print(", servo2: ");
+      Serial.print(servo2);
+      Serial.print(", servo3: ");
+      Serial.print(servo3);
+      Serial.print(", servo4: ");
+      Serial.print(servo4);
+      Serial.println();
+      m_servoDebugUpdateTime = nowTime + 100U;
+    }
+  }
 
-    //Variables
-    int32_t m_idleUp = 0U;
-    int32_t m_minThrottle = 0U;
+  void debugMotors(const uint32_t motor1, const uint32_t motor2, const uint32_t motor3, const uint32_t motor4)
+  {
+    const uint64_t nowTime = millis();
 
-    /**
+    if (m_motorDebugUpdateTime <= nowTime)
+    {
+      Serial.print("motor1: ");
+      Serial.print(motor1);
+      Serial.print(", motor2: ");
+      Serial.print(motor2);
+      Serial.print(", motor3: ");
+      Serial.print(motor3);
+      Serial.print(", motor4: ");
+      Serial.print(motor4);
+      Serial.println();
+      m_motorDebugUpdateTime = nowTime + 100U;
+    }
+  }
+
+protected:
+  static constexpr int32_t IDLE_UP = RxBase::MIN_NORMALISED + Config::IDLE_UP_VALUE;
+  static constexpr int32_t MIN_THROTTLE = RxBase::MIN_NORMALISED + Config::MIN_THROTTLE_VALUE;
+
+  enum class Actuator : uint32_t
+  {
+    CHANNEL_1 = 0U,
+    CHANNEL_2,
+    CHANNEL_3,
+    CHANNEL_4,
+  };
+
+  //Variables
+  int32_t m_idleUp = 0U;
+  int32_t m_minThrottle = 0U;
+
+  /**
     * @brief  Writes the demanded value/position to the servos.
     * @param  
-    */ 
-    void writeServos(const uint32_t servo1, const uint32_t servo2)
+    */
+  void writeServos(const uint32_t servo1, const uint32_t servo2)
+  {
+    if constexpr(Config::REVERSE_SERVO_1)
     {
-      if constexpr(Config::REVERSE_SERVO_1)
-      {
-        servo[0].setTimerTicks((m_maxServoTimerTicks - servo1) + m_minServoTimerTicks); 
-      }
-      else
-      {
-        servo[0].setTimerTicks(servo1);   
-      }
-
-      if constexpr(Config::REVERSE_SERVO_2)
-      {
-        servo[1].setTimerTicks((m_maxServoTimerTicks - servo2) + m_minServoTimerTicks); 
-      }
-      else
-      {
-        servo[1].setTimerTicks(servo2); 
-      } 
-
-      if constexpr(Config::DEBUG_SERVO_OUTPUT)
-      {
-        debugServos(servo1, servo2, servo[3].getDefaultTimerTicks(), servo[4].getDefaultTimerTicks());
-      } 
+      servo[0].setTimerTicks((m_maxServoTimerTicks - servo1) + m_minServoTimerTicks);
+    }
+    else
+    {
+      servo[0].setTimerTicks(servo1);
     }
 
-    /**
+    if constexpr(Config::REVERSE_SERVO_2)
+    {
+      servo[1].setTimerTicks((m_maxServoTimerTicks - servo2) + m_minServoTimerTicks);
+    }
+    else
+    {
+      servo[1].setTimerTicks(servo2);
+    }
+
+    if constexpr(Config::DEBUG_SERVO_OUTPUT)
+    {
+      debugServos(servo1, servo2, servo[3].getDefaultTimerTicks(), servo[4].getDefaultTimerTicks());
+    }
+  }
+
+  /**
     * @brief  Writes the demanded value/position to the servos.
     * @param  
-    */ 
-    void writeServos(const uint32_t servo1, const uint32_t servo2, const uint32_t servo3, const uint32_t servo4)
+    */
+  void writeServos(const uint32_t servo1, const uint32_t servo2, const uint32_t servo3, const uint32_t servo4)
+  {
+    if constexpr(Config::REVERSE_SERVO_1)
     {
-      if constexpr(Config::REVERSE_SERVO_1)
-      {
-        servo[0].setTimerTicks((m_maxServoTimerTicks - servo1) + m_minServoTimerTicks); 
-      }
-      else
-      {
-        servo[0].setTimerTicks(servo1);   
-      }
-
-      if constexpr(Config::REVERSE_SERVO_2)
-      {
-        servo[1].setTimerTicks((m_maxServoTimerTicks - servo2) + m_minServoTimerTicks); 
-      }
-      else
-      {
-        servo[1].setTimerTicks(servo2); 
-      } 
-
-      if constexpr(Config::REVERSE_SERVO_3)
-      {
-        servo[2].setTimerTicks((m_maxServoTimerTicks - servo3) + m_minServoTimerTicks); 
-      }
-      else
-      {
-        servo[2].setTimerTicks(servo3);   
-      }
-
-      if constexpr(Config::REVERSE_SERVO_4)
-      {
-        servo[3].setTimerTicks((m_maxServoTimerTicks - servo4) + m_minServoTimerTicks); 
-      }
-      else
-      {
-        servo[3].setTimerTicks(servo4); 
-      }  
-
-      if constexpr(Config::DEBUG_SERVO_OUTPUT)
-      {
-        debugServos(servo1, servo2, servo3, servo4);
-      } 
+      servo[0].setTimerTicks((m_maxServoTimerTicks - servo1) + m_minServoTimerTicks);
+    }
+    else
+    {
+      servo[0].setTimerTicks(servo1);
     }
 
-    /**
+    if constexpr(Config::REVERSE_SERVO_2)
+    {
+      servo[1].setTimerTicks((m_maxServoTimerTicks - servo2) + m_minServoTimerTicks);
+    }
+    else
+    {
+      servo[1].setTimerTicks(servo2);
+    }
+
+    if constexpr(Config::REVERSE_SERVO_3)
+    {
+      servo[2].setTimerTicks((m_maxServoTimerTicks - servo3) + m_minServoTimerTicks);
+    }
+    else
+    {
+      servo[2].setTimerTicks(servo3);
+    }
+
+    if constexpr(Config::REVERSE_SERVO_4)
+    {
+      servo[3].setTimerTicks((m_maxServoTimerTicks - servo4) + m_minServoTimerTicks);
+    }
+    else
+    {
+      servo[3].setTimerTicks(servo4);
+    }
+
+    if constexpr(Config::DEBUG_SERVO_OUTPUT)
+    {
+      debugServos(servo1, servo2, servo3, servo4);
+    }
+  }
+
+  /**
     * @brief  Writes the required demanded values to the motors.
     * @param  
-    */ 
-    void writeMotors(const uint32_t motor1, const uint32_t motor2)
+    */
+  void writeMotors(const uint32_t motor1, const uint32_t motor2)
+  {
+    motor[0].setTimerTicks(motor1);
+    motor[1].setTimerTicks(motor2);
+
+    if constexpr(Config::DEBUG_MOTOR_OUTPUT)
     {
-      motor[0].setTimerTicks(motor1);   
-      motor[1].setTimerTicks(motor2);  
-
-      if constexpr(Config::DEBUG_MOTOR_OUTPUT)
-      {
-        debugMotors(motor1, motor2, motor[2].getDefaultTimerTicks(), motor[3].getDefaultTimerTicks()); 
-      } 
+      debugMotors(motor1, motor2, motor[2].getDefaultTimerTicks(), motor[3].getDefaultTimerTicks());
     }
+  }
 
-    void writeMotors(const uint32_t motor1, const uint32_t motor2, const uint32_t motor3, const uint32_t motor4)
+  void writeMotors(const uint32_t motor1, const uint32_t motor2, const uint32_t motor3, const uint32_t motor4)
+  {
+    motor[0].setTimerTicks(motor1);
+    motor[1].setTimerTicks(motor2);
+    motor[2].setTimerTicks(motor3);
+    motor[3].setTimerTicks(motor4);
+
+    if constexpr(Config::DEBUG_MOTOR_OUTPUT)
     {
-      motor[0].setTimerTicks(motor1);   
-      motor[1].setTimerTicks(motor2); 
-      motor[2].setTimerTicks(motor3);   
-      motor[3].setTimerTicks(motor4);  
-
-      if constexpr(Config::DEBUG_MOTOR_OUTPUT)
-      {
-        debugMotors(motor1, motor2, motor3, motor4); 
-      } 
+      debugMotors(motor1, motor2, motor3, motor4);
     }
-  
-    /**
+  }
+
+  /**
     * @brief  Converts calculated pass through servo demands to correct timer tick values.
     * @param  
-    */ 
-    uint32_t mapNormalisedServoToTimerTicks(const int32_t channelValue)
-    {
-      return static_cast<uint32_t>(map32(channelValue, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, m_minServoTimerTicks, m_maxServoTimerTicks));
-    }
+    */
+  uint32_t mapNormalisedServoToTimerTicks(const int32_t channelValue)
+  {
+    return static_cast<uint32_t>(map32(channelValue, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, m_minServoTimerTicks, m_maxServoTimerTicks));
+  }
 
-    /**
+  /**
     * @brief  Converts calculated pass through motor demands to correct timer tick values.
     * @param  
-    */ 
-    uint32_t mapNormalisedMotorToTimerTicks(const int32_t channelValue)
-    {   
-      return static_cast<uint32_t>(map32(channelValue, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, m_minMotorTimerTicks, m_maxMotorTimerTicks));
-    }
+    */
+  uint32_t mapNormalisedMotorToTimerTicks(const int32_t channelValue)
+  {
+    return static_cast<uint32_t>(map32(channelValue, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, m_minMotorTimerTicks, m_maxMotorTimerTicks));
+  }
 
-    /**
+  /**
     * @brief  Converts calculated rate mode motor demands to correct timer tick values.
     * @param  
-    */ 
-    uint32_t mapRateMotorToTimerTicks(const int32_t channelValue)
-    {
-      return static_cast<uint32_t>(map32(channelValue, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT, m_minMotorTimerTicks, m_maxMotorTimerTicks));
-    }
+    */
+  uint32_t mapRateMotorToTimerTicks(const int32_t channelValue)
+  {
+    return static_cast<uint32_t>(map32(channelValue, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT, m_minMotorTimerTicks, m_maxMotorTimerTicks));
+  }
 
-    /**
+  /**
     * @brief  Converts calculated rate mode servo demands to correct timer tick values.
     * @param  
-    */ 
-    uint32_t mapRateServoToTimerTicks(const int32_t channelValue)
-    {
-      return static_cast<uint32_t>(map32(channelValue, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT, m_minServoTimerTicks, m_maxServoTimerTicks));
-    }
+    */
+  uint32_t mapRateServoToTimerTicks(const int32_t channelValue)
+  {
+    return static_cast<uint32_t>(map32(channelValue, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT, m_minServoTimerTicks, m_maxServoTimerTicks));
+  }
 
-    /**
+  /**
     * @brief  Gets the default timer ticks for motors i.e. motors off.
     * @param  
-    */ 
-    uint32_t getDefaultMotorTicks(Actuator number)
-    {
-      return motor[static_cast<uint32_t>(number)].getDefaultTimerTicks();
-    }
+    */
+  uint32_t getDefaultMotorTicks(Actuator number)
+  {
+    return motor[static_cast<uint32_t>(number)].getDefaultTimerTicks();
+  }
 
-    /**
+  /**
     * @brief  Gets the default timer ticks for servos i.e. servo centred.
     * @param  
-    */ 
-    uint32_t getDefaultServoTicks(Actuator number)
-    {
-      return servo[static_cast<uint32_t>(number)].getDefaultTimerTicks();
-    }
+    */
+  uint32_t getDefaultServoTicks(Actuator number)
+  {
+    return servo[static_cast<uint32_t>(number)].getDefaultTimerTicks();
+  }
 
-    /**
+  /**
     * @brief  Gets the max timer ticks for motors.
-    */ 
-    uint32_t getMaxMotorTicks() const 
-    {
-      return m_maxMotorTimerTicks;
-    }
+    */
+  uint32_t getMaxMotorTicks() const
+  {
+    return m_maxMotorTimerTicks;
+  }
 
-    /**
+  /**
     * @brief  Prevent PID being clipped due to extremes of motor control. 
     * @brief  If PID goes beyond max motor ticks then subtract the overshoot from all motors.
     * @brief  If PID goes below min motor ticks then add the undershoot to all motors.
@@ -396,144 +396,144 @@ class ModelBase : public Utilities
     * @param  motor2 to control
     * @param  motor3 to control
     * @param  motor4 to control
-    */ 
-    void multicopterMotorMagic(uint32_t * const motor1, uint32_t * const motor2, uint32_t * const motor3, uint32_t * const motor4)
+    */
+  void multicopterMotorMagic(uint32_t * const motor1, uint32_t * const motor2, uint32_t * const motor3, uint32_t * const motor4)
+  {
+    uint32_t underShoot = 0;
+    uint32_t overShoot = 0;
+    //When PID undershoots the min motor timer tick, take the maximum undershoot value and add it to all motors. This allows full PID control at min throttle ...my version of air mode :-P
+    if (*motor1 < m_minThrottle)
     {
-      uint32_t underShoot = 0;
-      uint32_t overShoot = 0;
-      //When PID undershoots the min motor timer tick, take the maximum undershoot value and add it to all motors. This allows full PID control at min throttle ...my version of air mode :-P 
-      if (*motor1 < m_minThrottle)
+      underShoot = m_minThrottle - *motor1;
+    }
+    else
+    {
+      if (*motor1 > m_maxMotorTimerTicks)
       {
-        underShoot = m_minThrottle - *motor1;
+        overShoot = *motor1 - m_maxMotorTimerTicks;
       }
-      else
-      {
-        if (*motor1 > m_maxMotorTimerTicks)
-        {
-          overShoot = *motor1 - m_maxMotorTimerTicks;
-        }
-      }
+    }
 
-      if (*motor2 < m_minThrottle)
+    if (*motor2 < m_minThrottle)
+    {
+      const uint32_t tempUnderShoot = m_minThrottle - *motor2;
+      underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
+    }
+    else
+    {
+      if (*motor2 > m_maxMotorTimerTicks)
       {
-        const uint32_t tempUnderShoot = m_minThrottle - *motor2;
-        underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
+        const uint32_t tempOverShoot = *motor2 - m_maxMotorTimerTicks;
+        overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
       }
-      else
-      {
-        if (*motor2 > m_maxMotorTimerTicks)
-        {
-          const uint32_t tempOverShoot = *motor2 - m_maxMotorTimerTicks;
-          overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
-        }
-      }
+    }
 
-      if (*motor3 < m_minThrottle)
+    if (*motor3 < m_minThrottle)
+    {
+      const uint32_t tempUnderShoot = m_minThrottle - *motor3;
+      underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
+    }
+    else
+    {
+      if (*motor3 > m_maxMotorTimerTicks)
       {
-        const uint32_t tempUnderShoot = m_minThrottle - *motor3;
-        underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
+        const uint32_t tempOverShoot = *motor3 - m_maxMotorTimerTicks;
+        overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
       }
-      else
-      {
-        if (*motor3 > m_maxMotorTimerTicks)
-        {
-          const uint32_t tempOverShoot = *motor3 - m_maxMotorTimerTicks;
-          overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
-        }
-      }
+    }
 
-      if (*motor4 < m_minThrottle)
+    if (*motor4 < m_minThrottle)
+    {
+      const uint32_t tempUnderShoot = m_minThrottle - *motor4;
+      underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
+    }
+    else
+    {
+      if (*motor4 > m_maxMotorTimerTicks)
       {
-        const uint32_t tempUnderShoot = m_minThrottle - *motor4;
-        underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;     
+        const uint32_t tempOverShoot = *motor4 - m_maxMotorTimerTicks;
+        overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
       }
-      else
-      {
-        if (*motor4 > m_maxMotorTimerTicks)
-        {
-          const uint32_t tempOverShoot = *motor4 - m_maxMotorTimerTicks;
-          overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
-        }
-      }
+    }
 
-      //We assume overShoot and underShoot cannot occur at the same time
-      //If one or more motors PID is undershooting then add the different to all to maintain control at low throttle
-      if (0 < underShoot)
+    //We assume overShoot and underShoot cannot occur at the same time
+    //If one or more motors PID is undershooting then add the different to all to maintain control at low throttle
+    if (0 < underShoot)
+    {
+      *motor1 += underShoot;
+      *motor2 += underShoot;
+      *motor3 += underShoot;
+      *motor4 += underShoot;
+    }
+    else
+    {
+      //If one or more motors PID is overshooting then subtract the different to all to maintain control at high throttle
+      if (0 < overShoot)
       {
-        *motor1 += underShoot;
-        *motor2 += underShoot;
-        *motor3 += underShoot;
-        *motor4 += underShoot;
+        *motor1 -= overShoot;
+        *motor2 -= overShoot;
+        *motor3 -= overShoot;
+        *motor4 -= overShoot;
       }
-      else
-      {
-        //If one or more motors PID is overshooting then subtract the different to all to maintain control at high throttle
-        if (0 < overShoot)
-        {
-          *motor1 -= overShoot;
-          *motor2 -= overShoot;
-          *motor3 -= overShoot;
-          *motor4 -= overShoot;
-        }
-      }
-    };
+    }
+  };
 
 
-    /**
+  /**
     * @brief  Prevent PID being clipped due to extremes of motor control. 
     * @brief  If PID goes beyond max motor ticks then subtract the overshoot from all motors.
     * @brief  If PID goes below min motor ticks then add the undershoot to all motors.
     * @param  motor1 to control
     * @param  motor2 to control
-    */ 
-    void multicopterMotorMagic(uint32_t * const motor1, uint32_t * const motor2)
-    {      
-      uint32_t underShoot = 0;
-      uint32_t overShoot = 0;
-      //When PID undershoots the min motor timer ticks, take the maximum undershoot value and add it to all motors. This allows full PID control at min throttle ...my version of air mode :-P 
-      //When PID overshoots the max motor timer ticks, take the maximum overshoot value and subtract it from all motors. This allows full PID control at max throttle ...my version of anti gravity mode :-P 
-      if (*motor1 < m_minThrottle)
+    */
+  void multicopterMotorMagic(uint32_t * const motor1, uint32_t * const motor2)
+  {
+    uint32_t underShoot = 0;
+    uint32_t overShoot = 0;
+    //When PID undershoots the min motor timer ticks, take the maximum undershoot value and add it to all motors. This allows full PID control at min throttle ...my version of air mode :-P
+    //When PID overshoots the max motor timer ticks, take the maximum overshoot value and subtract it from all motors. This allows full PID control at max throttle ...my version of anti gravity mode :-P
+    if (*motor1 < m_minThrottle)
+    {
+      underShoot = m_minThrottle - *motor1;
+    }
+    else
+    {
+      if (*motor1 > m_maxMotorTimerTicks)
       {
-        underShoot = m_minThrottle - *motor1;
+        overShoot = *motor1 - m_maxMotorTimerTicks;
       }
-      else
-      {
-        if (*motor1 > m_maxMotorTimerTicks)
-        {
-          overShoot = *motor1 - m_maxMotorTimerTicks;
-        }
-      }
+    }
 
-      if (*motor2 < m_minThrottle)
+    if (*motor2 < m_minThrottle)
+    {
+      const uint32_t tempUnderShoot = m_minThrottle - *motor2;
+      underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
+    }
+    else
+    {
+      if (*motor2 > m_maxMotorTimerTicks)
       {
-        const uint32_t tempUnderShoot = m_minThrottle - *motor2;
-        underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
+        const uint32_t tempOverShoot = *motor2 - m_maxMotorTimerTicks;
+        overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
       }
-      else
-      {
-        if (*motor2 > m_maxMotorTimerTicks)
-        {
-          const uint32_t tempOverShoot = *motor2 - m_maxMotorTimerTicks;
-          overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
-        }
-      }
+    }
 
-      //If one or more motors PID is undershooting then add the different to all to maintain control at low throttle
-      if (0 < underShoot)
+    //If one or more motors PID is undershooting then add the different to all to maintain control at low throttle
+    if (0 < underShoot)
+    {
+      *motor1 += underShoot;
+      *motor2 += underShoot;
+    }
+    else
+    {
+      if (0 < overShoot)
       {
-        *motor1 += underShoot;
-        *motor2 += underShoot;
+        //If one or more motors PID is overshooting then subtract the different to all to maintain control at high throttle
+        *motor1 -= overShoot;
+        *motor2 -= overShoot;
       }
-      else
-      {
-        if (0 < overShoot)
-        {
-          //If one or more motors PID is overshooting then subtract the different to all to maintain control at high throttle
-          *motor1 -= overShoot;
-          *motor2 -= overShoot;
-        }
-      }
-    };
+    }
+  };
 };
 
 
@@ -541,238 +541,257 @@ class ModelBase : public Utilities
 * @brief    Plane with wing ailerons/flaps, rudder and elevator. 
 * @note     Channel output map: Left aileron, right aileron elevator, rudder, motor 1, motor 2
 * @note     3 position flaps work with this model.
-*/ 
+*/
 class PlaneFullHouse : public ModelBase
 {
-  public:   
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 4U;
-    static constexpr uint8_t SERVO_1_PIN    = D0;
-    static constexpr uint8_t SERVO_2_PIN    = D1;
-    static constexpr uint8_t SERVO_3_PIN    = D2;
-    static constexpr uint8_t SERVO_4_PIN    = D3;
-    static constexpr uint8_t MOTOR_1_PIN    = D8;
-    static constexpr uint8_t MOTOR_2_PIN    = D9;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 4U;
+  static constexpr uint8_t SERVO_1_PIN    = D0;
+  static constexpr uint8_t SERVO_2_PIN    = D1;
+  static constexpr uint8_t SERVO_3_PIN    = D2;
+  static constexpr uint8_t SERVO_4_PIN    = D3;
+  static constexpr uint8_t MOTOR_1_PIN    = D8;
+  static constexpr uint8_t MOTOR_2_PIN    = D9;
 
-    //Configure this model as a quadcopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a quadcopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    PlaneFullHouse() : ModelBase(m_modelConfig){};
-    ~PlaneFullHouse(){};
+  PlaneFullHouse() : ModelBase(m_modelConfig){};
+  ~PlaneFullHouse(){};
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */    
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+    */
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    int32_t negativeFlap = 0;
+
+    if constexpr(Config::USE_FLAPS)
     {
-      int32_t negativeFlap = 0;
-
-      if constexpr(Config::USE_FLAPS)
-      {
-        //Loss of precision in modifying flaps, but as its flaps we do not care.
-        negativeFlap = map32(demands->flaps, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US,  SBus::MID_NORMALISED_US, SBus::MAX_NORMALISED_US);
-      }
-
-      const uint32_t leftAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll - negativeFlap) + (trim->servo1 * getTrimMultiplier())); 
-      const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll + negativeFlap) + (trim->servo2 * getTrimMultiplier()));
-      const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));      
-      const uint32_t yawTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));      
-      writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+      //Loss of precision in modifying flaps, but as its flaps we do not care.
+      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, RxBase::MID_NORMALISED, RxBase::MAX_NORMALISED);
     }
 
-    /**
+    // constraint add to prevent overflow
+    const int32_t rollMinusFlap = constrain(demands->roll + negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollPlusFlap = constrain(demands->roll - negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t leftAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
+    const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
+    const uint32_t yawTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));
+    writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+  }
+
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */   
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    { 
-      int32_t negativeFlap = 0;
+    */
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    int32_t negativeFlap = 0;
 
-      if constexpr(Config::USE_FLAPS)
-      {
-        //Loss of precision in modifying flaps, but as its flaps we do not care.
-        negativeFlap = map32(demands->flaps, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US,  0, PIDF::PIDF_MAX_LIMIT);
-      }
-
-      const uint32_t leftAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll - negativeFlap) + (trim->servo1 * getTrimMultiplier())); 
-      const uint32_t rightAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll + negativeFlap) + (trim->servo2 * getTrimMultiplier()));
-      const uint32_t pitchTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));      
-      const uint32_t yawTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));      
-      writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+    if constexpr(Config::USE_FLAPS)
+    {
+      //Loss of precision in modifying flaps, but as its flaps we do not care.
+      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0, PIDF::PIDF_MAX_LIMIT);
     }
 
-    /**
+    // constraint add to prevent overflow
+    const int32_t rollMinusFlap = constrain(demands->roll - negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t rollPlusFlap = constrain(demands->yaw + negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t leftAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
+    const uint32_t pitchTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
+    const uint32_t yawTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));
+    writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+  }
+
+  /**
     * @brief  Motor mixer when not in rate mode
     * @param  demands - The rc demands
-    */   
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapNormalisedMotorToTimerTicks(demands->throttle + demands->yaw);
-        const uint32_t motor2 = mapNormalisedMotorToTimerTicks(demands->throttle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t throttlePlusYaw = constrain(demands->throttle + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
+      const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when in rate/level mode
     * @param  demands - The rc demands
-    */     
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Upscale throttle
-        const int32_t modifiedThrottle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapRateMotorToTimerTicks(modifiedThrottle + demands->yaw);
-        const uint32_t motor2 = mapRateMotorToTimerTicks(modifiedThrottle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Upscale throttle
+      const int32_t modifiedThrottle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t modThrottlePlusYaw = constrain(modifiedThrottle + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
+      const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 };
-
 
 
 /**
 * @brief    Plane with wing ailerons/flaps, with rudder and elevator mixed for V-tail i.e.'Talon' type model. 
 * @note     Channel output map: left aileron, right aileron, Left taileron, right taileron, motor 1, motor 2
 * @note     3 position flaps work with this model.
-*/ 
+*/
 class PlaneFullHouseVTail : public ModelBase
 {
-  public:
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 4U;
-    static constexpr uint8_t SERVO_1_PIN    = D0;
-    static constexpr uint8_t SERVO_2_PIN    = D1;
-    static constexpr uint8_t SERVO_3_PIN    = D2;
-    static constexpr uint8_t SERVO_4_PIN    = D3;
-    static constexpr uint8_t MOTOR_1_PIN    = D8;
-    static constexpr uint8_t MOTOR_2_PIN    = D9;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 4U;
+  static constexpr uint8_t SERVO_1_PIN    = D0;
+  static constexpr uint8_t SERVO_2_PIN    = D1;
+  static constexpr uint8_t SERVO_3_PIN    = D2;
+  static constexpr uint8_t SERVO_4_PIN    = D3;
+  static constexpr uint8_t MOTOR_1_PIN    = D8;
+  static constexpr uint8_t MOTOR_2_PIN    = D9;
 
-    //Configure this model...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    PlaneFullHouseVTail() : ModelBase(m_modelConfig){};
-    ~PlaneFullHouseVTail(){};
+  PlaneFullHouseVTail() : ModelBase(m_modelConfig){};
+  ~PlaneFullHouseVTail(){};
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */    
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+    */
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    int32_t negativeFlap = 0;
+
+    if constexpr(Config::USE_FLAPS)
     {
-      int32_t negativeFlap = 0;
-
-      if constexpr(Config::USE_FLAPS)
-      {
-        //Loss of precision in modifying flaps, but as its flaps we do not care.
-        negativeFlap = map32(demands->flaps, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US,  SBus::MID_NORMALISED_US, SBus::MAX_NORMALISED_US);
-      }
-
-      const uint32_t leftAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll - negativeFlap) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll + negativeFlap) + (trim->servo2 * getTrimMultiplier()));
-      const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
-      const uint32_t yawTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));
-      writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+      //Loss of precision in modifying flaps, but as its flaps we do not care.
+      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, RxBase::MID_NORMALISED, RxBase::MAX_NORMALISED);
     }
+    // constraint add to prevent overflow
+    const int32_t rollMinusFlap = constrain(demands->roll + negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollPlusFlap = constrain(demands->roll - negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t leftAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
+    const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
+    const uint32_t yawTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));
+    writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+  }
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */   
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    { 
-      int32_t negativeFlap = 0;
+    */
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    int32_t negativeFlap = 0;
 
-      if constexpr(Config::USE_FLAPS)
-      {
-        //Loss of precision in modifying flaps, but as its flaps we do not care.
-        negativeFlap = map32(demands->flaps, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US,  0, PIDF::PIDF_MAX_LIMIT);
-      }
-
-      const uint32_t leftAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll - negativeFlap) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t rightAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll + negativeFlap) + (trim->servo2 * getTrimMultiplier()));
-      const uint32_t pitchTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw - demands->pitch) + (trim->servo3 * getTrimMultiplier()));
-      const uint32_t yawTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw + demands->pitch) + (trim->servo4 * getTrimMultiplier()));
-      writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+    if constexpr(Config::USE_FLAPS)
+    {
+      //Loss of precision in modifying flaps, but as its flaps we do not care.
+      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0, PIDF::PIDF_MAX_LIMIT);
     }
+    // constraint add to prevent overflow
+    const int32_t rollMinusFlap = constrain(demands->roll - negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t rollPlusFlap = constrain(demands->roll + negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t yawMinusPitch = constrain(demands->yaw - demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t yawPlusPitch = constrain(demands->yaw + demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t leftAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
+    const uint32_t pitchTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(yawMinusPitch) + (trim->servo3 * getTrimMultiplier()));
+    const uint32_t yawTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(yawPlusPitch) + (trim->servo4 * getTrimMultiplier()));
+    writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when not in rate mode
     * @param  demands - The rc demands
-    */   
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapNormalisedMotorToTimerTicks(demands->throttle + demands->yaw);
-        const uint32_t motor2 = mapNormalisedMotorToTimerTicks(demands->throttle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t throttlePlusYaw = constrain(demands->throttle + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
+      const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when in rate/level mode
     * @param  demands - The rc demands
-    */     
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Upscale throttle
-        const int32_t modifiedThrottle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapRateMotorToTimerTicks(modifiedThrottle + demands->yaw);
-        const uint32_t motor2 = mapRateMotorToTimerTicks(modifiedThrottle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Upscale throttle
+      const int32_t modifiedThrottle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t modThrottlePlusYaw = constrain(modifiedThrottle + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
+      const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 };
 
 
@@ -781,96 +800,104 @@ class PlaneFullHouseVTail : public ModelBase
 * @note     Roll and yaw corrections are mapped to rudder control. This makes for better rudder/elevator aerobatics but harder to tune.
 * @note     Channel output map: rudder, elevator, motor 1, motor 2
 * @note     Both roll and yaw gyro corrections are mixeded to rudder, this makes for better aerobatics but is harder to tune.
-*/ 
+*/
 class PlaneAdvancedRudderElevator : public ModelBase
 {
-  public: 
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 2U;
-    static constexpr uint8_t SERVO_1_PIN    = D0;
-    static constexpr uint8_t SERVO_2_PIN    = D1;
-    static constexpr uint8_t MOTOR_1_PIN    = D2;
-    static constexpr uint8_t MOTOR_2_PIN    = D3;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 2U;
+  static constexpr uint8_t SERVO_1_PIN    = D0;
+  static constexpr uint8_t SERVO_2_PIN    = D1;
+  static constexpr uint8_t MOTOR_1_PIN    = D2;
+  static constexpr uint8_t MOTOR_2_PIN    = D3;
 
-    //Configure this model...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    PlaneAdvancedRudderElevator() : ModelBase(m_modelConfig){};
-    ~PlaneAdvancedRudderElevator(){};
+  PlaneAdvancedRudderElevator() : ModelBase(m_modelConfig){};
+  ~PlaneAdvancedRudderElevator(){};
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */    
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll + demands->yaw) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t elevatorTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-      writeServos(rudderTicks, elevatorTicks);
-    }
+    */
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    // constraint add to prevent overflow
+    const int32_t rollPlusYaw = constrain(demands->roll + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusYaw) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t elevatorTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
+    writeServos(rudderTicks, elevatorTicks);
+  }
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */   
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    { 
-      const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll + demands->yaw) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t elevatorTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-      writeServos(rudderTicks, elevatorTicks);
-    }
+    */
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    // constraint add to prevent overflow
+    const int32_t rollPlusYaw = constrain(demands->roll + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusYaw) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t elevatorTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
+    writeServos(rudderTicks, elevatorTicks);
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when not in rate mode
     * @param  demands - The rc demands
-    */   
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapNormalisedMotorToTimerTicks(demands->throttle + demands->yaw);
-        const uint32_t motor2 = mapNormalisedMotorToTimerTicks(demands->throttle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t throttlePlusYaw = constrain(demands->throttle + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
+      const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when in rate/level mode
     * @param  demands - The rc demands
-    */     
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Upscale throttle
-        const int32_t modifiedThrottle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapRateMotorToTimerTicks(modifiedThrottle + demands->yaw);
-        const uint32_t motor2 = mapRateMotorToTimerTicks(modifiedThrottle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Upscale throttle
+      const int32_t modifiedThrottle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t modThrottlePlusYaw = constrain(modifiedThrottle + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
+      const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 };
 
 
@@ -878,293 +905,316 @@ class PlaneAdvancedRudderElevator : public ModelBase
 * @brief    Plane with rudder elevator only. 
 * @note     Roll correction are mapped to rudder control.
 * @note     Channel output map: rudder, elevator, motor 1, motor 2
-*/ 
+*/
 class PlaneRudderElevator : public ModelBase
 {
-  public: 
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 2U;
-    static constexpr uint8_t SERVO_1_PIN    = D0;
-    static constexpr uint8_t SERVO_2_PIN    = D1;
-    static constexpr uint8_t MOTOR_1_PIN    = D2;
-    static constexpr uint8_t MOTOR_2_PIN    = D3;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 2U;
+  static constexpr uint8_t SERVO_1_PIN    = D0;
+  static constexpr uint8_t SERVO_2_PIN    = D1;
+  static constexpr uint8_t MOTOR_1_PIN    = D2;
+  static constexpr uint8_t MOTOR_2_PIN    = D3;
 
-    //Configure this model...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    PlaneRudderElevator() : ModelBase(m_modelConfig){};
-    ~PlaneRudderElevator(){};
+  PlaneRudderElevator() : ModelBase(m_modelConfig){};
+  ~PlaneRudderElevator(){};
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */    
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t elevatorTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-      writeServos(rudderTicks, elevatorTicks);
-    }
+    */
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t elevatorTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
+    writeServos(rudderTicks, elevatorTicks);
+  }
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */   
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    { 
-      const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t elevatorTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-      writeServos(rudderTicks, elevatorTicks);
-    }
+    */
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t elevatorTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
+    writeServos(rudderTicks, elevatorTicks);
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when not in rate mode
     * @param  demands - The rc demands
-    */   
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapNormalisedMotorToTimerTicks(demands->throttle + demands->yaw);
-        const uint32_t motor2 = mapNormalisedMotorToTimerTicks(demands->throttle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t throttlePlusYaw = constrain(demands->throttle + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
+      const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when in rate/level mode
     * @param  demands - The rc demands
-    */     
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Upscale throttle
-        const int32_t modifiedThrottle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapRateMotorToTimerTicks(modifiedThrottle + demands->yaw);
-        const uint32_t motor2 = mapRateMotorToTimerTicks(modifiedThrottle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Upscale throttle
+      const int32_t modifiedThrottle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t modThrottlePlusYaw = constrain(modifiedThrottle + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
+      const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 };
 
 
 /**
 * @brief    Plane with V-tail controls only. 
 * @note     Channel output map: left taileron, right taileron, motor 1, motor 2
-*/ 
+*/
 class PlaneVTail : public ModelBase
 {
-  public:  
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 2U;
-    static constexpr uint8_t SERVO_1_PIN    = D0;
-    static constexpr uint8_t SERVO_2_PIN    = D1;
-    static constexpr uint8_t MOTOR_1_PIN    = D2;
-    static constexpr uint8_t MOTOR_2_PIN    = D3;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 2U;
+  static constexpr uint8_t SERVO_1_PIN    = D0;
+  static constexpr uint8_t SERVO_2_PIN    = D1;
+  static constexpr uint8_t MOTOR_1_PIN    = D2;
+  static constexpr uint8_t MOTOR_2_PIN    = D3;
 
-    //Configure this model...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    PlaneVTail() : ModelBase(m_modelConfig){};
-    ~PlaneVTail(){};
+  PlaneVTail() : ModelBase(m_modelConfig){};
+  ~PlaneVTail(){};
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */    
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      const uint32_t leftTaileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll + demands->pitch) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t rightTaileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll - demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-      writeServos(leftTaileronTicks, rightTaileronTicks);
-    }
+    */
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    // constraint add to prevent overflow
+    const int32_t rollPlusPitch = constrain(demands->roll + demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollMinusPitch = constrain(demands->roll - demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t leftTaileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightTaileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
+    writeServos(leftTaileronTicks, rightTaileronTicks);
+  }
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */   
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    { 
-      const uint32_t leftElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll + demands->pitch) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t rightElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll - demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-      writeServos(leftElevonTicks, rightElevonTicks);
-    }
+    */
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    // constraint add to prevent overflow
+    const int32_t rollPlusPitch = constrain(demands->roll + demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t rollMinusPitch = constrain(demands->roll - demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t leftElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
+    writeServos(leftElevonTicks, rightElevonTicks);
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when not in rate mode
     * @param  demands - The rc demands
-    */   
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapNormalisedMotorToTimerTicks(demands->throttle + demands->yaw);
-        const uint32_t motor2 = mapNormalisedMotorToTimerTicks(demands->throttle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t throttlePlusYaw = constrain(demands->throttle + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
+      const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when in rate/level mode
     * @param  demands - The rc demands
-    */     
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Upscale throttle
-        const int32_t modifiedThrottle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapRateMotorToTimerTicks(modifiedThrottle + demands->yaw);
-        const uint32_t motor2 = mapRateMotorToTimerTicks(modifiedThrottle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Upscale throttle
+      const int32_t modifiedThrottle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t modThrottlePlusYaw = constrain(modifiedThrottle + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
+      const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 };
-
 
 
 /**
 * @brief    Flying wing class with 2 elevons and rudder if required. 
 * @note     Channel output map: left elevon, right elevon, rudder, LEDc unused, motor 1, motor 2
-*/ 
+*/
 class PlaneFlyingWing : public ModelBase
 {
-  public: 
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 4U;
-    static constexpr uint8_t SERVO_1_PIN    = D0;
-    static constexpr uint8_t SERVO_2_PIN    = D1;
-    static constexpr uint8_t SERVO_3_PIN    = D2;
-    static constexpr uint8_t SERVO_4_PIN    = D3;
-    static constexpr uint8_t MOTOR_1_PIN    = D8;
-    static constexpr uint8_t MOTOR_2_PIN    = D9;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 4U;
+  static constexpr uint8_t SERVO_1_PIN    = D0;
+  static constexpr uint8_t SERVO_2_PIN    = D1;
+  static constexpr uint8_t SERVO_3_PIN    = D2;
+  static constexpr uint8_t SERVO_4_PIN    = D3;
+  static constexpr uint8_t MOTOR_1_PIN    = D8;
+  static constexpr uint8_t MOTOR_2_PIN    = D9;
 
-    //Configure this model as a quadcopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a quadcopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    PlaneFlyingWing() : ModelBase(m_modelConfig){};
-    ~PlaneFlyingWing(){};
+  PlaneFlyingWing() : ModelBase(m_modelConfig){};
+  ~PlaneFlyingWing(){};
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */     
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      const uint32_t leftElevonTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll + demands->pitch) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t rightElevonTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll - demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-      const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo3 * getTrimMultiplier()));
-      writeServos(leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4));
-    }
+    */
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    // constraint add to prevent overflow
+    const int32_t rollPlusPitch = constrain(demands->roll + demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollMinusPitch = constrain(demands->roll - demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t leftElevonTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightElevonTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
+    const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo3 * getTrimMultiplier()));
+    writeServos(leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4));
+  }
 
-    /**
+  /**
     * @brief  Servo mixer
     * @param  demands - The rc demands.
     * @param  trim - The servo trims to apply
-    */   
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    { 
-      const uint32_t leftElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll + demands->pitch) + (trim->servo1 * getTrimMultiplier()));
-      const uint32_t rightElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll - demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-      const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw) + (trim->servo3 * getTrimMultiplier()));
-      writeServos(leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4));
-    }
+    */
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    // constraint add to prevent overflow
+    const int32_t rollPlusPitch = constrain(demands->roll + demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t rollMinusPitch = constrain(demands->roll - demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t leftElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
+    const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw) + (trim->servo3 * getTrimMultiplier()));
+    writeServos(leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4));
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when not in rate mode
     * @param  demands - The rc demands
-    */   
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapNormalisedMotorToTimerTicks(demands->throttle + demands->yaw);
-        const uint32_t motor2 = mapNormalisedMotorToTimerTicks(demands->throttle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t throttlePlusYaw = constrain(demands->throttle + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+      const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
+      const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 
-    /**
+  /**
     * @brief  Motor mixer when in rate/level mode
     * @param  demands - The rc demands
-    */     
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+    */
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    if constexpr(Config::USE_DIFFERENTIAL_THRUST)
     {
-      if constexpr(Config::USE_DIFFERENTIAL_THRUST)
-      {
-        //Upscale throttle
-        const int32_t modifiedThrottle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-        //Convert demands to timer ticks
-        const uint32_t motor1 = mapRateMotorToTimerTicks(modifiedThrottle + demands->yaw);
-        const uint32_t motor2 = mapRateMotorToTimerTicks(modifiedThrottle - demands->yaw);
-        writeMotors(motor1, motor2);
-      }
-      else
-      {
-        const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-        writeMotors(motor, motor);
-      }
+      //Upscale throttle
+      const int32_t modifiedThrottle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      //Convert demands to timer ticks - constraint add to prevent overflow
+      const int32_t modThrottlePlusYaw = constrain(modifiedThrottle + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const int32_t modThrottleMinusYaw = constrain(demands->roll - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+      const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
+      const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
+      writeMotors(motor1, motor2);
     }
+    else
+    {
+      const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
+      writeMotors(motor, motor);
+    }
+  }
 };
 
 
@@ -1179,64 +1229,64 @@ class PlaneFlyingWing : public ModelBase
 * @note       x
 * @note     3   1
 * @note     Channel output map: motor 1, motor 2, motor 3, motor 4
-*/ 
+*/
 class QuadXCopter : public ModelBase
 {
-  public:
-    static constexpr uint8_t NUMBER_MOTORS  = 4U;
-    static constexpr uint8_t NUMBER_SERVOS  = 0U;
-    static constexpr uint8_t MOTOR_1_PIN    = D0;
-    static constexpr uint8_t MOTOR_2_PIN    = D1;
-    static constexpr uint8_t MOTOR_3_PIN    = D2;
-    static constexpr uint8_t MOTOR_4_PIN    = D3;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 4U;
+  static constexpr uint8_t NUMBER_SERVOS  = 0U;
+  static constexpr uint8_t MOTOR_1_PIN    = D0;
+  static constexpr uint8_t MOTOR_2_PIN    = D1;
+  static constexpr uint8_t MOTOR_3_PIN    = D2;
+  static constexpr uint8_t MOTOR_4_PIN    = D3;
 
-    //Configure this model as a quadcopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
-      {0U, 0U, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a quadcopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
+          {0U, 0U, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    QuadXCopter() : ModelBase(m_modelConfig)
-    {
-      const uint32_t minThrottle = map32(MIN_THROTTLE, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-      m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-    };
+  QuadXCopter() : ModelBase(m_modelConfig)
+  {
+    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
+  };
 
-    ~QuadXCopter(){};
-    
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
-    {
-      writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
-    }
+  ~QuadXCopter(){};
 
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final 
-    {
-      //Rate mode only when armed
-      //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
-      int32_t throttle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, IDLE_UP, SBus::MAX_NORMALISED_US);
-      //Now remap to work with rate mode
-      throttle = map32(throttle, IDLE_UP, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
+  }
 
-      //Set control mix and convert demands to timer ticks
-      uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->pitch + demands->roll - demands->yaw);
-      uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->pitch + demands->roll + demands->yaw);
-      uint32_t motor3 = mapRateMotorToTimerTicks(throttle - demands->pitch - demands->roll + demands->yaw);
-      uint32_t motor4 = mapRateMotorToTimerTicks(throttle + demands->pitch - demands->roll - demands->yaw);
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    //Rate mode only when armed
+    //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
+    int32_t throttle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, IDLE_UP, RxBase::MAX_NORMALISED);
+    //Now remap to work with rate mode
+    throttle = map32(throttle, IDLE_UP, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
 
-      multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);      
+    //Set control mix and convert demands to timer ticks
+    uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->pitch + demands->roll - demands->yaw);
+    uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->pitch + demands->roll + demands->yaw);
+    uint32_t motor3 = mapRateMotorToTimerTicks(throttle - demands->pitch - demands->roll + demands->yaw);
+    uint32_t motor4 = mapRateMotorToTimerTicks(throttle + demands->pitch - demands->roll - demands->yaw);
 
-      motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-      motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
-      motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
-      motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
+    multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
 
-      writeMotors(motor1, motor2, motor3, motor4);
-    };
+    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
+    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
+    motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
+
+    writeMotors(motor1, motor2, motor3, motor4);
+  };
 };
 
 
@@ -1247,296 +1297,304 @@ class QuadXCopter : public ModelBase
 * @note     4 + 2
 * @note       3
 * @note     Channel output map: motor 1, motor 2, motor 3, motor 4
-*/ 
+*/
 class QuadPlusCopter : public ModelBase
 {
-  public:
-    static constexpr uint8_t NUMBER_MOTORS  = 4U;
-    static constexpr uint8_t NUMBER_SERVOS  = 0U;
-    static constexpr uint8_t MOTOR_1_PIN    = D0;
-    static constexpr uint8_t MOTOR_2_PIN    = D1;
-    static constexpr uint8_t MOTOR_3_PIN    = D2;
-    static constexpr uint8_t MOTOR_4_PIN    = D3;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 4U;
+  static constexpr uint8_t NUMBER_SERVOS  = 0U;
+  static constexpr uint8_t MOTOR_1_PIN    = D0;
+  static constexpr uint8_t MOTOR_2_PIN    = D1;
+  static constexpr uint8_t MOTOR_3_PIN    = D2;
+  static constexpr uint8_t MOTOR_4_PIN    = D3;
 
-    //Configure this model as a quadcopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
-      {0U, 0U, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a quadcopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
+          {0U, 0U, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    QuadPlusCopter() : ModelBase(m_modelConfig)
-    {
-      const uint32_t minThrottle = map32(MIN_THROTTLE, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-      m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-    };
+  QuadPlusCopter() : ModelBase(m_modelConfig)
+  {
+    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
+  };
 
-    ~QuadPlusCopter(){};
-    
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
-    {
-      writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
-    }
+  ~QuadPlusCopter(){};
 
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final 
-    {
-      //Rate mode only when armed
-      //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
-      int32_t throttle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, IDLE_UP, SBus::MAX_NORMALISED_US);
-      //Now remap to work with rate mode
-      throttle = map32(throttle, IDLE_UP, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
+  }
 
-      //Set control mix and convert demands to timer ticks
-      uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->pitch - demands->yaw);
-      uint32_t motor2 = mapRateMotorToTimerTicks(throttle - demands->roll + demands->yaw);
-      uint32_t motor3 = mapRateMotorToTimerTicks(throttle + demands->pitch - demands->yaw);
-      uint32_t motor4 = mapRateMotorToTimerTicks(throttle + demands->roll + demands->yaw);
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    //Rate mode only when armed
+    //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
+    int32_t throttle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, IDLE_UP, RxBase::MAX_NORMALISED);
+    //Now remap to work with rate mode
+    throttle = map32(throttle, IDLE_UP, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
 
-      multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);      
+    //Set control mix and convert demands to timer ticks
+    uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->pitch - demands->yaw);
+    uint32_t motor2 = mapRateMotorToTimerTicks(throttle - demands->roll + demands->yaw);
+    uint32_t motor3 = mapRateMotorToTimerTicks(throttle + demands->pitch - demands->yaw);
+    uint32_t motor4 = mapRateMotorToTimerTicks(throttle + demands->roll + demands->yaw);
 
-      motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-      motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
-      motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
-      motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
+    multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
 
-      writeMotors(motor1, motor2, motor3, motor4);
-    };
+    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
+    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
+    motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
+
+    writeMotors(motor1, motor2, motor3, motor4);
+  };
 };
 
 
 /**
 * @brief    Chinook class. 
 * @note     Channel output map: Front servo, rear servo, motor 1, motor 2
-*/ 
+*/
 class ChinookCopter : public ModelBase
 {
-  public:
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 2U;
-    static constexpr uint8_t MOTOR_1_PIN    = D0;
-    static constexpr uint8_t MOTOR_2_PIN    = D1;
-    static constexpr uint8_t SERVO_1_PIN    = D2;
-    static constexpr uint8_t SERVO_2_PIN    = D3;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 2U;
+  static constexpr uint8_t MOTOR_1_PIN    = D0;
+  static constexpr uint8_t MOTOR_2_PIN    = D1;
+  static constexpr uint8_t SERVO_1_PIN    = D2;
+  static constexpr uint8_t SERVO_2_PIN    = D3;
 
-    //Configure this model as a quadcopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a quadcopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    ChinookCopter() : ModelBase(m_modelConfig)
-    {
-      const uint32_t minThrottle = map32(MIN_THROTTLE, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-      m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-    };
+  ChinookCopter() : ModelBase(m_modelConfig)
+  {
+    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
+  };
 
-    ~ChinookCopter(){};
+  ~ChinookCopter(){};
 
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
-    {
-      writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
-    }
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
+  }
 
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final 
-    {
-      //Rate mode only when armed
-      //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
-      int32_t throttle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, IDLE_UP, SBus::MAX_NORMALISED_US);
-      //Now remap to work with rate mode
-      throttle = map32(throttle, IDLE_UP, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    //Rate mode only when armed
+    //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
+    int32_t throttle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, IDLE_UP, RxBase::MAX_NORMALISED);
+    //Now remap to work with rate mode
+    throttle = map32(throttle, IDLE_UP, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
 
-      //Set control mix and convert demands to timer ticks
-      uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->pitch);
-      uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->pitch);
+    //Set control mix and convert demands to timer ticks
+    uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->pitch);
+    uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->pitch);
 
-      multicopterMotorMagic(&motor1, &motor2);      
+    multicopterMotorMagic(&motor1, &motor2);
 
-      motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-      motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
+    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
 
-      writeMotors(motor1, motor2);
-    };
+    writeMotors(motor1, motor2);
+  };
 
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final 
-    {
-      //When disarmed
-      const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->roll + demands->yaw) + (trim->servo1 * getTrimMultiplier());
-      const uint32_t servo2 = mapNormalisedServoToTimerTicks(demands->roll - demands->yaw) + (trim->servo2 * getTrimMultiplier());
-      writeServos(servo1, servo2);
-    }
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When disarmed - constraint add to prevent overflow
+    const int32_t rollPlusYaw = constrain(demands->roll  + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t rollMinusYaw = constrain(demands->roll  - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t servo1 = mapNormalisedServoToTimerTicks(rollPlusYaw) + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapNormalisedServoToTimerTicks(rollMinusYaw) + (trim->servo2 * getTrimMultiplier());
+    writeServos(servo1, servo2);
+  }
 
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      //When armed
-      const uint32_t servo1 = mapRateServoToTimerTicks(demands->roll + demands->yaw) + (trim->servo1 * getTrimMultiplier());
-      const uint32_t servo2 = mapRateServoToTimerTicks(demands->roll - demands->yaw) + (trim->servo2 * getTrimMultiplier());
-      writeServos(servo1, servo2);
-    }
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When armed - constraint add to prevent overflow
+    const int32_t rollPlusYaw = constrain(demands->roll  + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t rollMinusYaw = constrain(demands->roll  - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t servo1 = mapRateServoToTimerTicks(rollPlusYaw) + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapRateServoToTimerTicks(rollMinusYaw) + (trim->servo2 * getTrimMultiplier());
+    writeServos(servo1, servo2);
+  }
 };
 
 
 /**
 * @brief    Bicopter class. 
 * @note     Channel output left servo: right servo, motor 1, motor 2
-*/ 
+*/
 class BiCopter : public ModelBase
 {
-  public:
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 2U;
-    static constexpr uint8_t MOTOR_1_PIN    = D0;
-    static constexpr uint8_t MOTOR_2_PIN    = D1;
-    static constexpr uint8_t SERVO_1_PIN    = D2;
-    static constexpr uint8_t SERVO_2_PIN    = D3;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 2U;
+  static constexpr uint8_t MOTOR_1_PIN    = D0;
+  static constexpr uint8_t MOTOR_2_PIN    = D1;
+  static constexpr uint8_t SERVO_1_PIN    = D2;
+  static constexpr uint8_t SERVO_2_PIN    = D3;
 
-    //Configure this model as a bicopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a bicopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    BiCopter() : ModelBase(m_modelConfig)
-    {
-      const uint32_t minThrottle = map32(MIN_THROTTLE, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-      m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-    };
+  BiCopter() : ModelBase(m_modelConfig)
+  {
+    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
+  };
 
-    ~BiCopter(){};
+  ~BiCopter(){};
 
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
-    {
-      writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
-    }
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
+  }
 
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final 
-    {
-      //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
-      int32_t throttle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, IDLE_UP, SBus::MAX_NORMALISED_US);
-      //Now remap to work with rate mode
-      throttle = map32(throttle, IDLE_UP, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
+    int32_t throttle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, IDLE_UP, RxBase::MAX_NORMALISED);
+    //Now remap to work with rate mode
+    throttle = map32(throttle, IDLE_UP, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
 
-      //Set control mix and convert demands to timer ticks
-      uint32_t motor1 = mapRateMotorToTimerTicks(throttle + demands->roll);
-      uint32_t motor2 = mapRateMotorToTimerTicks(throttle - demands->roll);
+    //Set control mix and convert demands to timer ticks
+    uint32_t motor1 = mapRateMotorToTimerTicks(throttle + demands->roll);
+    uint32_t motor2 = mapRateMotorToTimerTicks(throttle - demands->roll);
 
-      multicopterMotorMagic(&motor1, &motor2);      
+    multicopterMotorMagic(&motor1, &motor2);
 
-      motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-      motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
+    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
 
-      writeMotors(motor1, motor2);
-    };
+    writeMotors(motor1, motor2);
+  };
 
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final 
-    {
-      //When disarmed
-      const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->yaw + demands->pitch) + (trim->servo1 * getTrimMultiplier());
-      const uint32_t servo2 = mapNormalisedServoToTimerTicks(demands->yaw - demands->pitch) + (trim->servo2 * getTrimMultiplier());
-      writeServos(servo1, servo2);
-    }
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When disarmed - constraint add to prevent overflow
+    const int32_t yawPlusPitch = constrain(demands->yaw  + demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t yawMinusPitch = constrain(demands->yaw  - demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t servo1 = mapNormalisedServoToTimerTicks(yawPlusPitch) + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapNormalisedServoToTimerTicks(yawMinusPitch) + (trim->servo2 * getTrimMultiplier());
+    writeServos(servo1, servo2);
+  }
 
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      //When armed
-      const uint32_t servo1 = mapRateServoToTimerTicks(demands->yaw + demands->pitch) + (trim->servo1 * getTrimMultiplier());
-      const uint32_t servo2 = mapRateServoToTimerTicks(demands->yaw - demands->pitch) + (trim->servo2 * getTrimMultiplier());
-      writeServos(servo1, servo2);
-    }
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When armed - constraint add to prevent overflow
+    const int32_t yawPlusPitch = constrain(demands->yaw  + demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t yawMinusPitch = constrain(demands->yaw  - demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t servo1 = mapRateServoToTimerTicks(yawPlusPitch) + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapRateServoToTimerTicks(yawMinusPitch) + (trim->servo2 * getTrimMultiplier());
+    writeServos(servo1, servo2);
+  }
 };
 
 
 /**
 * @brief    Tricopter class. 
 * @note     Channel output map: tail servo, LEDc unused, motor 1, motor 2, motor 3
-*/ 
+*/
 class TriCopter : public ModelBase
 {
-  public:
-    static constexpr uint8_t NUMBER_MOTORS  = 4U; //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
-    static constexpr uint8_t NUMBER_SERVOS  = 2U; //Purposely defining 2 as LEDc channles are pairs.
-    static constexpr uint8_t MOTOR_1_PIN    = D0;
-    static constexpr uint8_t MOTOR_2_PIN    = D1;
-    static constexpr uint8_t MOTOR_3_PIN    = D2;
-    static constexpr uint8_t MOTOR_4_PIN    = D3; //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
-    static constexpr uint8_t SERVO_1_PIN    = D8;
-    static constexpr uint8_t SERVO_2_PIN    = D9;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 4U; //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
+  static constexpr uint8_t NUMBER_SERVOS  = 2U; //Purposely defining 2 as LEDc channles are pairs.
+  static constexpr uint8_t MOTOR_1_PIN    = D0;
+  static constexpr uint8_t MOTOR_2_PIN    = D1;
+  static constexpr uint8_t MOTOR_3_PIN    = D2;
+  static constexpr uint8_t MOTOR_4_PIN    = D3;  //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
+  static constexpr uint8_t SERVO_1_PIN    = D8;
+  static constexpr uint8_t SERVO_2_PIN    = D9;
 
-    //Configure this model as a tricopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
-      {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a tricopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
+          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    TriCopter() : ModelBase(m_modelConfig)
-    {
-      const uint32_t minThrottle = map32(MIN_THROTTLE, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-      m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-    };
+  TriCopter() : ModelBase(m_modelConfig)
+  {
+    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
+  };
 
-    ~TriCopter(){};
+  ~TriCopter(){};
 
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
-    {
-      writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
-    }
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
+  }
 
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final 
-    {
-      //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
-      int32_t throttle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, IDLE_UP, SBus::MAX_NORMALISED_US);
-      //Now remap to work with rate mode
-      throttle = map32(throttle, IDLE_UP, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
+    int32_t throttle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, IDLE_UP, RxBase::MAX_NORMALISED);
+    //Now remap to work with rate mode
+    throttle = map32(throttle, IDLE_UP, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
 
-      //Set control mix and convert demands to timer ticks
-      const int32_t oneThirdPitch = static_cast<int32_t>((static_cast<float>(demands->roll) * 1.3333f) + 0.5f);
-      const int32_t twoThirdPitch = static_cast<int32_t>((static_cast<float>(demands->roll) * 0.6666f) + 0.5f);
-      uint32_t motor1 = mapRateMotorToTimerTicks(throttle + oneThirdPitch);                   //Rear motor
-      uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->roll - twoThirdPitch);   //Left motor
-      uint32_t motor3 = mapRateMotorToTimerTicks(throttle - demands->roll - twoThirdPitch);   //Right motor
-      uint32_t motor4 = getDefaultMotorTicks(Actuator::CHANNEL_4);
+    //Set control mix and convert demands to timer ticks
+    const int32_t oneThirdPitch = static_cast<int32_t>((static_cast<float>(demands->roll) * 1.3333f) + 0.5f);
+    const int32_t twoThirdPitch = static_cast<int32_t>((static_cast<float>(demands->roll) * 0.6666f) + 0.5f);
+    uint32_t motor1 = mapRateMotorToTimerTicks(throttle + oneThirdPitch);                   //Rear motor
+    uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->roll - twoThirdPitch);   //Left motor
+    uint32_t motor3 = mapRateMotorToTimerTicks(throttle - demands->roll - twoThirdPitch);   //Right motor
+    uint32_t motor4 = getDefaultMotorTicks(Actuator::CHANNEL_4);
 
-      multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);      
+    multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
 
-      motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-      motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
-      motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
-      motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
+    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
+    motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
 
-      writeMotors(motor1, motor2, motor3, motor4);
-    };
+    writeMotors(motor1, motor2, motor3, motor4);
+  };
 
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final 
-    {
-      //When disarmed
-      const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo1 * getTrimMultiplier());
-      writeServos(servo1, getDefaultServoTicks(Actuator::CHANNEL_2));
-    }
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When disarmed
+    const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo1 * getTrimMultiplier());
+    writeServos(servo1, getDefaultServoTicks(Actuator::CHANNEL_2));
+  }
 
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      //When armed
-      const uint32_t servo1 = mapRateServoToTimerTicks(demands->yaw) + (trim->servo1 * getTrimMultiplier());
-      writeServos(servo1, getDefaultServoTicks(Actuator::CHANNEL_2));
-    }
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When armed
+    const uint32_t servo1 = mapRateServoToTimerTicks(demands->yaw) + (trim->servo1 * getTrimMultiplier());
+    writeServos(servo1, getDefaultServoTicks(Actuator::CHANNEL_2));
+  }
 };
 
 
@@ -1544,75 +1602,75 @@ class TriCopter : public ModelBase
 /**
 * @brief    Dualcopter class. 
 * @note     Channel output map: roll servo, pitch servo, motor 1, motor 2
-*/ 
+*/
 class DualCopter : public ModelBase
 {
-  public:
-    static constexpr uint8_t NUMBER_MOTORS  = 2U;
-    static constexpr uint8_t NUMBER_SERVOS  = 2U;
-    static constexpr uint8_t MOTOR_1_PIN    = D0;
-    static constexpr uint8_t MOTOR_2_PIN    = D1;
-    static constexpr uint8_t SERVO_1_PIN    = D2;
-    static constexpr uint8_t SERVO_2_PIN    = D3;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
+  static constexpr uint8_t NUMBER_SERVOS  = 2U;
+  static constexpr uint8_t MOTOR_1_PIN    = D0;
+  static constexpr uint8_t MOTOR_2_PIN    = D1;
+  static constexpr uint8_t SERVO_1_PIN    = D2;
+  static constexpr uint8_t SERVO_2_PIN    = D3;
 
-    //Configure this model as a dualcopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a dualcopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    DualCopter() : ModelBase(m_modelConfig)
-    {
-      const uint32_t minThrottle = map32(MIN_THROTTLE, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-      m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-    };
+  DualCopter() : ModelBase(m_modelConfig)
+  {
+    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
+  };
 
-    ~DualCopter(){};
+  ~DualCopter(){};
 
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
-    {
-      writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
-    }
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
+  }
 
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final 
-    {
-      //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
-      int32_t throttle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, IDLE_UP, SBus::MAX_NORMALISED_US);
-      //Now remap to work with rate mode
-      throttle = map32(throttle, IDLE_UP, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
+    int32_t throttle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, IDLE_UP, RxBase::MAX_NORMALISED);
+    //Now remap to work with rate mode
+    throttle = map32(throttle, IDLE_UP, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
 
-      //Set control mix and convert demands to timer ticks
-      uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->yaw);
-      uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->yaw);
+    //Set control mix and convert demands to timer ticks
+    uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->yaw);
+    uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->yaw);
 
-      multicopterMotorMagic(&motor1, &motor2);      
+    multicopterMotorMagic(&motor1, &motor2);
 
-      motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-      motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
+    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
 
-      writeMotors(motor1, motor2);
-    };
+    writeMotors(motor1, motor2);
+  };
 
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final 
-    {
-      //When disarmed
-      const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo1 * getTrimMultiplier());
-      const uint32_t servo2 = mapNormalisedServoToTimerTicks(demands->roll) + (trim->servo2 * getTrimMultiplier());
-      writeServos(servo1, servo2);
-    }
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When disarmed
+    const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapNormalisedServoToTimerTicks(demands->roll) + (trim->servo2 * getTrimMultiplier());
+    writeServos(servo1, servo2);
+  }
 
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      //When armed
-      const uint32_t servo1 = mapRateServoToTimerTicks(demands->pitch) + (trim->servo1 * getTrimMultiplier());
-      const uint32_t servo2 = mapRateServoToTimerTicks(demands->roll) + (trim->servo2 * getTrimMultiplier());
-      writeServos(servo1, servo2);
-    }
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When armed
+    const uint32_t servo1 = mapRateServoToTimerTicks(demands->pitch) + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapRateServoToTimerTicks(demands->roll) + (trim->servo2 * getTrimMultiplier());
+    writeServos(servo1, servo2);
+  }
 };
 
 
@@ -1620,68 +1678,72 @@ class DualCopter : public ModelBase
 * @brief    Singlecopter class. 
 * @note     4 servos arranged with 90 degree speration.
 * @note     Channel output map: servo 1, servo 2, servo 3, servo 4, motor 1, LEDc unused
-*/ 
+*/
 class SingleCopter : public ModelBase
 {
-  public:
-    static constexpr uint8_t NUMBER_MOTORS  = 2U; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
-    static constexpr uint8_t NUMBER_SERVOS  = 4U;
-    static constexpr uint8_t MOTOR_1_PIN    = D0;
-    static constexpr uint8_t MOTOR_2_PIN    = D1; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
-    static constexpr uint8_t SERVO_1_PIN    = D2;
-    static constexpr uint8_t SERVO_2_PIN    = D3;
-    static constexpr uint8_t SERVO_3_PIN    = D8;
-    static constexpr uint8_t SERVO_4_PIN    = D9;
+public:
+  static constexpr uint8_t NUMBER_MOTORS  = 2U; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
+  static constexpr uint8_t NUMBER_SERVOS  = 4U;
+  static constexpr uint8_t MOTOR_1_PIN    = D0;
+  static constexpr uint8_t MOTOR_2_PIN    = D1; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
+  static constexpr uint8_t SERVO_1_PIN    = D2;
+  static constexpr uint8_t SERVO_2_PIN    = D3;
+  static constexpr uint8_t SERVO_3_PIN    = D8;
+  static constexpr uint8_t SERVO_4_PIN    = D9;
 
-    //Configure this model as a singlecopter...
-    static constexpr ModelBase::ModelConfig m_modelConfig =
-    {
-      {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-      {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
-      Config::MOTOR_REFRESH_RATE,
-      Config::SERVO_REFRESH_RATE,
-      NUMBER_MOTORS,
-      NUMBER_SERVOS,
-    };
+  //Configure this model as a singlecopter...
+  static constexpr ModelBase::ModelConfig m_modelConfig =
+      {
+          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
+          Config::MOTOR_REFRESH_RATE,
+          Config::SERVO_REFRESH_RATE,
+          NUMBER_MOTORS,
+          NUMBER_SERVOS,
+      };
 
-    SingleCopter() : ModelBase(m_modelConfig){};
+  SingleCopter() : ModelBase(m_modelConfig){};
 
-    ~SingleCopter(){};
+  ~SingleCopter(){};
 
-    virtual void motorMixer(DemandProcessor::Demands const * const demands) final
-    {
-      writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
-    }
+  virtual void motorMixer(DemandProcessor::Demands const * const demands) final
+  {
+    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
+  }
 
-    virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final 
-    {
-      //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
-      int32_t throttle = map32(demands->throttle, SBus::MIN_NORMALISED_US, SBus::MAX_NORMALISED_US, IDLE_UP, SBus::MAX_NORMALISED_US);
-      //Now remap to work with rate mode
-      throttle = map32(throttle, IDLE_UP, SBus::MAX_NORMALISED_US, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-      
-      //Set control mix and convert demands to timer ticks
-      uint32_t motor1 = mapRateMotorToTimerTicks(throttle);
-      writeMotors(motor1, getDefaultMotorTicks(Actuator::CHANNEL_2));
-    };
+  virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
+  {
+    //Remap throttle to avoid tx stick deadzone between min stick position and and idle up value.
+    int32_t throttle = map32(demands->throttle, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, IDLE_UP, RxBase::MAX_NORMALISED);
+    //Now remap to work with rate mode
+    throttle = map32(throttle, IDLE_UP, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
 
-    virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final 
-    {
-      //When disarmed
-      const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->roll + demands->yaw) + (trim->servo1 * getTrimMultiplier());
-      const uint32_t servo2 = mapNormalisedServoToTimerTicks(demands->pitch + demands->yaw) + (trim->servo2 * getTrimMultiplier());
-      const uint32_t servo3 = mapNormalisedServoToTimerTicks(demands->roll + demands->yaw) + (trim->servo3 * getTrimMultiplier());
-      const uint32_t servo4 = mapNormalisedServoToTimerTicks(demands->pitch + demands->yaw) + (trim->servo4 * getTrimMultiplier());
-      writeServos(servo1, servo2, servo3, servo4);
-    }
+    //Set control mix and convert demands to timer ticks
+    uint32_t motor1 = mapRateMotorToTimerTicks(throttle);
+    writeMotors(motor1, getDefaultMotorTicks(Actuator::CHANNEL_2));
+  };
 
-    virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
-    {
-      //When armed
-      const uint32_t servo1 = mapRateServoToTimerTicks(demands->roll + demands->yaw) + (trim->servo1 * getTrimMultiplier());
-      const uint32_t servo2 = mapRateServoToTimerTicks(demands->pitch + demands->yaw) + (trim->servo2 * getTrimMultiplier());
-      const uint32_t servo3 = mapRateServoToTimerTicks(demands->roll + demands->yaw) + (trim->servo3 * getTrimMultiplier());
-      const uint32_t servo4 = mapRateServoToTimerTicks(demands->pitch + demands->yaw) + (trim->servo4 * getTrimMultiplier());
-      writeServos(servo1, servo2, servo3, servo4);
-    }
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When disarmed - constraint add to prevent overflow
+    const int32_t rollYaw   = constrain(demands->roll  + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t pitchYaw  = constrain(demands->pitch + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const uint32_t servo1 = mapNormalisedServoToTimerTicks(rollYaw)  + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapNormalisedServoToTimerTicks(pitchYaw) + (trim->servo2 * getTrimMultiplier());
+    const uint32_t servo3 = mapNormalisedServoToTimerTicks(rollYaw)  + (trim->servo3 * getTrimMultiplier());
+    const uint32_t servo4 = mapNormalisedServoToTimerTicks(pitchYaw) + (trim->servo4 * getTrimMultiplier());    
+    writeServos(servo1, servo2, servo3, servo4);
+  }
+
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
+  {
+    //When armed - constraint add to prevent overflow
+    const int32_t rollYaw   = constrain(demands->roll  + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const int32_t pitchYaw  = constrain(demands->pitch + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    const uint32_t servo1 = mapRateServoToTimerTicks(rollYaw)  + (trim->servo1 * getTrimMultiplier());
+    const uint32_t servo2 = mapRateServoToTimerTicks(pitchYaw) + (trim->servo2 * getTrimMultiplier());
+    const uint32_t servo3 = mapRateServoToTimerTicks(rollYaw)  + (trim->servo3 * getTrimMultiplier());
+    const uint32_t servo4 = mapRateServoToTimerTicks(pitchYaw) + (trim->servo4 * getTrimMultiplier());    
+    writeServos(servo1, servo2, servo3, servo4);
+  }
 };

--- a/PlainFlightController/RxBase.cpp
+++ b/PlainFlightController/RxBase.cpp
@@ -1,0 +1,112 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   RxBase.cpp
+* @brief  Base class implementation for RC receiver switch state checking.
+*/
+
+#include "RxBase.hpp"
+
+
+/**
+* @brief    Check if a channel is in the high switch position.
+* @param    channelData - The normalised channel data to check.
+* @return   true if channel value is above high threshold, false otherwise.
+*/
+bool
+RxBase::isSwitchHigh(const int32_t channelData)
+{
+  bool result = false;
+
+  if (channelData > SWITCH_HIGH_NORM)
+  {
+    result = true;
+  }
+
+  return result;
+}
+
+
+/**
+* @brief    Check if a channel is in the low switch position.
+* @param    channelData - The normalised channel data to check.
+* @return   true if channel value is below low threshold, false otherwise.
+*/
+bool
+RxBase::isSwitchLow(const int32_t channelData)
+{
+  bool result = false;
+
+  if (channelData < SWITCH_LOW_NORM)
+  {
+    result = true;
+  }
+
+  return result;
+}
+
+
+/**
+* @brief    Get the 3-position switch state for normalised channel data.
+* @param    channelData - The normalised channel data to check.
+* @return   SwitchPosition enum (LOW, MID, or HIGH).
+*/
+RxBase::SwitchPosition
+RxBase::getSwitch3Position(const int32_t channelData)
+{
+  SwitchPosition position = SwitchPosition::SW_MID;
+
+  if (channelData > SWITCH_HIGH_NORM)
+  {
+    position = SwitchPosition::SW_HIGH;
+  }
+  else if (channelData < SWITCH_LOW_NORM)
+  {
+    position = SwitchPosition::SW_LOW;
+  }
+  else
+  {
+    position = SwitchPosition::SW_MID;
+  }
+
+  return position;
+}
+
+
+/**
+* @brief    Get the 2-position switch state for normalised channel data.
+* @param    channelData - The normalised channel data to check.
+* @return   SwitchPosition enum (LOW or HIGH).
+*/
+RxBase::SwitchPosition
+RxBase::getSwitch2Position(const int32_t channelData)
+{
+  SwitchPosition position = SwitchPosition::SW_LOW;
+
+  if (channelData > SWITCH_HIGH_NORM)
+  {
+    position = SwitchPosition::SW_HIGH;
+  }
+  else
+  {
+    position = SwitchPosition::SW_LOW;
+  }
+
+  return position;
+}

--- a/PlainFlightController/RxBase.hpp
+++ b/PlainFlightController/RxBase.hpp
@@ -1,0 +1,166 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   RxBase.hpp
+* @brief  Base class for RC receiver implementations providing common interface and normalization.
+*/
+
+#pragma once
+
+#include <inttypes.h>
+
+/**
+ * @class RxBase
+ * @brief Base class for all receiver types, providing common constants, channel mapping, and data structures.
+ */
+class RxBase
+{
+public:
+  static constexpr uint32_t MAX_RX_CHANNELS = 16U;
+  static constexpr int32_t MIN_NORMALISED = -1024;
+  static constexpr int32_t MID_NORMALISED = 0;
+  static constexpr int32_t MAX_NORMALISED = 1024;
+  static constexpr int32_t SWITCH_HIGH_NORM = 512;
+  static constexpr int32_t SWITCH_LOW_NORM = -512;
+  static constexpr int32_t LOW_THROTTLE_NORM = -922;  // Changed to be 5% of range - post test fix
+
+  /**
+     * @enum ReceiverType
+     * @brief Class of receiver.  Add to this list when new receiver protocols defined
+     */
+  enum class ReceiverType
+  {
+    SBUS,
+    CRSF
+  };
+
+  /**
+     * @enum ChannelName
+     * @brief Standard channel names for RC control mapping.
+     * Other channels must be referred to by number
+     */
+  enum class ChannelName : uint32_t
+  {
+    THROTTLE = 0U,
+    ROLL,
+    PITCH,
+    YAW,
+    ARM,
+    MODE,
+    AUX1,
+    AUX2,
+    AUX3
+  };
+
+  /**
+     * @enum SwitchPosition
+     * @brief Enumeration for switch states.
+     */
+  enum class SwitchPosition : uint32_t
+  {
+    SW_LOW = 0U,
+    SW_MID,
+    SW_HIGH
+  };
+
+  /**
+     * @struct RxPacket
+     * @brief Standardized receiver data packet for all receiver types.
+     */
+  struct RxPacket
+  {
+    bool failsafe;
+    bool lostComms;
+    int32_t ch[MAX_RX_CHANNELS];  // Normalised data
+  };
+
+  /**
+     * @brief Virtual destructor for proper cleanup of derived classes.
+     */
+  virtual ~RxBase() = default;
+
+  /**
+     * @brief Get receiver data packet.
+     * @return RxPacket containing failsafe status, communication status, and normalised channel data.
+     */
+  virtual const RxPacket
+  getData() const = 0;
+
+  /**
+     * @brief Check if communications have been lost.
+     * @return true if communications lost, false otherwise.
+     */
+  virtual const bool
+  hasLostCommunications() const = 0;
+
+  /**
+     * @brief Get new data from receiver.
+     * @return true when new data is available, false otherwise.
+     */
+  virtual bool
+  getDemands() = 0;
+
+  /**
+     * @brief Get channel index from channel name.
+     * @param name The channel name enum.
+     * @return Channel index (0-based).
+     */
+  virtual uint32_t
+  getChannelIndex(ChannelName name) const = 0;
+
+  /**
+     * @brief Check if a channel is in the high switch position.
+     * @param channelData The normalised channel data to check.
+     * @return true if channel value is above high threshold, false otherwise.
+     */
+  static bool
+  isSwitchHigh(const int32_t channelData);
+
+  /**
+     * @brief Check if a channel is in the low switch position.
+     * @param channelData The normalised channel data to check.
+     * @return true if channel value is below low threshold, false otherwise.
+     */
+  static bool
+  isSwitchLow(const int32_t channelData);
+
+  /**
+     * @brief Get the 3-position switch state for normalised channel data.
+     * @param channelData The normalised channel data to check.
+     * @return SwitchPosition enum (LOW, MID, or HIGH).
+     */
+  static SwitchPosition
+  getSwitch3Position(const int32_t channelData);
+
+  /**
+     * @brief Get the 2-position switch state for normalised channel data.
+     * @param channelData The normalised channel data to check.
+     * @return SwitchPosition enum (LOW or HIGH).
+     */
+  static SwitchPosition
+  getSwitch2Position(const int32_t channelData);
+
+protected:
+  RxPacket m_rxData = {true, true, {0}};
+
+  /**
+     * @brief Default constructor (protected to prevent direct instantiation).
+     */
+  RxBase() = default;
+};

--- a/PlainFlightController/RxBase.hpp
+++ b/PlainFlightController/RxBase.hpp
@@ -125,6 +125,16 @@ public:
   getChannelIndex(ChannelName name) const = 0;
 
   /**
+     * @brief Helper function to reduce verbosity.
+     * @param name The channel name enum (from RxBase).
+     * @return Channel index (0-based).
+     */
+  int32_t getChannel(const RxPacket& data, ChannelName name) const
+  {
+    return data.ch[getChannelIndex(name)];
+  }
+
+  /**
      * @brief Check if a channel is in the high switch position.
      * @param channelData The normalised channel data to check.
      * @return true if channel value is above high threshold, false otherwise.

--- a/PlainFlightController/SBus.cpp
+++ b/PlainFlightController/SBus.cpp
@@ -17,8 +17,8 @@
 */
 
 /**
-* @file   Sbus.cpp
-* @brief  This class handles communications with an Sbus Rx.
+* @file   SBus.cpp
+* @brief  This class handles communications with an SBus RC receiver.
 */
 
 /*
@@ -31,100 +31,126 @@
 */
 
 #include "SBus.hpp"
+#include "Utilities.hpp"
 
 
 /**
-* @brief    SBus constructor  
-* @param    *uart, rxPin, txPin
-*/  
+* @brief    SBus constructor.
+* @param    *uart - Pointer to hardware serial port.
+* @param    rxPin - RX pin number.
+* @param    txPin - TX pin number.
+*/
 SBus::SBus(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin)
 {
   m_uart = uart;
   m_uart->begin(SBUS_BAUD, SERIAL_8E2, rxPin, txPin, true);
-  m_uart->flush();  
+  m_uart->flush();
 }
 
 
 /**
 * @brief    Decodes the SBus serial stream into usable channel and flag data.
 * @return   Returns true when new data is available.
-*/  
-bool    
+*/
+bool
 SBus::getDemands()
 {
   uint32_t currentByte;
   uint32_t rxCount = 0U;
+  uint32_t rawChannels[NUM_SBUS_CH];
 
   //We loop for a maximum of 6 bytes then get out of here to avoid blocking main loop.
-  while (m_uart->available() && (rxCount < 6U)) 
+  while (m_uart->available() && (rxCount < 6U))
   {
     currentByte = m_uart->read();
     rxCount++;
 
-    if (0U == m_count) 
+    if (0U == m_count)
     {
-      if ((currentByte == HEADER) && ((m_prevByte == FOOTER) || ((m_prevByte & 0x0FU) == FOOTER2))) 
+      if ((currentByte == HEADER) && ((m_prevByte == FOOTER) || ((m_prevByte & 0x0FU) == FOOTER2)))
       {
         m_buff[m_count] = currentByte;
         m_count++;
-      } 
-    } 
-    else if (m_count < (PAYLOAD_LEN + HEADER_LEN)) 
+      }
+    }
+    else if (m_count < (PAYLOAD_LEN + HEADER_LEN))
     {
       m_buff[m_count] = currentByte;
       m_count++;
-    } 
-    else if (m_count < (PAYLOAD_LEN + HEADER_LEN + FOOTER_LEN)) 
+    }
+    else if (m_count < (PAYLOAD_LEN + HEADER_LEN + FOOTER_LEN))
     {
       m_count = 0U;
       m_prevByte = currentByte;
-      if ((currentByte == FOOTER) || ((currentByte & 0x0F) == FOOTER2)) 
+      if ((currentByte == FOOTER) || ((currentByte & 0x0FU) == FOOTER2))
       {
-        //Decode sbus data
-        m_sbus.ch[0]  = (uint32_t)(m_buff[1] | ((m_buff[2] << 8U) & 0x07FFU));
-        m_sbus.ch[1]  = (uint32_t)((m_buff[2] >> 3U) | ((m_buff[3] << 5U) & 0x07FFU));
-        m_sbus.ch[2]  = (uint32_t)((m_buff[3] >> 6U) | (m_buff[4] << 2U) | ((m_buff[5] << 10U) & 0x07FFU));
-        m_sbus.ch[3]  = (uint32_t)((m_buff[5] >> 1U) | ((m_buff[6] << 7U) & 0x07FFU));
-        m_sbus.ch[4]  = (uint32_t)((m_buff[6] >> 4U) | ((m_buff[7] << 4U) & 0x07FFU));
-        m_sbus.ch[5]  = (uint32_t)((m_buff[7] >> 7U) | (m_buff[8] << 1U) | ((m_buff[9] << 9U) & 0x07FFU));
-        m_sbus.ch[6]  = (uint32_t)((m_buff[9] >> 2U) | ((m_buff[10] << 6U) & 0x07FFU));
-        m_sbus.ch[7]  = (uint32_t)((m_buff[10] >> 5U) | ((m_buff[11] << 3U) & 0x07FFU));
+        // Decode SBus data into raw channel values
+        rawChannels[0] = (uint32_t)(m_buff[1] | ((m_buff[2] << 8U) & 0x07FFU));
+        rawChannels[1] = (uint32_t)((m_buff[2] >> 3U) | ((m_buff[3] << 5U) & 0x07FFU));
+        rawChannels[2] = (uint32_t)((m_buff[3] >> 6U) | (m_buff[4] << 2U) | ((m_buff[5] << 10U) & 0x07FFU));
+        rawChannels[3] = (uint32_t)((m_buff[5] >> 1U) | ((m_buff[6] << 7U) & 0x07FFU));
+        rawChannels[4] = (uint32_t)((m_buff[6] >> 4U) | ((m_buff[7] << 4U) & 0x07FFU));
+        rawChannels[5] = (uint32_t)((m_buff[7] >> 7U) | (m_buff[8] << 1U) | ((m_buff[9] << 9U) & 0x07FFU));
+        rawChannels[6] = (uint32_t)((m_buff[9] >> 2U) | ((m_buff[10] << 6U) & 0x07FFU));
+        rawChannels[7] = (uint32_t)((m_buff[10] >> 5U) | ((m_buff[11] << 3U) & 0x07FFU));
+
         if constexpr(Config::USE_PROP_HANG_MODE)
         {
-          m_sbus.ch[8]  = (uint32_t)(m_buff[12] | ((m_buff[13] << 8U) & 0x07FFU));
+          rawChannels[8] = (uint32_t)(m_buff[12] | ((m_buff[13] << 8U) & 0x07FFU));
         }
         else
         {
           if constexpr(USE_ALL_18_CHANNELS)  //Speeds up main loop by not processing all 18 channels
           {
-            m_sbus.ch[8]  = (uint32_t)(m_buff[12] | ((m_buff[13] << 8U) & 0x07FFU));
-            m_sbus.ch[9]  = (uint32_t)((m_buff[13] >> 3U) | ((m_buff[14] << 5U) & 0x07FFU));
-            m_sbus.ch[10] = (uint32_t)((m_buff[14] >> 6U) | ((m_buff[15] << 2U) | (m_buff[16] << 10U) & 0x07FFU));
-            m_sbus.ch[11] = (uint32_t)((m_buff[16] >> 1U) | ((m_buff[17] << 7U) & 0x07FFU));
-            m_sbus.ch[12] = (uint32_t)((m_buff[17] >> 4U) | ((m_buff[18] << 4U) & 0x07FFU));
-            m_sbus.ch[13] = (uint32_t)((m_buff[18] >> 7U) | ((m_buff[19] << 1U) | ((m_buff[20] << 9U) & 0x07FFU)));
-            m_sbus.ch[14] = (uint32_t)((m_buff[20] >> 2U) | ((m_buff[21] << 6U) & 0x07FFU));
-            m_sbus.ch[15] = (uint32_t)((m_buff[21] >> 5U) | ((m_buff[22] << 3U) & 0x07FFU));                               
-            m_sbus.ch17 = (m_buff[23] & CH17_MASK) ? true : false;
-            m_sbus.ch18 = (m_buff[23] & CH18_MASK) ? true : false;
-          }
-        }
-        //Decode lost frame bit
-        m_sbus.lostFrame = (m_buff[23] & LOST_FRAME_MASK) ? true : false;
-        //Decode failsafe bit
-        m_sbus.failsafe = (m_buff[23] & FAILSAFE_MASK) ? true : false;
-        lossOfCommsTimer.set(COMMS_TIME_OUT_PERIOD);
-        m_lostComms = false;
+            static_assert(!USE_ALL_18_CHANNELS || (MAX_RX_CHANNELS >= 18), "MAX_RC_CHANNELS must be at least 18 when USE_ALL_18_CHANNELS is true");
+            rawChannels[8] = (uint32_t)(m_buff[12] | ((m_buff[13] << 8U) & 0x07FFU));
+            rawChannels[9] = (uint32_t)((m_buff[13] >> 3U) | ((m_buff[14] << 5U) & 0x07FFU));
+            rawChannels[10] = (uint32_t)((m_buff[14] >> 6U) | (m_buff[15] << 2U) | ((m_buff[16] << 10U) & 0x07FFU));
+            rawChannels[11] = (uint32_t)((m_buff[16] >> 1U) | ((m_buff[17] << 7U) & 0x07FFU));
+            rawChannels[12] = (uint32_t)((m_buff[17] >> 4U) | ((m_buff[18] << 4U) & 0x07FFU));
+            rawChannels[13] = (uint32_t)((m_buff[18] >> 7U) | (m_buff[19] << 1U) | ((m_buff[20] << 9U) & 0x07FFU));
+            rawChannels[14] = (uint32_t)((m_buff[20] >> 2U) | ((m_buff[21] << 6U) & 0x07FFU));
+            rawChannels[15] = (uint32_t)((m_buff[21] >> 5U) | ((m_buff[22] << 3U) & 0x07FFU));
+            rawChannels[17] = (m_buff[23] & CH17_MASK) ? MAX_SBUS_US : MIN_SBUS_US;  // No special boolean channels
+            rawChannels[18] = (m_buff[23] & CH18_MASK) ? MAX_SBUS_US : MIN_SBUS_US;  // No special boolean channels
+          }  
+        } 
 
-        if constexpr(Config::DEBUG_SBUS)
+        // Normalise channels immediately after decoding
+        uint32_t numChannels = 8U;
+        if constexpr (Config::USE_PROP_HANG_MODE)
+        {
+          numChannels = 9U;
+        }
+        else if constexpr (USE_ALL_18_CHANNELS)
+        {
+          numChannels = 18U;
+        }
+
+        for (uint32_t i = 0U; i < numChannels; i++)
+        {
+          m_rxData.ch[i] = map32(rawChannels[i], MIN_SBUS_US, MAX_SBUS_US, MIN_NORMALISED, MAX_NORMALISED);
+        }
+
+        // Decode lost frame bit
+        m_lostFrame = (m_buff[23] & LOST_FRAME_MASK) ? true : false;
+
+        // Decode failsafe bit
+        m_rxData.failsafe = (m_buff[23] & FAILSAFE_MASK) ? true : false;
+
+        // Reset communications timer
+        lossOfCommsTimer.set(COMMS_TIME_OUT_PERIOD);
+        m_rxData.lostComms = false;
+
+        if constexpr(Config::DEBUG_RX)
         {
           printData();
         }
 
         return true;
-      } 
+      }
     } 
-    else 
+    else
     {
       m_count = 0U;
     }
@@ -134,7 +160,7 @@ SBus::getDemands()
 
   if (CTimer::State::EXPIRED == lossOfCommsTimer.getState())
   {
-    m_lostComms = true;
+    m_rxData.lostComms = true;
   }
 
   return false;
@@ -142,34 +168,34 @@ SBus::getDemands()
 
 
 /**
-* @brief    Returns the most recent SBus data.  
-* @return   SbusPacket
-*/  
-const SBus::SbusPacket 
-SBus::getData()
+* @brief    Returns the most recent receiver data.
+* @return   RxPacket containing failsafe, communication status, and normalised channel data.
+*/
+const RxBase::RxPacket
+SBus::getData() const
 {
-  return m_sbus;
+  return m_rxData;
 }
 
 
 /**
-* @brief    Prints SBus data to console    
-* @param    True when Sbus comms has been lost
-*/  
+* @brief    Check if communications have been lost.
+* @return   true when SBus comms has been lost, false otherwise.
+*/
 const bool
 SBus::hasLostCommunications() const
 {
-  return m_lostComms;
+  return m_rxData.lostComms;
 }
 
 
 /**
-* @brief    Prints SBus data to console    
-*/  
-void 
+* @brief    Prints SBus data to console for debugging.
+*/
+void
 SBus::printData(void)
 {
-  uint8_t channels;
+  uint32_t channels;
 
   if constexpr(USE_ALL_18_CHANNELS)
   {
@@ -187,14 +213,16 @@ SBus::printData(void)
     }
   }
 
-  // Display the received data 
-  for (uint8_t i = 0U; i < channels; i++) 
+  // Display the received normalised data
+  for (uint32_t i = 0U; i < channels; i++)
   {
-    Serial.print(m_sbus.ch[i]);
+    Serial.print(m_rxData.ch[i]);
     Serial.print("\t");
   }
-  // Display lost frames and failsafe data 
-  Serial.print(m_sbus.lostFrame);
+  // Display lost frames and failsafe data
+  Serial.print(m_lostFrame);
   Serial.print("\t");
-  Serial.println(m_sbus.failsafe);
+  Serial.print(m_rxData.failsafe);
+  Serial.print("\t");
+  Serial.println(m_rxData.lostComms);
 }

--- a/PlainFlightController/SBus.hpp
+++ b/PlainFlightController/SBus.hpp
@@ -104,7 +104,7 @@ public:
      * @param name The channel name enum.
      * @return Channel index (0-based).
      */
-  constexpr uint32_t getChannelIndex(ChannelName name) const
+  uint32_t getChannelIndex(ChannelName name) const
   {
     return CHANNEL_MAP[static_cast<uint32_t>(name)];
   }

--- a/PlainFlightController/WifiConfig.cpp
+++ b/PlainFlightController/WifiConfig.cpp
@@ -138,7 +138,7 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
 {
   if (!client)
   {
-    client = server.available();   // listen for incoming clients
+    client = server.accept();   // listen for incoming clients
     m_currentLine = "";
   }
   else 

--- a/PlainFlightController/WifiConfig.hpp
+++ b/PlainFlightController/WifiConfig.hpp
@@ -78,8 +78,8 @@ class WifiConfig : public Html
     String STR_SERVO_TRIMS = "GET /SERVO_TRIMS?";    
     String STR_VOLT_TRIM   = "GET /VOLT_TRIM?";
     // Set these to your desired credentials.
-    static constexpr char *SSID = "PlainFlight";
-    static constexpr char *PASSWORD = "12345678";
+    static constexpr char SSID[] = "PlainFlight";
+    static constexpr char PASSWORD[] = "12345678";
     static constexpr uint32_t HTML_DOC_BUFF_SIZE = sizeof(INDEX_HTML);
 
     //Methods


### PR DESCRIPTION
This PR closes #12.

While the original proposal suggested performing this as a number of PRs, some of that work has been omitted after rereading the project goals.  Instead this PR contains two major pieces of work.  The first is to implement a base class for the receiver classes and add a Crsf receiver class to the existing SBus class. The second is to introduce a universal scaling for all receiver data.  These data are now scaled to +/- 1024 immediately on reception. Full details below.

The addition of a base class for the receivers is relatively straight forward.  Common structures are moved into the base class and where necessary local variants are introduced for the specific receivers.  One issue was the use of normalised scaling constants from the SBus class across other areas of code (for example in ModelTypes, DemandProcessor and FlightControl).  Although these constants are the same in both SBus and Crsf, other receivers may not scale the same and so the idea of a universal normalizing scale range is introduced.  The range is +/- 1024 or 11 bits.  My research suggests that no common receiver protocol uses more than 11 bits for data so this should suffice. 

By using a signed power of 2 for the range we open the possibility of creating far more efficient scaling than the map32 macro in Utilities.hpp.  In fact a more efficient scaling class was proposed in the original issue and this was implemented in an earlier draft of this PR.  However, it was subsequently removed for two reasons, firstly the map32 macro was only 40% slower than the revised scaling function when taking into account compiler optimizations for both versions.  While this is significant the reduction in loop time is marginal.  Secondly the map32 is very easy to understand and adding potentially more complex scaling functions for a marginal improvement in loop time was thought to be against the spirit of this application.  map32 is used extensively and the resulting changes to the code base would be (actually were) huge.  They can always be added later as an efficiency move if thought necessary.

Instead it was decided to simply adopt the +/-1024 normalized range and accept the compiler optimizations that result.  Just the moving of the normalized range constants to the RxBase class from SBus has resulted in a significant number of changes although they are relatively simple.

Although not directly related to this PR, while testing the implementation a possible overflow condition was detected in the modelTypes.hpp file.  Specifically a large number of instances in 9 classes were found where demand values were summed before being mapped to motor or servo ticks.  Note that this was not found in any of the multicopter motorRateMixer instances where the values were always constrained appropriately.  

As an aside, while I do not understand the preference for 32 bit variables in this application when 8 or 16 bit variables would, to me, be more logical, I believe that I have kept to this pattern in my code.  I have also tried to keep to the coding standard and naming conventions.

Note that the changes in this PR have been tested on the bench but have not yet been flown.