### PR TITLE
Reverse outputs

### DIFF
--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -77,10 +77,7 @@ class Config
     static constexpr bool REVERSE_ROLL_CORRECTIONS            = false;
     static constexpr bool REVERSE_YAW_CORRECTIONS             = false;
     static constexpr bool CALIBRATE_ESC                       = false;  //Remove all propellers before calibrating ESC's !
-    static constexpr bool REVERSE_SERVO_1                     = false;  //Should only need to use REVERSE_SERVO when same handed servos horns used on ailerons etc
-    static constexpr bool REVERSE_SERVO_2                     = false;
-    static constexpr bool REVERSE_SERVO_3                     = false;
-    static constexpr bool REVERSE_SERVO_4                     = false;
+    static constexpr bool REVERSE_OUTPUT[LedcServo::MAX_LEDC_CHANNELS] = {false, false, false, false, false, false, false, false};//Should only need to use REVERSE_SERVO when same handed servos horns used on ailerons etc
     static constexpr bool EXTEND_SERVO_TRAVEL_RANGE           = false;  //Servo travel 1 to 2ms when false, 0.8 to 2.2ms when true. 
     //Auto levelled prop hanging/tail sitting mode. You need to understand flight controllers well to configure this...
     static constexpr bool USE_PROP_HANG_MODE                  = false;  //Experimental mode that applies self levelling algorithm to pitch/yaw for prop hanging via Tx channel 9
@@ -114,8 +111,7 @@ class Config
     static constexpr bool DEBUG_GYRO_CALIBRATION              = false;
     static constexpr bool DEBUG_CONFIGURATOR                  = false;
     static constexpr bool DEBUG_MPU6050                       = false;
-    static constexpr bool DEBUG_MOTOR_OUTPUT                  = false;
-    static constexpr bool DEBUG_SERVO_OUTPUT                  = false;
+    static constexpr bool DEBUG_OUTPUT                        = false;
 
     //USB serial
     static constexpr uint32_t USB_BAUD                        = 500000U;

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -77,8 +77,16 @@ class Config
     static constexpr bool REVERSE_ROLL_CORRECTIONS            = false;
     static constexpr bool REVERSE_YAW_CORRECTIONS             = false;
     static constexpr bool CALIBRATE_ESC                       = false;  //Remove all propellers before calibrating ESC's !
-    static constexpr bool REVERSE_OUTPUT[LedcServo::MAX_LEDC_CHANNELS] = {false, false, false, false, false, false, false, false};//Should only need to use REVERSE_SERVO when same handed servos horns used on ailerons etc
     static constexpr bool EXTEND_SERVO_TRAVEL_RANGE           = false;  //Servo travel 1 to 2ms when false, 0.8 to 2.2ms when true. 
+    //Servo reversing... Should only need to use REVERSE_SERVO when same handed servos horns used on ailerons etc
+    static constexpr bool REVERSE_SERVO_1                     = false; 
+    static constexpr bool REVERSE_SERVO_2                     = false;  
+    static constexpr bool REVERSE_SERVO_3                     = false; 
+    static constexpr bool REVERSE_SERVO_4                     = false; 
+    static constexpr bool REVERSE_SERVO_5                     = false; 
+    static constexpr bool REVERSE_SERVO_6                     = false; 
+    static constexpr bool REVERSE_SERVO_7                     = false; 
+    static constexpr bool REVERSE_SERVO_8                     = false; 
     //Auto levelled prop hanging/tail sitting mode. You need to understand flight controllers well to configure this...
     static constexpr bool USE_PROP_HANG_MODE                  = false;  //Experimental mode that applies self levelling algorithm to pitch/yaw for prop hanging via Tx channel 9
     static constexpr bool REVERSE_PROP_HANG_PITCH_CORRECTIONS = false;  //Should pitch corrections operate in wrong sense in prophang then set to true

--- a/PlainFlightController/LedcServo.cpp
+++ b/PlainFlightController/LedcServo.cpp
@@ -22,6 +22,24 @@
 */
 
 #include "LedcServo.hpp"
+#include "Config.hpp"
+
+
+/**
+* @brief  Global variable that spans all instances of LedcServo. 
+*/  
+static bool g_reverseOutput[LedcServo::MAX_LEDC_CHANNELS] = 
+  {
+  Config::REVERSE_SERVO_1, 
+  Config::REVERSE_SERVO_2, 
+  Config::REVERSE_SERVO_3, 
+  Config::REVERSE_SERVO_4, 
+  Config::REVERSE_SERVO_5, 
+  Config::REVERSE_SERVO_6, 
+  Config::REVERSE_SERVO_7, 
+  Config::REVERSE_SERVO_8
+  };
+
 
 /**
 * @brief  Constructor for LedcServo class. 

--- a/PlainFlightController/LedcServo.cpp
+++ b/PlainFlightController/LedcServo.cpp
@@ -29,7 +29,7 @@
 * @brief  Global variable that spans all instances of LedcServo. 
 */  
 static bool g_reverseOutput[LedcServo::MAX_LEDC_CHANNELS] = 
-  {
+{
   Config::REVERSE_SERVO_1, 
   Config::REVERSE_SERVO_2, 
   Config::REVERSE_SERVO_3, 
@@ -38,7 +38,7 @@ static bool g_reverseOutput[LedcServo::MAX_LEDC_CHANNELS] =
   Config::REVERSE_SERVO_6, 
   Config::REVERSE_SERVO_7, 
   Config::REVERSE_SERVO_8
-  };
+ };
 
 
 /**

--- a/PlainFlightController/LedcServo.cpp
+++ b/PlainFlightController/LedcServo.cpp
@@ -65,6 +65,23 @@ LedcServo::LedcServo(const uint8_t pwmPin, RefreshRate refreshRate, const uint32
 
 /**
 * @brief  Constructor for LedcServo class. 
+* @param  pin to output servo PWM/pulse on.
+* @param  Servo refresh rate Hz. 
+* @param  Inital value and failsafe position of servo. 1500ms is servo centered.
+* @param  isReversed values written to this servo will be ticks from maxTicks
+* @note   Recommend setting throttle channel initial/failsafe value to 1000ms.
+* @note   Set analogue servos to 50Hz only! Digital servos typically 150-250Hz, check servo datasheet before setting!
+* @note   Too high a refresh rate may permanently damage servo(s)!
+*/  
+LedcServo::LedcServo(const uint8_t pwmPin, RefreshRate refreshRate, const uint32_t initialMicroSeconds, const bool extendTravelLimits, const bool isReversed) 
+  : LedcServo(pwmPin, refreshRate, initialMicroSeconds, extendTravelLimits)
+{
+  m_isReversed = isReversed;
+}
+
+
+/**
+* @brief  Constructor for LedcServo class. 
 * @return True upon initialisation success.
 */
 bool 
