### PR TITLE
Refactor model outputs part2

### DIFF
--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -362,8 +362,8 @@ protected:
           for (uint32_t* motor : motors)
             *motor -= overShoot;
       }
+  };
 };
-
 
 /**
 * @brief    Plane with wing ailerons/flaps, rudder and elevator. 
@@ -1095,7 +1095,7 @@ public:
     uint32_t motor3 = mapRateMotorToTimerTicks(throttle - demands->pitch - demands->roll + demands->yaw);
     uint32_t motor4 = mapRateMotorToTimerTicks(throttle + demands->pitch - demands->roll - demands->yaw);
 
-    multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
+    multicopterMotorMagic({&motor1, &motor2, &motor3, &motor4});
 
     motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
     motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
@@ -1158,7 +1158,7 @@ public:
     uint32_t motor3 = mapRateMotorToTimerTicks(throttle + demands->pitch - demands->yaw);
     uint32_t motor4 = mapRateMotorToTimerTicks(throttle + demands->roll + demands->yaw);
 
-    multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
+    multicopterMotorMagic({&motor1, &motor2, &motor3, &motor4});
 
     motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
     motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
@@ -1215,7 +1215,7 @@ public:
     uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->pitch);
     uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->pitch);
 
-    multicopterMotorMagic(&motor1, &motor2);
+    multicopterMotorMagic({&motor1, &motor2});
 
     motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
     motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
@@ -1289,7 +1289,7 @@ public:
     uint32_t motor1 = mapRateMotorToTimerTicks(throttle + demands->roll);
     uint32_t motor2 = mapRateMotorToTimerTicks(throttle - demands->roll);
 
-    multicopterMotorMagic(&motor1, &motor2);
+    multicopterMotorMagic({&motor1, &motor2});
 
     motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
     motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
@@ -1338,7 +1338,7 @@ public:
   //Configure this model as a tricopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {SERVO_1_PIN, MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
+          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1369,7 +1369,7 @@ public:
     uint32_t motor3 = mapRateMotorToTimerTicks(throttle - demands->roll - twoThirdPitch);   //Right motor
     uint32_t motor4 = getDefaultMotorTicks(Actuator::CHANNEL_4);
 
-    multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
+    multicopterMotorMagic({&motor1, &motor2, &motor3, &motor4});
 
     motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
     motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
@@ -1439,7 +1439,7 @@ public:
     uint32_t motor1 = mapRateMotorToTimerTicks(throttle - demands->yaw);
     uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->yaw);
 
-    multicopterMotorMagic(&motor1, &motor2);
+    multicopterMotorMagic({&motor1, &motor2});
 
     motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
     motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
@@ -1473,10 +1473,10 @@ public:
 class SingleCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U; //Purposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
+  static constexpr uint8_t NUMBER_MOTORS  = 2U;
   static constexpr uint8_t NUMBER_SERVOS  = 4U;
   static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
+  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2;
   static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_3;
   static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_4;
   static constexpr uint8_t SERVO_3_PIN    = Config::ESP32S3.OUTPUT_5;
@@ -1485,7 +1485,7 @@ public:
   //Configure this model as a singlecopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -86,8 +86,7 @@ public:
 
     const int32_t rateMinThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED,
                                       -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    m_rateMinThrottleTicks = static_cast<uint32_t>(map32(rateMinThrottle, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT,
-                                                      m_minMotorTimerTicks, m_maxMotorTimerTicks));
+    m_rateMinThrottleTicks = mapRateMotorToTimerTicks(rateMinThrottle);
   }
 
   ~ModelBase(){};
@@ -334,9 +333,9 @@ protected:
       {
           const uint32_t val = *motor;
 
-          if (val < m_minThrottle)
+          if (val < m_rateMinThrottleTicks)
           {
-              const uint32_t tempUnder = m_minThrottle - val;
+              const uint32_t tempUnder = m_rateMinThrottleTicks - val;
               if (tempUnder > underShoot)
                   underShoot = tempUnder;
           }

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -83,6 +83,11 @@ public:
     m_maxServoTimerTicks = static_cast<int32_t>(servoAt(0).getMaxTimerTicks());
     m_minMotorTimerTicks = static_cast<int32_t>(motorAt(0).getMinTimerTicks());//And/or all motors will be the same refresh rate
     m_maxMotorTimerTicks = static_cast<int32_t>(motorAt(0).getMaxTimerTicks());
+
+    const int32_t rateMinThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED,
+                                      -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
+    m_rateMinThrottleTicks = static_cast<uint32_t>(map32(rateMinThrottle, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT,
+                                                      m_minMotorTimerTicks, m_maxMotorTimerTicks));
   }
 
   ~ModelBase(){};
@@ -158,6 +163,7 @@ private:
   int32_t m_maxServoTimerTicks;
   int32_t m_minMotorTimerTicks;
   int32_t m_maxMotorTimerTicks;
+  uint32_t m_rateMinThrottleTicks;
 
   //Objects
   LedcServo outputs[LedcServo::MAX_LEDC_CHANNELS];
@@ -180,7 +186,7 @@ protected:
 
   //Variables
   const int32_t m_idleUp;
-  int32_t m_minThrottle;
+  const int32_t m_minThrottle;
   const uint8_t m_totalOutputs;
 
   /**
@@ -210,7 +216,7 @@ protected:
               }
               debugUpdateTime = nowTime + 100U;
           }
-    }
+      }
   }
 
   /**
@@ -292,151 +298,70 @@ protected:
   }
 
   /**
-    * @brief  Prevent PID being clipped due to extremes of motor control. 
-    * @brief  If PID goes beyond max motor ticks then subtract the overshoot from all motors.
-    * @brief  If PID goes below min motor ticks then add the undershoot to all motors.
-    * @param  motor1 to control
-    * @param  motor2 to control
-    * @param  motor3 to control
-    * @param  motor4 to control
+    * @brief  Gets the min "Rate" timer ticks for motors.
     */
