### PR TITLE
Simplify ESP32-S3 module and pinout selection, allow GRB and RGB LEDs

### DIFF
--- a/PlainFlightController/BoardConfig.hpp
+++ b/PlainFlightController/BoardConfig.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+#include "Config.hpp"
+
+// Create new board definitions here to match your use case.
+// Note: Only one board type should be defined.
+namespace BoardConfig {
+#ifdef BOARD_XIAO_ESP32S3
+  // Seeed Studio XIAO ESP32-S3
+  // Output pins (servo/motor channels 1-6)
+  static constexpr uint8_t OUTPUT_PIN_1  = 1U;   // GPIO1  = D0
+  static constexpr uint8_t OUTPUT_PIN_2  = 2U;   // GPIO2  = D1
+  static constexpr uint8_t OUTPUT_PIN_3  = 3U;   // GPIO3  = D2
+  static constexpr uint8_t OUTPUT_PIN_4  = 4U;   // GPIO4  = D3
+  static constexpr uint8_t OUTPUT_PIN_5  = 7U;   // GPIO7  = D8
+  static constexpr uint8_t OUTPUT_PIN_6  = 8U;   // GPIO8  = D9
+
+  //Auxillary IO pin allocation - only change if you know what you are doing
+  static constexpr uint8_t LED_ONBOARD   = 21U;  // GPIO21 = LED_BUILTIN
+  static constexpr uint8_t I2C_SDA       = 12U;  // GPIO12 not defined by arduino
+  static constexpr uint8_t I2C_SCL       = 13U;  // GPIO13 not defined by arduino
+  static constexpr uint8_t RECEIVER_RX   = 44U;  // GPIO44 = D7
+  static constexpr uint8_t RECEIVER_TX   = 43U;  // GPIO43
+  static constexpr uint8_t EXT_LED_PIN   = 43U;  // GPIO43 = D6
+  static constexpr uint8_t BATT_ADC_PIN  = 9U;   // GPIO9  = D10
+#elif defined(BOARD_WAVESHARE_ZERO)
+  // Waveshare ESP32-S3 Zero
+  // Output pins (servo/motor channels 1-6)
+  static constexpr uint8_t OUTPUT_PIN_1  = 1U;   // GPIO1  = D6
+  static constexpr uint8_t OUTPUT_PIN_2  = 2U;   // GPIO2  = D5
+  static constexpr uint8_t OUTPUT_PIN_3  = 3U;   // GPIO3  = D4
+  static constexpr uint8_t OUTPUT_PIN_4  = 4U;   // GPIO4  = D3
+  static constexpr uint8_t OUTPUT_PIN_5  = 7U;   // GPIO7  = D2
+  static constexpr uint8_t OUTPUT_PIN_6  = 8U;   // GPIO8  = D1
+
+  //Auxillary IO pin allocation - only change if you know what you are doing
+  static constexpr uint8_t LED_ONBOARD   = 21U;  // GPIO21
+  static constexpr uint8_t I2C_SDA       = 12U;  // GPIO12 = OUTPUT_IO12
+  static constexpr uint8_t I2C_SCL       = 13U;  // GPIO13 = OUTPUT_IO13
+  static constexpr uint8_t EXT_LED_PIN   = 11U;  // GPIO11 = OUTPUT_IO11
+  static constexpr uint8_t RECEIVER_RX   = 44U;  // GPIO44 = RX
+  static constexpr uint8_t RECEIVER_TX   = 43U;  // GPIO43 = Tx
+  static constexpr uint8_t BATT_ADC_PIN  = 9U;   // GPIO9  = OUTPUT_IO09
+#else
+  #error "No board defined. Please define a BOARD_xxx in Config.hpp"
+#endif
+}

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -30,6 +30,10 @@
 #include "RxBase.hpp"
 
 
+// Select board type here
+#define BOARD_XIAO_ESP32S3
+//#define BOARD_WAVESHARE_ZERO
+
 /**
  * @class Config
  */
