### PR TITLE
Cleanup of ModelTypes (Refactor model outputs part3)

### DIFF
--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -332,43 +332,43 @@ protected:
 
   void multicopterMotorMagic(std::initializer_list<uint32_t*> motors)
   {
-      uint32_t underShoot = 0;
-      uint32_t overShoot  = 0;
+    uint32_t underShoot = 0U;
+    uint32_t overShoot  = 0U;
 
-      // Find the SINGLE largest undershoot OR overshoot across ALL motors.
-      // We only check overshoot on a motor if it is NOT undershooting (exactly as the original code did).
-      for (uint32_t* motor : motors)
-      {
-          const uint32_t val = *motor;
+    // Find the SINGLE largest undershoot OR overshoot across ALL motors.
+    // We only check overshoot on a motor if it is NOT undershooting (exactly as the original code did).
+    for (uint32_t* motor : motors)
+    {
+        const uint32_t val = *motor;
 
-          if (val < m_rateMinThrottleTicks)
-          {
-              const uint32_t tempUnder = m_rateMinThrottleTicks - val;
-              if (tempUnder > underShoot)
-                  underShoot = tempUnder;
-          }
-          else if (val > m_maxMotorTimerTicks)
-          {
-              const uint32_t tempOver = val - m_maxMotorTimerTicks;
-              if (tempOver > overShoot)
-                  overShoot = tempOver;
-          }
-      }
+        if (val < m_rateMinThrottleTicks)
+        {
+            const uint32_t tempUnder = m_rateMinThrottleTicks - val;
+            if (tempUnder > underShoot)
+                underShoot = tempUnder;
+        }
+        else if (val > m_maxMotorTimerTicks)
+        {
+            const uint32_t tempOver = val - m_maxMotorTimerTicks;
+            if (tempOver > overShoot)
+                overShoot = tempOver;
+        }
+    }
 
-      // We assume undershoot and overshoot cannot occur at the same time.
-      // Apply the correction to EVERY motor so the whole set is shifted together.
-      if (0 < underShoot)
-      {
-          // Add the max undershoot to all motors → full PID control remains at minimum throttle.
-          for (uint32_t* motor : motors)
-            *motor += underShoot;
-      }
-      else if (0 < overShoot)
-      {
-          // Subtract the max overshoot from all motors → full PID control remains at maximum throttle.
-          for (uint32_t* motor : motors)
-            *motor -= overShoot;
-      }
+    // We assume undershoot and overshoot cannot occur at the same time.
+    // Apply the correction to EVERY motor so the whole set is shifted together.
+    if (0 < underShoot)
+    {
+        // Add the max undershoot to all motors → full PID control remains at minimum throttle.
+        for (uint32_t* motor : motors)
+          *motor += underShoot;
+    }
+    else if (0 < overShoot)
+    {
+        // Subtract the max overshoot from all motors → full PID control remains at maximum throttle.
+        for (uint32_t* motor : motors)
+          *motor -= overShoot;
+    }
   }
 };
 

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -120,23 +120,27 @@ public:
     }
   }
 
-  //TODO - the following should be pure virtual as we could write to uninitialised LEDc channels !!
+  /**
+    * @brief  Servo mixer
+    * @param  demands - The RC demands
+    * @param  trim - The saved servo trim values
+    * @note   Default implementation asserts if the model declares servos but does not override this method.
+    */
+  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim)
+  {
+    assert(m_modelConfig.numberServos == 0 && "servoMixer must be overridden in models that declare servos");
+  }
 
   /**
     * @brief  Servo mixer
     * @param  demands - The RC demands
     * @param  trim - The saved servo trim values
-    * @note   Cannot be pure virtual as some multicopters do not have servos.
+    * @note   Default implementation asserts if the model declares servos but does not override this method.
     */
-  virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim){}
-
-  /**
-    * @brief  Servo mixer
-    * @param  demands - The RC demands
-    * @param  trim - The saved servo trim values
-    * @note   Cannot be pure virtual as some multicopters do not have servos.
-    */
-  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim){}
+  virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim)
+  {
+    assert(m_modelConfig.numberServos == 0 && "servoRateMixer not overridden for a model declared with servos");
+  }
 
   /**
     * @brief  Motor mixer pure virtual - can be overriden.
@@ -181,6 +185,10 @@ protected:
     CHANNEL_2,
     CHANNEL_3,
     CHANNEL_4,
+    CHANNEL_5,
+    CHANNEL_6,
+    CHANNEL_7,
+    CHANNEL_8
   };
 
   //Variables
@@ -361,11 +369,11 @@ protected:
           for (uint32_t* motor : motors)
             *motor -= overShoot;
       }
-  };
+  }
 };
 
 /**
-* @brief    Plane with wing ailerons/flaps, rudder and elevator. 
+* @brief    Plane with wing ailerons/flaperons, rudder and elevator. 
 * @note     Channel output map: Left aileron, right aileron elevator, rudder, motor 1, motor 2
 * @note     3 position flaps work with this model.
 */