-  void multicopterMotorMagic(uint32_t * const motor1, uint32_t * const motor2, uint32_t * const motor3, uint32_t * const motor4)
+  uint32_t getRateMinThrottleTicks() const
   {
-    uint32_t underShoot = 0;
-    uint32_t overShoot = 0;
-    //When PID undershoots the min motor timer tick, take the maximum undershoot value and add it to all motors. This allows full PID control at min throttle ...my version of air mode :-P
-    if (*motor1 < m_minThrottle)
-    {
-      underShoot = m_minThrottle - *motor1;
-    }
-    else
-    {
-      if (*motor1 > m_maxMotorTimerTicks)
-      {
-        overShoot = *motor1 - m_maxMotorTimerTicks;
-      }
-    }
-
-    if (*motor2 < m_minThrottle)
-    {
-      const uint32_t tempUnderShoot = m_minThrottle - *motor2;
-      underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
-    }
-    else
-    {
-      if (*motor2 > m_maxMotorTimerTicks)
-      {
-        const uint32_t tempOverShoot = *motor2 - m_maxMotorTimerTicks;
-        overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
-      }
-    }
-
-    if (*motor3 < m_minThrottle)
-    {
-      const uint32_t tempUnderShoot = m_minThrottle - *motor3;
-      underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
-    }
-    else
-    {
-      if (*motor3 > m_maxMotorTimerTicks)
-      {
-        const uint32_t tempOverShoot = *motor3 - m_maxMotorTimerTicks;
-        overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
-      }
-    }
-
-    if (*motor4 < m_minThrottle)
-    {
-      const uint32_t tempUnderShoot = m_minThrottle - *motor4;
-      underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
-    }
-    else
-    {
-      if (*motor4 > m_maxMotorTimerTicks)
-      {
-        const uint32_t tempOverShoot = *motor4 - m_maxMotorTimerTicks;
-        overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
-      }
-    }
-
-    //We assume overShoot and underShoot cannot occur at the same time
-    //If one or more motors PID is undershooting then add the different to all to maintain control at low throttle
-    if (0 < underShoot)
-    {
-      *motor1 += underShoot;
-      *motor2 += underShoot;
-      *motor3 += underShoot;
-      *motor4 += underShoot;
-    }
-    else
-    {
-      //If one or more motors PID is overshooting then subtract the different to all to maintain control at high throttle
-      if (0 < overShoot)
-      {
-        *motor1 -= overShoot;
-        *motor2 -= overShoot;
-        *motor3 -= overShoot;
-        *motor4 -= overShoot;
-      }
-    }
-  };
-
+    return m_rateMinThrottleTicks;
+  }
 
   /**
-    * @brief  Prevent PID being clipped due to extremes of motor control. 
-    * @brief  If PID goes beyond max motor ticks then subtract the overshoot from all motors.
-    * @brief  If PID goes below min motor ticks then add the undershoot to all motors.
-    * @param  motor1 to control
-    * @param  motor2 to control
-    */
-  void multicopterMotorMagic(uint32_t * const motor1, uint32_t * const motor2)
+    * @brief Prevent PID being clipped due to extremes of motor control.
+    * @brief If any PID value goes beyond max motor ticks then subtract the MAX overshoot (across all motors) from EVERY motor.
+    * @brief If any PID value goes below min motor ticks then add the MAX undershoot (across all motors) to EVERY motor.
+    * @brief This preserves full PID authority at both min and max throttle (your "air mode" / "anti-gravity mode").
+    *
+    * @param motors     Array of pointers to the motor timer values (one pointer per motor).
+    *
+    * Call example for a bicopter (2 motors):
+    *     multicopterMotorMagic({motor1, motor2});
+    *
+    * Call example for a quadcopter (4 motors):
+    *     multicopterMotorMagic({motor1, motor2, motor3, motor4});
+    *
+    * Call example for a hexacopter (6 motors) or octocopter (8 motors) follows the same pattern.
+  */
+
+
+  void multicopterMotorMagic(std::initializer_list<uint32_t*> motors)
   {
-    uint32_t underShoot = 0;
-    uint32_t overShoot = 0;
-    //When PID undershoots the min motor timer ticks, take the maximum undershoot value and add it to all motors. This allows full PID control at min throttle ...my version of air mode :-P
-    //When PID overshoots the max motor timer ticks, take the maximum overshoot value and subtract it from all motors. This allows full PID control at max throttle ...my version of anti gravity mode :-P
-    if (*motor1 < m_minThrottle)
-    {
-      underShoot = m_minThrottle - *motor1;
-    }
-    else
-    {
-      if (*motor1 > m_maxMotorTimerTicks)
-      {
-        overShoot = *motor1 - m_maxMotorTimerTicks;
-      }
-    }
+      uint32_t underShoot = 0;
+      uint32_t overShoot  = 0;
 
-    if (*motor2 < m_minThrottle)
-    {
-      const uint32_t tempUnderShoot = m_minThrottle - *motor2;
-      underShoot = (tempUnderShoot > underShoot) ? tempUnderShoot : underShoot;
-    }
-    else
-    {
-      if (*motor2 > m_maxMotorTimerTicks)
+      // Find the SINGLE largest undershoot OR overshoot across ALL motors.
+      // We only check overshoot on a motor if it is NOT undershooting (exactly as the original code did).
+      for (uint32_t* motor : motors)
       {
-        const uint32_t tempOverShoot = *motor2 - m_maxMotorTimerTicks;
-        overShoot = (tempOverShoot > overShoot) ? tempOverShoot : overShoot;
-      }
-    }
+          const uint32_t val = *motor;
 
-    //If one or more motors PID is undershooting then add the different to all to maintain control at low throttle
-    if (0 < underShoot)
-    {
-      *motor1 += underShoot;
-      *motor2 += underShoot;
-    }
-    else
-    {
-      if (0 < overShoot)
-      {
-        //If one or more motors PID is overshooting then subtract the different to all to maintain control at high throttle
-        *motor1 -= overShoot;
-        *motor2 -= overShoot;
+          if (val < m_minThrottle)
+          {
+              const uint32_t tempUnder = m_minThrottle - val;
+              if (tempUnder > underShoot)
+                  underShoot = tempUnder;
+          }
+          else if (val > m_maxMotorTimerTicks)
+          {
+              const uint32_t tempOver = val - m_maxMotorTimerTicks;
+              if (tempOver > overShoot)
+                  overShoot = tempOver;
+          }
       }
-    }
-  };
+
+      // We assume undershoot and overshoot cannot occur at the same time.
+      // Apply the correction to EVERY motor so the whole set is shifted together.
+      if (0 < underShoot)
+      {
+          // Add the max undershoot to all motors → full PID control remains at minimum throttle.
+          for (uint32_t* motor : motors)
+            *motor += underShoot;
+      }
+      else if (0 < overShoot)
+      {
+          // Subtract the max overshoot from all motors → full PID control remains at maximum throttle.
+          for (uint32_t* motor : motors)
+            *motor -= overShoot;
+      }
 };
 
 