@@ -71,6 +75,7 @@ class Config
     static constexpr bool USE_EXTERNAL_LED                    = false;
     static constexpr bool USE_ACRO_TRAINER                    = false;  //When pitch & roll sticks centred levelled mode, else rate mode.
     static constexpr bool USE_ONBOARD_NEOPIXEL                = false;  //When using Waveshare ESP32-S3 Zero/Tiny set to true, make sure LED pin is set correctly.
+    static constexpr bool SWAP_NEOPIXEL_RED_GREEN             = false;   //Some NeoPixel devices use GRB instead of RGB set this if the colours are incorrect
     static constexpr bool REVERSE_PITCH_CORRECTIONS           = false;  //Set REVERSE_x_CORRECTIONS to true to reverse gyro/levelling corrections
     static constexpr bool REVERSE_ROLL_CORRECTIONS            = false;
     static constexpr bool REVERSE_YAW_CORRECTIONS             = false;
@@ -113,16 +118,6 @@ class Config
     static constexpr bool DEBUG_MPU6050                       = false;
     static constexpr bool DEBUG_MOTOR_OUTPUT                  = false;
     static constexpr bool DEBUG_SERVO_OUTPUT                  = false;
-
-    //Auxillary IO pin allocation - only change if you know what you are doing
-    //Note: As default pins D0, D1, D2, D3, D8, D9 are used for motors/servos.
-    static constexpr uint8_t LED_ONBOARD                      = 21U;  //Pin 21 on XIAO or use LED_BUILTIN. Waveshare boards do not recognise LED_BUILTIN... Tiny is pin 38, Zero in pin 21.
-    static constexpr uint8_t I2C_SDA                          = D4;
-    static constexpr uint8_t I2C_SCL                          = D5;
-    static constexpr uint8_t EXT_LED_PIN                      = D6;
-    static constexpr uint8_t RECEIVER_RX                      = 44U;
-    static constexpr uint8_t RECEIVER_TX                      = 43U;  //Pin function not used but reserved
-    static constexpr uint8_t BATT_ADC_PIN                     = D10;
 
     //USB serial
     static constexpr uint32_t USB_BAUD                        = 500000U;

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -29,6 +29,9 @@
 #include "LedcServo.hpp"
 #include "RxBase.hpp"
 
+// Select board type here
+#define BOARD_XIAO_ESP32S3
+//#define BOARD_WAVESHARE_ZERO
 
 // Select board type here
 #define BOARD_XIAO_ESP32S3

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -32,10 +32,10 @@ DemandProcessor::DemandProcessor()
   // Add instantiation code here for new receiver protocols
   if constexpr (Config::RECEIVER_TYPE == RxBase::ReceiverType::SBUS)
   {
-    radioCtrl = new SBus(Config::RECEIVER_UART, Config::RECEIVER_RX, Config::RECEIVER_TX);
+    radioCtrl = new SBus(Config::RECEIVER_UART, BoardConfig::RECEIVER_RX, BoardConfig::RECEIVER_TX);
   } else if constexpr (Config::RECEIVER_TYPE == RxBase::ReceiverType::CRSF)
   {
-    radioCtrl = new Crsf(Config::RECEIVER_UART, Config::RECEIVER_RX, Config::RECEIVER_TX);
+    radioCtrl = new Crsf(Config::RECEIVER_UART, BoardConfig::RECEIVER_RX, BoardConfig::RECEIVER_TX);
   }
 
 

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -29,6 +29,7 @@
 #include "SBus.hpp"
 #include "Crsf.hpp"
 #include "Config.hpp"
+#include "BoardConfig.hpp"
 #include "Configurator.hpp"
 
 

--- a/PlainFlightController/FlightControl.hpp
+++ b/PlainFlightController/FlightControl.hpp
@@ -31,6 +31,7 @@
 #include "PIDF.hpp"
 #include "IMU.hpp"
 #include "Config.hpp"