@@ -102,7 +119,9 @@ LedcServo::setTimerTicks(const uint32_t requiredTicks)
   {
     m_timerTicks = constrain(requiredTicks, m_minTicks, m_maxTicks);
   }
-
+  if (m_isReversed){
+    m_timerTicks = (m_maxTicks - m_timerTicks) + m_minTicks;
+  }
   ledcWrite(m_pwmPin, m_timerTicks);
 }
 

--- a/PlainFlightController/LedcServo.hpp
+++ b/PlainFlightController/LedcServo.hpp
@@ -27,7 +27,6 @@
 #include "Utilities.hpp"
 
 
-
 /**
 * @class LedcServo
 */

--- a/PlainFlightController/LedcServo.hpp
+++ b/PlainFlightController/LedcServo.hpp
@@ -51,8 +51,10 @@ class LedcServo : public Utilities
     static constexpr uint32_t MID_MICRO_SECONDS = 1500U;
     static constexpr uint32_t MIN_MICRO_SECONDS = 1000U;
     static constexpr uint32_t CALIBRATE_ESC_DELAY = 5000;
-
+    static constexpr uint8_t MAX_LEDC_CHANNELS = 8U;  //ESP32S3 has 8 PWM channels that operate in frequency pairs.
+    LedcServo() = default;
     LedcServo(const uint8_t pwmPin, const RefreshRate refreshRate, const uint32_t initialMicroSeconds, const bool extendTravelLimits);
+    LedcServo(const uint8_t pwmPin, const RefreshRate refreshRate, const uint32_t initialMicroSeconds, const bool extendTravelLimits, const bool isReversed);
     bool begin();
     void setTimerTicks(const uint32_t requiredTicks);
     void debug() const;
@@ -63,6 +65,8 @@ class LedcServo : public Utilities
     uint32_t getMaxTimerTicks() const;
     uint32_t getDefaultTimerTicks() const {return m_defaultTimerTicks;}
     int32_t getTrimMultiplier() const {return m_trimMultiplier;}    
+    bool getIsReversed() const {return m_isReversed;}
+    void setIsReversed(bool isReversed) {m_isReversed = isReversed;}
 
   private:
     static constexpr int32_t LEDC_BIT_RESOLUTION  = 14;
@@ -80,5 +84,6 @@ class LedcServo : public Utilities
     uint32_t m_maxTicks;
     uint32_t m_extendedTickRange;
     int32_t m_trimMultiplier;  
+    bool m_isReversed = false;  // Ensure default behaviour  
     bool m_extendTravelLimits;  
 };

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -29,43 +29,53 @@
 #include "Config.hpp"
 #include "DemandProcessor.hpp"
 