@@ -1147,11 +1072,7 @@ public:
           NUMBER_SERVOS,
       };
 
-  QuadXCopter() : ModelBase(m_modelConfig)
-  {
-    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-  };
+  QuadXCopter() : ModelBase(m_modelConfig){};
 
   ~QuadXCopter(){};
 
@@ -1176,10 +1097,10 @@ public:
 
     multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
 
-    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
-    motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
-    motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor3 = constrain(motor3, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor4 = constrain(motor4, getRateMinThrottleTicks(), getMaxMotorTicks());
 
     writeMotors({motor1, motor2, motor3, motor4});
   };
@@ -1214,11 +1135,7 @@ public:
           NUMBER_SERVOS,
       };
 
-  QuadPlusCopter() : ModelBase(m_modelConfig)
-  {
-    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-  };
+  QuadPlusCopter() : ModelBase(m_modelConfig){};
 
   ~QuadPlusCopter(){};
 
@@ -1243,10 +1160,10 @@ public:
 
     multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
 
-    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
-    motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
-    motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor3 = constrain(motor3, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor4 = constrain(motor4, getRateMinThrottleTicks(), getMaxMotorTicks());
 
     writeMotors({motor1, motor2, motor3, motor4});
   };
@@ -1277,11 +1194,7 @@ public:
           NUMBER_SERVOS,
       };
 