@@ -493,7 +501,7 @@ public:
 
 
 /**
-* @brief    Plane with wing ailerons/flaps, with rudder and elevator mixed for V-tail i.e.'Talon' type model. 
+* @brief    Plane with wing ailerons/flaperons, with rudder and elevator mixed for V-tail i.e.'Talon' type model. 
 * @note     Channel output map: left aileron, right aileron, Left taileron, right taileron, motor 1, motor 2
 * @note     3 position flaps work with this model.
 */
@@ -539,11 +547,13 @@ public:
     // constraint add to prevent overflow
     const int32_t rollMinusFlap = constrain(demands->roll - negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
     const int32_t rollPlusFlap = constrain(demands->roll + negativeFlap, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t yawMinusPitch  = constrain(demands->yaw - demands->pitch,RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
+    const int32_t yawPlusPitch = constrain(demands->yaw + demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
     const uint32_t leftAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
-    const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
-    const uint32_t yawTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));
-    writeServos({leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks});
+    const uint32_t leftTaileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(yawMinusPitch) + (trim->servo3 * getTrimMultiplier()));
+    const uint32_t rightTaileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(yawPlusPitch) + (trim->servo4 * getTrimMultiplier()));
+    writeServos({leftAileronTicks, rightAileronTicks, leftTaileronTicks, rightTaileronTicks});
   }
 
   /**
@@ -567,9 +577,9 @@ public:
     const int32_t yawPlusPitch = constrain(demands->yaw + demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
     const uint32_t leftAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusFlap) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
-    const uint32_t pitchTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(yawMinusPitch) + (trim->servo3 * getTrimMultiplier()));
-    const uint32_t yawTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(yawPlusPitch) + (trim->servo4 * getTrimMultiplier()));
-    writeServos({leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks});
+    const uint32_t leftTaileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(yawMinusPitch) + (trim->servo3 * getTrimMultiplier()));
+    const uint32_t rightTaileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(yawPlusPitch) + (trim->servo4 * getTrimMultiplier()));
+    writeServos({leftAileronTicks, rightAileronTicks, leftTaileronTicks, rightTaileronTicks});
   }
 
   /**
@@ -877,9 +887,9 @@ public:
     // constraint add to prevent overflow
     const int32_t rollPlusPitch = constrain(demands->roll + demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
     const int32_t rollMinusPitch = constrain(demands->roll - demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
-    const uint32_t leftElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
-    const uint32_t rightElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
-    writeServos({leftElevonTicks, rightElevonTicks});
+    const uint32_t leftTaileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
+    const uint32_t rightTaileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
+    writeServos({leftTaileronTicks, rightTaileronTicks});
   }
 
   /**


### PR DESCRIPTION
## ModelTypes.hpp fix/refactor/docs: V-tail mixer fix, asserting servoMixer guard, and comment cleanups

**Branch:** `refactorModelOutputsPart3`
**Depends on:** None — independent of the refactoring branches.

### Summary
Three self-contained changes: a logic fix for the V-tail mixer in `PlaneFullHouseVTail`, a safety improvement to the default `servoMixer` / `servoRateMixer` bodies, and a batch of comment and naming cleanups.

### Changes

**V-tail mixer fix**
`PlaneFullHouseVTail::servoMixer()` previously passed raw `demands->pitch` and `demands->yaw` to servo 3 and 4 separately. Now correctly pre-computes `yawMinusPitch` / `yawPlusPitch` and maps them to `leftTaileronTicks` / `rightTaileronTicks` before writing. Applied to both normal and rate mixer paths. This addresses Issue #22.

**Asserting mixer guard**
The default `servoMixer()` and `servoRateMixer()` virtual bodies changed from silent no-ops to `assert(m_modelConfig.numberServos == 0)` guards, catching subclasses that forget to override when servos are configured. These should be virtual comment satisfied.

**Comment and naming cleanups**
"flaps" → "flaperons" in `PlaneFullHouseVTail` and `PlaneFullHouse` docs; "elevon" → "taileron" variable naming in `PlaneFullHouseVTail` and `PlaneVTail` rate mixer; comment typo fixes Note: that some of these might have been corrected earlier in the series; `CHANNEL_5`–`CHANNEL_8` added to the `Actuator` enum; minor comment rewording in `ModelBase`.