+#include "BoardConfig.hpp"
 #include "RxBase.hpp"
 #include "Configurator.hpp"
 #include "FileSystem.hpp"
@@ -74,13 +75,13 @@ class FlightControl : public Utilities
     void processPIDF(DemandProcessor::Demands * const demands);
 
     //Objects
-    Led statusLed = Led(Config::LED_ONBOARD);
-    LedNeopixel statusLedNeopixel = LedNeopixel(Config::LED_ONBOARD);
-    Led externLed = Led(Config::EXT_LED_PIN);
+    Led statusLed = Led(BoardConfig::LED_ONBOARD);
+    LedNeopixel statusLedNeopixel = LedNeopixel(BoardConfig::LED_ONBOARD);
+    Led externLed = Led(BoardConfig::EXT_LED_PIN);
     
 
     DemandProcessor rc = DemandProcessor();
-    BatteryMonitor batteryMonitor = BatteryMonitor(Config::BATT_ADC_PIN);
+    BatteryMonitor batteryMonitor = BatteryMonitor(BoardConfig::BATT_ADC_PIN);
     PIDF pitchPIDF = PIDF();
     PIDF yawPIDF = PIDF();
     PIDF rollPIDF = PIDF();

--- a/PlainFlightController/LED.hpp
+++ b/PlainFlightController/LED.hpp
@@ -193,9 +193,16 @@ class LedNeopixel : public Led
 
     virtual void setLed() override
     {
-      rgbLedWrite(m_ledPin, 
-                  sequences[m_playSequence].led[m_idx].colour.red, 
-                  sequences[m_playSequence].led[m_idx].colour.green,
-                  sequences[m_playSequence].led[m_idx].colour.blue);
+      if constexpr(Config::SWAP_NEOPIXEL_RED_GREEN){
+        rgbLedWrite(m_ledPin, 
+                    sequences[m_playSequence].led[m_idx].colour.green, 
+                    sequences[m_playSequence].led[m_idx].colour.red,
+                    sequences[m_playSequence].led[m_idx].colour.blue);
+      } else {
+        rgbLedWrite(m_ledPin, 
+                    sequences[m_playSequence].led[m_idx].colour.red, 
+                    sequences[m_playSequence].led[m_idx].colour.green,
+                    sequences[m_playSequence].led[m_idx].colour.blue);
+      }
     }
 };

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -27,6 +27,7 @@
 #include "Utilities.hpp"
 #include "PIDF.hpp"
 #include "Config.hpp"
+#include "BoardConfig.hpp"
 #include "DemandProcessor.hpp"
 
 
@@ -547,12 +548,12 @@ class PlaneFullHouse : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 4U;
-  static constexpr uint8_t SERVO_1_PIN    = D0;
-  static constexpr uint8_t SERVO_2_PIN    = D1;
-  static constexpr uint8_t SERVO_3_PIN    = D2;
-  static constexpr uint8_t SERVO_4_PIN    = D3;
-  static constexpr uint8_t MOTOR_1_PIN    = D8;
-  static constexpr uint8_t MOTOR_2_PIN    = D9;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t SERVO_3_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t SERVO_4_PIN    = BoardConfig::OUTPUT_PIN_4;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_5;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_6;
 
   //Configure this model as a quadcopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -676,12 +677,12 @@ class PlaneFullHouseVTail : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 4U;
-  static constexpr uint8_t SERVO_1_PIN    = D0;
-  static constexpr uint8_t SERVO_2_PIN    = D1;
-  static constexpr uint8_t SERVO_3_PIN    = D2;
-  static constexpr uint8_t SERVO_4_PIN    = D3;
-  static constexpr uint8_t MOTOR_1_PIN    = D8;
-  static constexpr uint8_t MOTOR_2_PIN    = D9;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t SERVO_3_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t SERVO_4_PIN    = BoardConfig::OUTPUT_PIN_4;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_5;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_6;
 
   //Configure this model...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -806,10 +807,10 @@ class PlaneAdvancedRudderElevator : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t SERVO_1_PIN    = D0;