-  ChinookCopter() : ModelBase(m_modelConfig)
-  {
-    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-  };
+  ChinookCopter() : ModelBase(m_modelConfig){};
 
   ~ChinookCopter(){};
 
@@ -1304,8 +1217,8 @@ public:
 
     multicopterMotorMagic(&motor1, &motor2);
 
-    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
 
     writeMotors({motor1, motor2});
   };
@@ -1356,11 +1269,7 @@ public:
           NUMBER_SERVOS,
       };
 
-  BiCopter() : ModelBase(m_modelConfig)
-  {
-    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-  };
+  BiCopter() : ModelBase(m_modelConfig){};
 
   ~BiCopter(){};
 
@@ -1382,8 +1291,8 @@ public:
 
     multicopterMotorMagic(&motor1, &motor2);
 
-    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
 
     writeMotors({motor1, motor2});
   };
@@ -1436,11 +1345,7 @@ public:
           NUMBER_SERVOS,
       };
 
-  TriCopter() : ModelBase(m_modelConfig)
-  {
-    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-  };
+  TriCopter() : ModelBase(m_modelConfig){};
 
   ~TriCopter(){};
 
@@ -1466,11 +1371,10 @@ public:
 
     multicopterMotorMagic(&motor1, &motor2, &motor3, &motor4);
 
-    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
-    motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
-    motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
-
+    motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor3 = constrain(motor3, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor4 = constrain(motor4, getRateMinThrottleTicks(), getMaxMotorTicks());
     writeMotors({motor1, motor2, motor3, motor4});
   };
 
@@ -1515,11 +1419,7 @@ public:
           NUMBER_SERVOS,
       };
 
-  DualCopter() : ModelBase(m_modelConfig)
-  {
-    const uint32_t minThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    m_minThrottle = mapRateMotorToTimerTicks(minThrottle);
-  };
+  DualCopter() : ModelBase(m_modelConfig){};
 
   ~DualCopter(){};
 
@@ -1541,8 +1441,8 @@ public:
 
     multicopterMotorMagic(&motor1, &motor2);
 
-    motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
-    motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
+    motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
+    motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
 
     writeMotors({motor1, motor2});
   };


### PR DESCRIPTION
 ## Refactor of ModelTypes.hpp Part 2: Centralise min-throttle calculation and fixed argument multicopterMotorMagic

**Branch:** `refactorModelOutputsPart2`
**Depends on:** `refactorModelOutputs` 

### Summary
This PR completes the refactor of ModelTypes.hpp (there is a third PR in this series but it is not directly connected to the refactor).  The split into two PRs is arbitrary but I hope that it makes review a little easier.  Each PR should result in compilable code. This PR eliminates boilerplate `m_minThrottle` calculations duplicated across every multicopter subclass by lifting them into `ModelBase`, and replaces fixed argument `multicopterMotorMagic` overloads with a single `std::initializer_list` version.

### Changes

**Centralised min-throttle**
Removes the repeated constructor body from `QuadXCopter`, `QuadPlusCopter`, `ChinookCopter`, `BiCopter`, `TriCopter`, and `DualCopter`. Adds `m_rateMinThrottleTicks` as a pre-computed `const` member in `ModelBase`, exposed via `getRateMinThrottleTicks()`. All inline `constrain()` calls updated to use the accessor.

**Variable argument motor magic**
Removes the two fixed argument `multicopterMotorMagic` overloads and replaces them with a single loop-based `std::initializer_list<uint32_t*>` version. All calls updated to brace-pointer syntax.