+static constexpr uint8_t PIN_UNUSED = 0xFF;  // Marker for unused outputs
 
 /**
 * @brief    Base class for all model types.
-* @note     Purposely limited to 4 motors and 4 servos as this covers most model types.
-* @note     Can be modified to use up to 8 servos, or 8 motors. Other combinations can be made.
-* @note     If using different refresh rates for motors/servos then you must use even numbers as LEDc timers are shared between two channels i.e 0-1, 2-3, 4-5, 6-7. 
+* @note     Arbitrary numbers of servos and motors up to LedcServo::MAX_LEDC_CHANNELS can be made
+* @note     A maximum of 4 different refresh rates are possible but we only use two
 */
 class ModelBase : public Utilities
 {
 public:
-  static constexpr uint8_t MAX_MOTORS = 4U;   //Must be even number as LEDc module shares 1 timer between 2 channels
-  static constexpr uint8_t MAX_SERVOS = 4U;   //Must be even number as LEDc module shares 1 timer between 2 channels
-  static constexpr uint8_t MAX_LEDC_CHANNELS = 8U;  //ESP32S3 has 8 PWM channels that operate in frequency pairs.
-
   //Structure used to define model type and actuators required.
   struct ModelConfig
   {
-    uint8_t motorPins[MAX_MOTORS];
-    uint8_t servoPins[MAX_SERVOS];
+    // Servos and Motors are assigned to contiguous positions in this array
+    // Servos occupy [0:numberServos-1] and Motors occupy [numberServos: numberServos+numberMotors-1]
+    uint8_t outputPins[LedcServo::MAX_LEDC_CHANNELS];  // MAX_LEDC_CHANNELS = 8 for the ESP32-S3
     LedcServo::RefreshRate motorRefresh;
     LedcServo::RefreshRate servoRefresh;
     uint8_t numberMotors;
     uint8_t numberServos;
   };
 
-  ModelBase(ModelConfig modelConfig) : m_modelConfig(modelConfig)
+  ModelBase(ModelConfig modelConfig) 
+    : m_modelConfig(modelConfig),
+      m_idleUp(IDLE_UP),
+      m_minThrottle(MIN_THROTTLE),
+      m_totalOutputs(modelConfig.numberServos + modelConfig.numberMotors)
   {
-    assert((m_modelConfig.numberMotors <= MAX_MOTORS));  //Ensure not more that max number of motor channels not exceeded.
-    assert((m_modelConfig.numberServos <= MAX_SERVOS));  //Ensure not more that max number of servo channels not exceeded.
-    //Ensure not more that max number of LEDc channels have been decalred...
-    //...Obviously the 2 asserts above would negate the need for the below, but just incase somebody tries to modify code beyond ESP32S3 HW limits.
-    assert((m_modelConfig.numberMotors + m_modelConfig.numberServos) <= MAX_LEDC_CHANNELS);
+    // Ensure not too many outputs are declared
+    assert(m_totalOutputs <= LedcServo::MAX_LEDC_CHANNELS);
+    // limit on timer numbers is satisfied as we admit only two refresh frequencies
 
-    m_minServoTimerTicks = static_cast<int32_t>(servo[0].getMinTimerTicks());//All servos will be the same refresh rate
-    m_maxServoTimerTicks = static_cast<int32_t>(servo[0].getMaxTimerTicks());
-    m_minMotorTimerTicks = static_cast<int32_t>(motor[0].getMinTimerTicks());//And/or all motors will be the same reshresh rate
-    m_maxMotorTimerTicks = static_cast<int32_t>(motor[0].getMaxTimerTicks());
+    for (int i = 0; i < m_totalOutputs; i++) {
+        bool isServo = i < m_modelConfig.numberServos;
+        outputs[i] = LedcServo(
+            m_modelConfig.outputPins[i],
+            isServo ? m_modelConfig.servoRefresh : m_modelConfig.motorRefresh,
+            isServo ? LedcServo::MID_MICRO_SECONDS : LedcServo::MIN_MICRO_SECONDS,
+            Config::REVERSE_OUTPUT[i],
+            Config::EXTEND_SERVO_TRAVEL_RANGE
+        );
+    }
+    // Max/Min Timer ticks are calulated during construction of LedcServo objects
+    m_minServoTimerTicks = static_cast<int32_t>(servoAt(0).getMinTimerTicks());//All servos will be the same refresh rate
+    m_maxServoTimerTicks = static_cast<int32_t>(servoAt(0).getMaxTimerTicks());
+    m_minMotorTimerTicks = static_cast<int32_t>(motorAt(0).getMinTimerTicks());//And/or all motors will be the same refresh rate
+    m_maxMotorTimerTicks = static_cast<int32_t>(motorAt(0).getMaxTimerTicks());
   }
 
   ~ModelBase(){};
@@ -75,28 +85,23 @@ public:
     */
   virtual void begin()
   {
-    for (uint32_t i=0; i<m_modelConfig.numberServos; i++)
+    for (uint8_t i=0; i<m_totalOutputs; i++)
     {
-      servo[i].begin();
-    }
-
-    for (uint32_t i=0; i<m_modelConfig.numberMotors; i++)
-    {
-      motor[i].begin();
+      outputs[i].begin();
     }
 
     if constexpr(Config::CALIBRATE_ESC)
     {
-      for (uint32_t i=0; i<m_modelConfig.numberMotors; i++)
+      for (uint8_t i=0; i<m_modelConfig.numberMotors; i++)
       {
-        motor[i].setTimerTicks(motor[i].getMaxTimerTicks());
+        motorAt(i).setTimerTicks(motorAt(0).getMaxTimerTicks());
       }
 
       delay(LedcServo::CALIBRATE_ESC_DELAY);
 
-      for (uint32_t i=0; i<m_modelConfig.numberMotors; i++)
+      for (uint8_t i=0; i<m_modelConfig.numberMotors; i++)
       {
-        motor[i].setTimerTicks(motor[i].getMinTimerTicks());
+        motorAt(i).setTimerTicks(motorAt(0).getMinTimerTicks());
       }
 
       Serial.println("Calibration complete. Disable CALIBRATE_ESC setting in Config.hpp.");
@@ -137,72 +142,24 @@ public:
   /**
     * @brief  This multiplier allows servo trim values to be constant across all RefreshRate's.
     */
-  int32_t getTrimMultiplier() const {return servo[0].getTrimMultiplier();}
+  int32_t getTrimMultiplier() const {return servoAt(0).getTrimMultiplier();}
 
 private:
   //Variables
+  ModelConfig m_modelConfig;
   int32_t m_minServoTimerTicks;
   int32_t m_maxServoTimerTicks;
   int32_t m_minMotorTimerTicks;
   int32_t m_maxMotorTimerTicks;
-  ModelConfig m_modelConfig;
   uint64_t m_motorDebugUpdateTime = 0U;
   uint64_t m_servoDebugUpdateTime = 0U;
 
   //Objects
-  LedcServo servo[MAX_SERVOS] =
-      {
-          LedcServo(m_modelConfig.servoPins[0], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS, Config::EXTEND_SERVO_TRAVEL_RANGE),
-          LedcServo(m_modelConfig.servoPins[1], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS, Config::EXTEND_SERVO_TRAVEL_RANGE),
-          LedcServo(m_modelConfig.servoPins[2], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS, Config::EXTEND_SERVO_TRAVEL_RANGE),
-          LedcServo(m_modelConfig.servoPins[3], m_modelConfig.servoRefresh, LedcServo::MID_MICRO_SECONDS, Config::EXTEND_SERVO_TRAVEL_RANGE),
-      };
-
-  LedcServo motor[MAX_MOTORS] =
-      {
-          LedcServo(m_modelConfig.motorPins[0], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS, Config::EXTEND_SERVO_TRAVEL_RANGE),
-          LedcServo(m_modelConfig.motorPins[1], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS, Config::EXTEND_SERVO_TRAVEL_RANGE),
-          LedcServo(m_modelConfig.motorPins[2], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS, Config::EXTEND_SERVO_TRAVEL_RANGE),
-          LedcServo(m_modelConfig.motorPins[3], m_modelConfig.motorRefresh, LedcServo::MIN_MICRO_SECONDS, Config::EXTEND_SERVO_TRAVEL_RANGE),
-      };
-
-  void debugServos(const uint32_t servo1, const uint32_t servo2, const uint32_t servo3, const uint32_t servo4)
-  {
-    const uint64_t nowTime = millis();
-
-    if (m_servoDebugUpdateTime <= nowTime)
-    {
-      Serial.print("servo1: ");
-      Serial.print(servo1);
-      Serial.print(", servo2: ");
-      Serial.print(servo2);
-      Serial.print(", servo3: ");
-      Serial.print(servo3);
-      Serial.print(", servo4: ");
-      Serial.print(servo4);
-      Serial.println();
-      m_servoDebugUpdateTime = nowTime + 100U;
-    }
-  }
-
-  void debugMotors(const uint32_t motor1, const uint32_t motor2, const uint32_t motor3, const uint32_t motor4)
-  {
-    const uint64_t nowTime = millis();
-
-    if (m_motorDebugUpdateTime <= nowTime)
-    {
-      Serial.print("motor1: ");
-      Serial.print(motor1);
-      Serial.print(", motor2: ");
-      Serial.print(motor2);
-      Serial.print(", motor3: ");
-      Serial.print(motor3);
-      Serial.print(", motor4: ");
-      Serial.print(motor4);
-      Serial.println();
-      m_motorDebugUpdateTime = nowTime + 100U;
-    }
-  }
+  LedcServo outputs[LedcServo::MAX_LEDC_CHANNELS];
+  LedcServo& servoAt(uint8_t i) { return outputs[i]; }
+  const LedcServo& servoAt(uint8_t i) const { return outputs[i]; }
+  LedcServo& motorAt(uint8_t i) { return outputs[m_modelConfig.numberServos + i]; }
+  const LedcServo& motorAt(uint8_t i) const { return outputs[m_modelConfig.numberServos + i]; }
 
 protected:
   static constexpr int32_t IDLE_UP = RxBase::MIN_NORMALISED + Config::IDLE_UP_VALUE;
@@ -217,113 +174,54 @@ protected:
   };
 
   //Variables
-  int32_t m_idleUp = 0U;
-  int32_t m_minThrottle = 0U;
+  const int32_t m_idleUp;
+  int32_t m_minThrottle;
+  const uint8_t m_totalOutputs;
 
   /**
-    * @brief  Writes the demanded value/position to the servos.
-    * @param  
-    */
-  void writeServos(const uint32_t servo1, const uint32_t servo2)
+   * @brief  Internal helper to write values to a subset of outputs.
+   * @param  startIndex The starting index in the 'outputs' array.
+   * @param  values     The list of timer ticks to apply.
+   * @param  label      String label for debug output ("Motor" or "Servo").
+   */
+  void writeToOutputs(uint8_t startIndex, std::initializer_list<uint32_t> values, const char* label)
   {
-    if constexpr(Config::REVERSE_SERVO_1)
-    {
-      servo[0].setTimerTicks((m_maxServoTimerTicks - servo1) + m_minServoTimerTicks);
-    }
-    else
-    {
-      servo[0].setTimerTicks(servo1);
-    }
+      static uint64_t debugUpdateTime = 0U;
+      int i = 0;
+      for (uint32_t v : values)
+      {
+          outputs[startIndex + i++].setTimerTicks(v);
+      }
 
-    if constexpr(Config::REVERSE_SERVO_2)
-    {
-      servo[1].setTimerTicks((m_maxServoTimerTicks - servo2) + m_minServoTimerTicks);
-    }
-    else
-    {
-      servo[1].setTimerTicks(servo2);
-    }
-
-    if constexpr(Config::DEBUG_SERVO_OUTPUT)
-    {
-      debugServos(servo1, servo2, servo[3].getDefaultTimerTicks(), servo[4].getDefaultTimerTicks());
+      if constexpr (Config::DEBUG_OUTPUT)
+      {
+          const uint64_t nowTime = millis();
+          if (debugUpdateTime <= nowTime)
+          {
+              int j = 0;
+              for (uint32_t v : values) 
+              {
+                  Serial.printf("%s %d: %u\n", label, j++, v);
+              }
+              debugUpdateTime = nowTime + 100U;
+          }
     }
   }
 
   /**
-    * @brief  Writes the demanded value/position to the servos.
-    * @param  
-    */
-  void writeServos(const uint32_t servo1, const uint32_t servo2, const uint32_t servo3, const uint32_t servo4)
+   * @brief  Writes values to motors.
+   */
+  void writeMotors(std::initializer_list<uint32_t> values)
   {
-    if constexpr(Config::REVERSE_SERVO_1)
-    {
-      servo[0].setTimerTicks((m_maxServoTimerTicks - servo1) + m_minServoTimerTicks);
-    }
-    else
-    {
-      servo[0].setTimerTicks(servo1);
-    }
-
-    if constexpr(Config::REVERSE_SERVO_2)
-    {
-      servo[1].setTimerTicks((m_maxServoTimerTicks - servo2) + m_minServoTimerTicks);
-    }
-    else
-    {
-      servo[1].setTimerTicks(servo2);
-    }
-
-    if constexpr(Config::REVERSE_SERVO_3)
-    {
-      servo[2].setTimerTicks((m_maxServoTimerTicks - servo3) + m_minServoTimerTicks);
-    }
-    else
-    {
-      servo[2].setTimerTicks(servo3);
-    }
-
-    if constexpr(Config::REVERSE_SERVO_4)
-    {
-      servo[3].setTimerTicks((m_maxServoTimerTicks - servo4) + m_minServoTimerTicks);
-    }
-    else
-    {
-      servo[3].setTimerTicks(servo4);
-    }
-
-    if constexpr(Config::DEBUG_SERVO_OUTPUT)
-    {
-      debugServos(servo1, servo2, servo3, servo4);
-    }
+      writeToOutputs(m_modelConfig.numberServos, values, "Motor");
   }
 
   /**
-    * @brief  Writes the required demanded values to the motors.
-    * @param  
-    */
-  void writeMotors(const uint32_t motor1, const uint32_t motor2)
+   * @brief  Writes values to servos.
+   */
+  void writeServos(std::initializer_list<uint32_t> values)
   {
-    motor[0].setTimerTicks(motor1);
-    motor[1].setTimerTicks(motor2);
-
-    if constexpr(Config::DEBUG_MOTOR_OUTPUT)
-    {
-      debugMotors(motor1, motor2, motor[2].getDefaultTimerTicks(), motor[3].getDefaultTimerTicks());
-    }
-  }
-
-  void writeMotors(const uint32_t motor1, const uint32_t motor2, const uint32_t motor3, const uint32_t motor4)
-  {
-    motor[0].setTimerTicks(motor1);
-    motor[1].setTimerTicks(motor2);
-    motor[2].setTimerTicks(motor3);
-    motor[3].setTimerTicks(motor4);
-
-    if constexpr(Config::DEBUG_MOTOR_OUTPUT)
-    {
-      debugMotors(motor1, motor2, motor3, motor4);
-    }
+      writeToOutputs(0, values, "Servo");
   }
 
   /**
@@ -368,7 +266,7 @@ protected:
     */
   uint32_t getDefaultMotorTicks(Actuator number)
   {
-    return motor[static_cast<uint32_t>(number)].getDefaultTimerTicks();
+    return motorAt(static_cast<uint32_t>(number)).getDefaultTimerTicks();
   }
 
   /**
@@ -377,7 +275,7 @@ protected:
     */
   uint32_t getDefaultServoTicks(Actuator number)
   {
-    return servo[static_cast<uint32_t>(number)].getDefaultTimerTicks();
+    return servoAt(static_cast<uint32_t>(number)).getDefaultTimerTicks();
   }
 
   /**
@@ -557,8 +455,7 @@ public:
   //Configure this model as PlaneFullHouse ...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -590,7 +487,7 @@ public:
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
     const uint32_t yawTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));
-    writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+    writeServos({leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks});
   }
 
   /**
@@ -615,7 +512,7 @@ public:
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t pitchTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
     const uint32_t yawTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));
-    writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+    writeServos({leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks});
   }
 
   /**
@@ -631,12 +528,12 @@ public:
       const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
       const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
       const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 
@@ -655,12 +552,12 @@ public:
       const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
       const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
       const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 };
@@ -686,8 +583,7 @@ public:
   //Configure this model as PlaneFullHouseVTail...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -718,7 +614,7 @@ public:
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t pitchTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo3 * getTrimMultiplier()));
     const uint32_t yawTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo4 * getTrimMultiplier()));
-    writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+    writeServos({leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks});
   }
 
   /**
@@ -744,7 +640,7 @@ public:
     const uint32_t rightAileronTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusFlap) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t pitchTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(yawMinusPitch) + (trim->servo3 * getTrimMultiplier()));
     const uint32_t yawTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(yawPlusPitch) + (trim->servo4 * getTrimMultiplier()));
-    writeServos(leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks);
+    writeServos({leftAileronTicks, rightAileronTicks, pitchTicks, yawTicks});
   }
 
   /**
@@ -760,12 +656,12 @@ public:
       const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
       const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
       const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 
@@ -784,12 +680,12 @@ public:
       const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
       const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
       const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 };
@@ -814,8 +710,7 @@ public:
   //Configure this model as PlaneAdvancedRudderElevator...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -836,7 +731,7 @@ public:
     const int32_t rollPlusYaw = constrain(demands->roll + demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
     const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusYaw) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t elevatorTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-    writeServos(rudderTicks, elevatorTicks);
+    writeServos({rudderTicks, elevatorTicks});
   }
 
   /**
@@ -850,7 +745,7 @@ public:
     const int32_t rollPlusYaw = constrain(demands->roll + demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
     const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusYaw) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t elevatorTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-    writeServos(rudderTicks, elevatorTicks);
+    writeServos({rudderTicks, elevatorTicks});
   }
 
   /**
@@ -866,12 +761,12 @@ public:
       const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
       const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
       const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 
@@ -890,12 +785,12 @@ public:
       const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
       const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
       const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 };
@@ -919,8 +814,7 @@ public:
   //Configure this model as PlaneRudderElevator...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -939,7 +833,7 @@ public:
   {
     const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->roll) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t elevatorTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-    writeServos(rudderTicks, elevatorTicks);
+    writeServos({rudderTicks, elevatorTicks});
   }
 
   /**
@@ -951,7 +845,7 @@ public:
   {
     const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->roll) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t elevatorTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->pitch) + (trim->servo2 * getTrimMultiplier()));
-    writeServos(rudderTicks, elevatorTicks);
+    writeServos({rudderTicks, elevatorTicks});
   }
 
   /**
@@ -967,12 +861,12 @@ public:
       const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
       const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
       const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 
@@ -991,12 +885,12 @@ public:
       const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
       const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
       const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 };
@@ -1019,8 +913,7 @@ public:
   //Configure this model as PlaneVTail...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1042,7 +935,7 @@ public:
     const int32_t rollMinusPitch = constrain(demands->roll - demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
     const uint32_t leftTaileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightTaileronTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
-    writeServos(leftTaileronTicks, rightTaileronTicks);
+    writeServos({leftTaileronTicks, rightTaileronTicks});
   }
 
   /**
@@ -1057,7 +950,7 @@ public:
     const int32_t rollMinusPitch = constrain(demands->roll - demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
     const uint32_t leftElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
-    writeServos(leftElevonTicks, rightElevonTicks);
+    writeServos({leftElevonTicks, rightElevonTicks});
   }
 
   /**
@@ -1073,12 +966,12 @@ public:
       const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
       const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
       const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 
@@ -1097,12 +990,12 @@ public:
       const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
       const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
       const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 };
@@ -1127,8 +1020,7 @@ public:
   //Configure this model as flying wing...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1151,7 +1043,7 @@ public:
     const uint32_t leftElevonTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightElevonTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo3 * getTrimMultiplier()));
-    writeServos(leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4));
+    writeServos({leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4)});
   }
 
   /**
@@ -1167,7 +1059,7 @@ public:
     const uint32_t leftElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw) + (trim->servo3 * getTrimMultiplier()));
-    writeServos(leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4));
+    writeServos({leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4)});
   }
 
   /**
@@ -1183,12 +1075,12 @@ public:
       const int32_t throttleMinusYaw = constrain(demands->throttle - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
       const uint32_t motor1 = mapNormalisedMotorToTimerTicks(throttlePlusYaw);
       const uint32_t motor2 = mapNormalisedMotorToTimerTicks(throttleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 
@@ -1207,12 +1099,12 @@ public:
       const int32_t modThrottleMinusYaw = constrain(modifiedThrottle - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
       const uint32_t motor1 = mapRateMotorToTimerTicks(modThrottlePlusYaw);
       const uint32_t motor2 = mapRateMotorToTimerTicks(modThrottleMinusYaw);
-      writeMotors(motor1, motor2);
+      writeMotors({motor1, motor2});
     }
     else
     {
       const uint32_t motor = mapNormalisedMotorToTimerTicks(demands->throttle);
-      writeMotors(motor, motor);
+      writeMotors({motor, motor});
     }
   }
 };
@@ -1243,8 +1135,7 @@ public:
   //Configure this model as a quadcopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
-          {0U, 0U, 0U, 0U},
+          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1261,7 +1152,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
+    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1285,7 +1176,7 @@ public:
     motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
     motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
 
-    writeMotors(motor1, motor2, motor3, motor4);
+    writeMotors({motor1, motor2, motor3, motor4});
   };
 };
 
@@ -1311,8 +1202,7 @@ public:
   //Configure this model as a quadcopter +...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
-          {0U, 0U, 0U, 0U},
+          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1329,7 +1219,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
+    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1353,7 +1243,7 @@ public:
     motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
     motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
 
-    writeMotors(motor1, motor2, motor3, motor4);
+    writeMotors({motor1, motor2, motor3, motor4});
   };
 };
 
@@ -1375,8 +1265,7 @@ public:
   //Configure this model as chinook...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1393,7 +1282,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
+    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1413,7 +1302,7 @@ public:
     motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
     motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
 
-    writeMotors(motor1, motor2);
+    writeMotors({motor1, motor2});
   };
 
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
@@ -1423,7 +1312,7 @@ public:
     const int32_t rollMinusYaw = constrain(demands->roll  - demands->yaw, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
     const uint32_t servo1 = mapNormalisedServoToTimerTicks(rollPlusYaw) + (trim->servo1 * getTrimMultiplier());
     const uint32_t servo2 = mapNormalisedServoToTimerTicks(rollMinusYaw) + (trim->servo2 * getTrimMultiplier());
-    writeServos(servo1, servo2);
+    writeServos({servo1, servo2});
   }
 
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
@@ -1433,7 +1322,7 @@ public:
     const int32_t rollMinusYaw = constrain(demands->roll  - demands->yaw, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
     const uint32_t servo1 = mapRateServoToTimerTicks(rollPlusYaw) + (trim->servo1 * getTrimMultiplier());
     const uint32_t servo2 = mapRateServoToTimerTicks(rollMinusYaw) + (trim->servo2 * getTrimMultiplier());
-    writeServos(servo1, servo2);
+    writeServos({servo1, servo2});
   }
 };
 
@@ -1455,8 +1344,7 @@ public:
   //Configure this model as a bicopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1473,7 +1361,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
+    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1492,7 +1380,7 @@ public:
     motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
     motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
 
-    writeMotors(motor1, motor2);
+    writeMotors({motor1, motor2});
   };
 
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
@@ -1502,7 +1390,7 @@ public:
     const int32_t yawMinusPitch = constrain(demands->yaw  - demands->pitch, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED);
     const uint32_t servo1 = mapNormalisedServoToTimerTicks(yawPlusPitch) + (trim->servo1 * getTrimMultiplier());
     const uint32_t servo2 = mapNormalisedServoToTimerTicks(yawMinusPitch) + (trim->servo2 * getTrimMultiplier());
-    writeServos(servo1, servo2);
+    writeServos({servo1, servo2});
   }
 
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
@@ -1512,7 +1400,7 @@ public:
     const int32_t yawMinusPitch = constrain(demands->yaw  - demands->pitch, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
     const uint32_t servo1 = mapRateServoToTimerTicks(yawPlusPitch) + (trim->servo1 * getTrimMultiplier());
     const uint32_t servo2 = mapRateServoToTimerTicks(yawMinusPitch) + (trim->servo2 * getTrimMultiplier());
-    writeServos(servo1, servo2);
+    writeServos({servo1, servo2});
   }
 };
 
@@ -1536,8 +1424,7 @@ public:
   //Configure this model as a tricopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN},
-          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1554,7 +1441,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4));
+    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1579,21 +1466,21 @@ public:
     motor3 = constrain(motor3, m_minThrottle, getMaxMotorTicks());
     motor4 = constrain(motor4, m_minThrottle, getMaxMotorTicks());
 
-    writeMotors(motor1, motor2, motor3, motor4);
+    writeMotors({motor1, motor2, motor3, motor4});
   };
 
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
     //When disarmed
     const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo1 * getTrimMultiplier());
-    writeServos(servo1, getDefaultServoTicks(Actuator::CHANNEL_2));
+    writeServos({servo1, getDefaultServoTicks(Actuator::CHANNEL_2)});
   }
 
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
     //When armed
     const uint32_t servo1 = mapRateServoToTimerTicks(demands->yaw) + (trim->servo1 * getTrimMultiplier());
-    writeServos(servo1, getDefaultServoTicks(Actuator::CHANNEL_2));
+    writeServos({servo1, getDefaultServoTicks(Actuator::CHANNEL_2)});
   }
 };
 
@@ -1616,8 +1503,7 @@ public:
   //Configure this model as a dualcopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, 0U, 0U},
+          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1634,7 +1520,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
+    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1653,7 +1539,7 @@ public:
     motor1 = constrain(motor1, m_minThrottle, getMaxMotorTicks());
     motor2 = constrain(motor2, m_minThrottle, getMaxMotorTicks());
 
-    writeMotors(motor1, motor2);
+    writeMotors({motor1, motor2});
   };
 
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
@@ -1661,7 +1547,7 @@ public:
     //When disarmed
     const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->pitch) + (trim->servo1 * getTrimMultiplier());
     const uint32_t servo2 = mapNormalisedServoToTimerTicks(demands->roll) + (trim->servo2 * getTrimMultiplier());
-    writeServos(servo1, servo2);
+    writeServos({servo1, servo2});
   }
 
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
@@ -1669,20 +1555,20 @@ public:
     //When armed
     const uint32_t servo1 = mapRateServoToTimerTicks(demands->pitch) + (trim->servo1 * getTrimMultiplier());
     const uint32_t servo2 = mapRateServoToTimerTicks(demands->roll) + (trim->servo2 * getTrimMultiplier());
-    writeServos(servo1, servo2);
+    writeServos({servo1, servo2});
   }
 };
 
 
 /**
 * @brief    Singlecopter class. 
-* @note     4 servos arranged with 90 degree speration.
+* @note     4 servos arranged with 90 degree separation.
 * @note     Channel output map: servo 1, servo 2, servo 3, servo 4, motor 1, LEDc unused
 */
 class SingleCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
+  static constexpr uint8_t NUMBER_MOTORS  = 2U; //Purposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
   static constexpr uint8_t NUMBER_SERVOS  = 4U;
   static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
   static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2; //Puposely defining 2 as LEDc channels are pairs. We need 2 motor pairs then lower refresh rate servos.
@@ -1694,8 +1580,7 @@ public:
   //Configure this model as a singlecopter...
   static constexpr ModelBase::ModelConfig m_modelConfig =
       {
-          {MOTOR_1_PIN, MOTOR_2_PIN, 0U, 0U},
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN},
+          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
           Config::MOTOR_REFRESH_RATE,
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
@@ -1708,7 +1593,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors(getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2));
+    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1720,7 +1605,7 @@ public:
 
     //Set control mix and convert demands to timer ticks
     uint32_t motor1 = mapRateMotorToTimerTicks(throttle);
-    writeMotors(motor1, getDefaultMotorTicks(Actuator::CHANNEL_2));
+    writeMotors({motor1, getDefaultMotorTicks(Actuator::CHANNEL_2)});
   };
 
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
@@ -1732,7 +1617,7 @@ public:
     const uint32_t servo2 = mapNormalisedServoToTimerTicks(pitchPlusYaw) + (trim->servo2 * getTrimMultiplier());
     const uint32_t servo3 = mapNormalisedServoToTimerTicks(rollPlusYaw)  + (trim->servo3 * getTrimMultiplier());
     const uint32_t servo4 = mapNormalisedServoToTimerTicks(pitchPlusYaw) + (trim->servo4 * getTrimMultiplier());    
-    writeServos(servo1, servo2, servo3, servo4);
+    writeServos({servo1, servo2, servo3, servo4});
   }
 
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
@@ -1744,6 +1629,6 @@ public:
     const uint32_t servo2 = mapRateServoToTimerTicks(pitchPlusYaw) + (trim->servo2 * getTrimMultiplier());
     const uint32_t servo3 = mapRateServoToTimerTicks(rollPlusYaw)  + (trim->servo3 * getTrimMultiplier());
     const uint32_t servo4 = mapRateServoToTimerTicks(pitchPlusYaw) + (trim->servo4 * getTrimMultiplier());    