-  static constexpr uint8_t SERVO_2_PIN    = D1;
-  static constexpr uint8_t MOTOR_1_PIN    = D2;
-  static constexpr uint8_t MOTOR_2_PIN    = D3;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_4;
 
   //Configure this model...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -911,10 +912,10 @@ class PlaneRudderElevator : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t SERVO_1_PIN    = D0;
-  static constexpr uint8_t SERVO_2_PIN    = D1;
-  static constexpr uint8_t MOTOR_1_PIN    = D2;
-  static constexpr uint8_t MOTOR_2_PIN    = D3;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_4;
 
   //Configure this model...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1011,10 +1012,10 @@ class PlaneVTail : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t SERVO_1_PIN    = D0;
-  static constexpr uint8_t SERVO_2_PIN    = D1;
-  static constexpr uint8_t MOTOR_1_PIN    = D2;
-  static constexpr uint8_t MOTOR_2_PIN    = D3;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_4;
 
   //Configure this model...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1117,12 +1118,12 @@ class PlaneFlyingWing : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 4U;
-  static constexpr uint8_t SERVO_1_PIN    = D0;
-  static constexpr uint8_t SERVO_2_PIN    = D1;
-  static constexpr uint8_t SERVO_3_PIN    = D2;
-  static constexpr uint8_t SERVO_4_PIN    = D3;
-  static constexpr uint8_t MOTOR_1_PIN    = D8;
-  static constexpr uint8_t MOTOR_2_PIN    = D9;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t SERVO_3_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t SERVO_4_PIN    = BoardConfig::OUTPUT_PIN_4;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_5;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_6;
 
   //Configure this model as a quadcopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1235,10 +1236,10 @@ class QuadXCopter : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 4U;
   static constexpr uint8_t NUMBER_SERVOS  = 0U;
-  static constexpr uint8_t MOTOR_1_PIN    = D0;
-  static constexpr uint8_t MOTOR_2_PIN    = D1;
-  static constexpr uint8_t MOTOR_3_PIN    = D2;
-  static constexpr uint8_t MOTOR_4_PIN    = D3;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t MOTOR_3_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t MOTOR_4_PIN    = BoardConfig::OUTPUT_PIN_4;
 
   //Configure this model as a quadcopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1303,10 +1304,10 @@ class QuadPlusCopter : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 4U;
   static constexpr uint8_t NUMBER_SERVOS  = 0U;
-  static constexpr uint8_t MOTOR_1_PIN    = D0;
-  static constexpr uint8_t MOTOR_2_PIN    = D1;
-  static constexpr uint8_t MOTOR_3_PIN    = D2;
-  static constexpr uint8_t MOTOR_4_PIN    = D3;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t MOTOR_3_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t MOTOR_4_PIN    = BoardConfig::OUTPUT_PIN_4;
 
   //Configure this model as a quadcopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1367,10 +1368,10 @@ class ChinookCopter : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t MOTOR_1_PIN    = D0;
-  static constexpr uint8_t MOTOR_2_PIN    = D1;
-  static constexpr uint8_t SERVO_1_PIN    = D2;
-  static constexpr uint8_t SERVO_2_PIN    = D3;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_4;
 
   //Configure this model as a quadcopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1447,10 +1448,10 @@ class BiCopter : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t MOTOR_1_PIN    = D0;
-  static constexpr uint8_t MOTOR_2_PIN    = D1;
-  static constexpr uint8_t SERVO_1_PIN    = D2;
-  static constexpr uint8_t SERVO_2_PIN    = D3;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_4;
 
   //Configure this model as a bicopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1526,12 +1527,12 @@ class TriCopter : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 4U; //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
   static constexpr uint8_t NUMBER_SERVOS  = 2U; //Purposely defining 2 as LEDc channles are pairs.
-  static constexpr uint8_t MOTOR_1_PIN    = D0;
-  static constexpr uint8_t MOTOR_2_PIN    = D1;
-  static constexpr uint8_t MOTOR_3_PIN    = D2;
-  static constexpr uint8_t MOTOR_4_PIN    = D3; //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
-  static constexpr uint8_t SERVO_1_PIN    = D8;
-  static constexpr uint8_t SERVO_2_PIN    = D9;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t MOTOR_3_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t MOTOR_4_PIN    = BoardConfig::OUTPUT_PIN_4;  //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_5;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_6;
 
   //Configure this model as a tricopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1608,10 +1609,10 @@ class DualCopter : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t MOTOR_1_PIN    = D0;
-  static constexpr uint8_t MOTOR_2_PIN    = D1;
-  static constexpr uint8_t SERVO_1_PIN    = D2;
-  static constexpr uint8_t SERVO_2_PIN    = D3;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_2;
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_4;
 
   //Configure this model as a dualcopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
@@ -1684,12 +1685,12 @@ class SingleCopter : public ModelBase
 public:
   static constexpr uint8_t NUMBER_MOTORS  = 2U; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
   static constexpr uint8_t NUMBER_SERVOS  = 4U;
-  static constexpr uint8_t MOTOR_1_PIN    = D0;
-  static constexpr uint8_t MOTOR_2_PIN    = D1; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
-  static constexpr uint8_t SERVO_1_PIN    = D2;
-  static constexpr uint8_t SERVO_2_PIN    = D3;
-  static constexpr uint8_t SERVO_3_PIN    = D8;
-  static constexpr uint8_t SERVO_4_PIN    = D9;
+  static constexpr uint8_t MOTOR_1_PIN    = BoardConfig::OUTPUT_PIN_1;
+  static constexpr uint8_t MOTOR_2_PIN    = BoardConfig::OUTPUT_PIN_2;  //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
+  static constexpr uint8_t SERVO_1_PIN    = BoardConfig::OUTPUT_PIN_3;
+  static constexpr uint8_t SERVO_2_PIN    = BoardConfig::OUTPUT_PIN_4;
+  static constexpr uint8_t SERVO_3_PIN    = BoardConfig::OUTPUT_PIN_5;
+  static constexpr uint8_t SERVO_4_PIN    = BoardConfig::OUTPUT_PIN_6;
 
   //Configure this model as a singlecopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =

--- a/PlainFlightController/Mpu6050.cpp
+++ b/PlainFlightController/Mpu6050.cpp
@@ -72,7 +72,7 @@ Mpu6050::initialise()
 void 
 Mpu6050::begin()
 {
-  i2c.begin(Config::I2C_SDA,Config::I2C_SCL,I2C_CLK_1MHZ);
+  i2c.begin(BoardConfig::I2C_SDA,BoardConfig::I2C_SCL,I2C_CLK_1MHZ);
   i2c.begin();
 }
 

--- a/PlainFlightController/Mpu6050.hpp
+++ b/PlainFlightController/Mpu6050.hpp
@@ -25,7 +25,7 @@
 #include <Arduino.h>
 #include "ESP32_SoftWire.h"
 #include "Config.hpp"
-
+#include "BoardConfig.hpp"
 
 class Mpu6050
 {


### PR DESCRIPTION
This PR addresses Issue #16 

Configuration items relating to pin selection have been moved from config.hpp to BoardConfig.hpp. Two example configurations have been included for the XIAO ESP32-S3 and the Waveshare Zero boards. Additional boards or different pin usage with these boards can be accommodated by editing or creating new board definitions. Boards are defined in the BoardConfig namespace. The desired board config is selected at the start of the Config.hpp file.

In addition to enabling different board configurations this PR also addresses the use of GRB Neopixel devices used on some boards. A new configuration option has been added to Config.hpp "SWAP_NEOPIXEL_RED_GREEN" which when set to true swaps red and green. Use this if your LED colours are not correct.