-    writeServos(servo1, servo2, servo3, servo4);
+    writeServos({servo1, servo2, servo3, servo4});
   }
 };

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -471,7 +471,7 @@ public:
     */
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
-    int32_t negativeFlap = 0U;
+    int32_t negativeFlap = 0;
 
     if constexpr(Config::USE_FLAPS)
     {
@@ -496,12 +496,12 @@ public:
     */
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
-    int32_t negativeFlap = 0U;
+    int32_t negativeFlap = 0;
 
     if constexpr(Config::USE_FLAPS)
     {
       //Loss of precision in modifying flaps, but as its flaps we do not care.
-      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0U, PIDF::PIDF_MAX_LIMIT);
+      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0, PIDF::PIDF_MAX_LIMIT);
     }
 
     // constraint add to prevent overflow
@@ -599,7 +599,7 @@ public:
     */
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
-    int32_t negativeFlap = 0U;
+    int32_t negativeFlap = 0;
 
     if constexpr(Config::USE_FLAPS)
     {
@@ -623,12 +623,12 @@ public:
     */
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
-    int32_t negativeFlap = 0U;
+    int32_t negativeFlap = 0;
 
     if constexpr(Config::USE_FLAPS)
     {
       //Loss of precision in modifying flaps, but as its flaps we do not care.
-      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0U, PIDF::PIDF_MAX_LIMIT);
+      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0, PIDF::PIDF_MAX_LIMIT);
     }
     // constraint add to prevent overflow
     const int32_t rollMinusFlap = constrain(demands->roll - negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -151,8 +151,6 @@ private:
   int32_t m_maxServoTimerTicks;
   int32_t m_minMotorTimerTicks;
   int32_t m_maxMotorTimerTicks;
-  uint64_t m_motorDebugUpdateTime = 0U;
-  uint64_t m_servoDebugUpdateTime = 0U;
 
   //Objects
   LedcServo outputs[LedcServo::MAX_LEDC_CHANNELS];

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -61,7 +61,8 @@ public:
     assert(m_totalOutputs <= LedcServo::MAX_LEDC_CHANNELS);
     // limit on timer numbers is satisfied as we admit only two refresh frequencies
 
-    for (int i = 0; i < m_totalOutputs; i++) {
+    for (uint8_t i = 0U; i < m_totalOutputs; i++)
+    {
         bool isServo = i < m_modelConfig.numberServos;
         outputs[i] = LedcServo(
             m_modelConfig.outputPins[i],
@@ -85,23 +86,23 @@ public:
     */
   virtual void begin()
   {
-    for (uint8_t i=0; i<m_totalOutputs; i++)
+    for (uint8_t i=0U; i<m_totalOutputs; i++)
     {
       outputs[i].begin();
     }
 
     if constexpr(Config::CALIBRATE_ESC)
     {
-      for (uint8_t i=0; i<m_modelConfig.numberMotors; i++)
+      for (uint8_t i=0U; i<m_modelConfig.numberMotors; i++)
       {
-        motorAt(i).setTimerTicks(motorAt(0).getMaxTimerTicks());
+        motorAt(i).setTimerTicks(motorAt(i).getMaxTimerTicks());
       }
 
       delay(LedcServo::CALIBRATE_ESC_DELAY);
 
-      for (uint8_t i=0; i<m_modelConfig.numberMotors; i++)
+      for (uint8_t i=0U; i<m_modelConfig.numberMotors; i++)
       {
-        motorAt(i).setTimerTicks(motorAt(0).getMinTimerTicks());
+        motorAt(i).setTimerTicks(motorAt(i).getMinTimerTicks());
       }
 
       Serial.println("Calibration complete. Disable CALIBRATE_ESC setting in Config.hpp.");
@@ -185,7 +186,7 @@ protected:
   void writeToOutputs(uint8_t startIndex, std::initializer_list<uint32_t> values, const char* label)
   {
       static uint64_t debugUpdateTime = 0U;
-      int i = 0;
+      uint8_t i = 0U;
       for (uint32_t v : values)
       {
           outputs[startIndex + i++].setTimerTicks(v);
@@ -196,7 +197,7 @@ protected:
           const uint64_t nowTime = millis();
           if (debugUpdateTime <= nowTime)
           {
-              int j = 0;
+              uint8_t j = 0U;
               for (uint32_t v : values) 
               {
                   Serial.printf("%s %d: %u\n", label, j++, v);
@@ -219,7 +220,7 @@ protected:
    */
   void writeServos(std::initializer_list<uint32_t> values)
   {
-      writeToOutputs(0, values, "Servo");
+      writeToOutputs(0U, values, "Servo");
   }
 
   /**
@@ -470,7 +471,7 @@ public:
     */
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
-    int32_t negativeFlap = 0;
+    int32_t negativeFlap = 0U;
 
     if constexpr(Config::USE_FLAPS)
     {
@@ -495,12 +496,12 @@ public:
     */
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
-    int32_t negativeFlap = 0;
+    int32_t negativeFlap = 0U;
 
     if constexpr(Config::USE_FLAPS)
     {
       //Loss of precision in modifying flaps, but as its flaps we do not care.
-      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0, PIDF::PIDF_MAX_LIMIT);
+      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0U, PIDF::PIDF_MAX_LIMIT);
     }
 
     // constraint add to prevent overflow
@@ -598,7 +599,7 @@ public:
     */
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
-    int32_t negativeFlap = 0;
+    int32_t negativeFlap = 0U;
 
     if constexpr(Config::USE_FLAPS)
     {
@@ -622,12 +623,12 @@ public:
     */
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
-    int32_t negativeFlap = 0;
+    int32_t negativeFlap = 0U;
 
     if constexpr(Config::USE_FLAPS)
     {
       //Loss of precision in modifying flaps, but as its flaps we do not care.
-      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0, PIDF::PIDF_MAX_LIMIT);
+      negativeFlap = map32(demands->flaps, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, 0U, PIDF::PIDF_MAX_LIMIT);
     }
     // constraint add to prevent overflow
     const int32_t rollMinusFlap = constrain(demands->roll - negativeFlap, -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -49,6 +49,7 @@ public:
     LedcServo::RefreshRate servoRefresh;
     uint8_t numberMotors;
     uint8_t numberServos;
+    bool reverseOutputs[LedcServo::MAX_LEDC_CHANNELS];
   };
 
   ModelBase(ModelConfig modelConfig) 
@@ -68,8 +69,8 @@ public:
             m_modelConfig.outputPins[i],
             isServo ? m_modelConfig.servoRefresh : m_modelConfig.motorRefresh,
             isServo ? LedcServo::MID_MICRO_SECONDS : LedcServo::MIN_MICRO_SECONDS,
-            Config::REVERSE_OUTPUT[i],
-            Config::EXTEND_SERVO_TRAVEL_RANGE
+            Config::EXTEND_SERVO_TRAVEL_RANGE,
+            m_modelConfig.reverseOutputs[i]
         );
     }
     // Max/Min Timer ticks are calulated during construction of LedcServo objects
@@ -459,6 +460,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   PlaneFullHouse() : ModelBase(m_modelConfig){};
@@ -587,6 +590,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   PlaneFullHouseVTail() : ModelBase(m_modelConfig){};
@@ -714,6 +719,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   PlaneAdvancedRudderElevator() : ModelBase(m_modelConfig){};
@@ -818,6 +825,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   PlaneRudderElevator() : ModelBase(m_modelConfig){};
@@ -917,6 +926,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   PlaneVTail() : ModelBase(m_modelConfig){};
@@ -1024,6 +1035,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   PlaneFlyingWing() : ModelBase(m_modelConfig){};
@@ -1139,6 +1152,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   QuadXCopter() : ModelBase(m_modelConfig)
@@ -1206,6 +1221,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   QuadPlusCopter() : ModelBase(m_modelConfig)
@@ -1269,6 +1286,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   ChinookCopter() : ModelBase(m_modelConfig)
@@ -1348,6 +1367,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   BiCopter() : ModelBase(m_modelConfig)
@@ -1428,6 +1449,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   TriCopter() : ModelBase(m_modelConfig)
@@ -1507,6 +1530,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   DualCopter() : ModelBase(m_modelConfig)
@@ -1584,6 +1609,8 @@ public:
           Config::SERVO_REFRESH_RATE,
           NUMBER_MOTORS,
           NUMBER_SERVOS,
+          {Config::REVERSE_SERVO_1, Config::REVERSE_SERVO_2, Config::REVERSE_SERVO_3, Config::REVERSE_SERVO_4,
+           Config::REVERSE_SERVO_5, Config::REVERSE_SERVO_6, Config::REVERSE_SERVO_7, Config::REVERSE_SERVO_8},
       };
 
   SingleCopter() : ModelBase(m_modelConfig){};


### PR DESCRIPTION
Alternative method for REVERSE_OUTPUT[] array in Config.hpp. This method is more in keeping with Config.hpp layout.
It has been tested with Waveshare Zero, plane full house, with servo 2 reversed (aileron servo). Outputs have been scoped and confirmed that one aileron output was reversed while the other was not.