### PR TITLE
Config reorganisation

### DIFF
--- a/PlainFlightController/BatteryMonitor.cpp
+++ b/PlainFlightController/BatteryMonitor.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "BatteryMonitor.hpp"
+#include "InternalConfig.hpp"
 
 
 /**
@@ -74,7 +75,7 @@ BatteryMonitor::setNumberCells()
     m_numberCells = 1U;
   }
 
-  if constexpr(Config::DEBUG_BATTERY_MONITOR)
+  if constexpr(InternalConfig::DEBUG_BATTERY_MONITOR)
   {
     Serial.print("Cells detected: ");
     Serial.println(m_numberCells);

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -32,3 +32,13 @@ enum class ReceiverType : uint8_t
   SBUS,
   CRSF
 };
+
+/**
+ * @enum GyroRate
+ * @brief Supported gyro rate range.
+ */
+enum class GyroRate : uint8_t
+{
+  IS_250_DEGS_SECOND,
+  IS_500_DEGS_SECOND
+};

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+
+/**
+ * @enum ModelType
+ * @brief Defines all aircraft configurations supported by the flight controller.
+ */
+enum class ModelType : uint8_t
+{
+  PLANE_FULL_HOUSE,
+  PLANE_FULL_HOUSE_V_TAIL,
+  PLANE_ADVANCED_RUDDER_ELEVATOR,
+  PLANE_RUDDER_ELEVATOR,
+  PLANE_V_TAIL,
+  PLANE_FLYING_WING,
+  QUAD_X_COPTER,
+  QUAD_P_COPTER,
+  BI_COPTER,
+  CHINOOK_COPTER,
+  TRI_COPTER,
+  DUAL_COPTER,
+  SINGLE_COPTER
+};
+
+/**
+ * @enum ReceiverType
+ * @brief Supported radio protocols.
+ */
+enum class ReceiverType : uint8_t
+{
+  SBUS,
+  CRSF
+};

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -98,9 +98,36 @@ class Config
   // SECTION 4: OUTPUT ASSIGNMENT
   // Maps the logical servo/motor channels of the selected model type to
   // physical output pins on the board.
-  //==========================================================================
+  // - SERVO_PINS: listed in the order your servos are wired, first to last.
+  // - MOTOR_PINS: listed in the order your motors are wired, first to last.
+  // The number of entries in each array defines the servo/motor count.
+  // You must update these arrays when changing model type.
+  //
+  // Example mappings by model:
+  //   PlaneFullHouse:     4 servos, 2 motors
+  //   TriCopter:          1 servo,  3 motors
+  //   BiCopter:           2 servos, 2 motors
+  //   PlaneRudderElev:    3 servos, 1 motor
+  // See specific aircraft class in ModelTypes for further documentation
+  // =========================================================================
 
-  // Work in progress
+  // PlaneFullHouse
+  static constexpr uint8_t SERVO_PINS[] =
+  {
+      ESP32S3.OUTPUT_1,   // Servo 1 - e.g. left aileron  (PlaneFullHouse)
+      ESP32S3.OUTPUT_2,   // Servo 2 - e.g. right aileron (PlaneFullHouse)
+      ESP32S3.OUTPUT_3,   // Servo 3 - e.g. elevator      (PlaneFullHouse)
+      ESP32S3.OUTPUT_4,   // Servo 4 - e.g. rudder        (PlaneFullHouse)
+  };
+
+  static constexpr uint8_t MOTOR_PINS[] =
+  {
+      ESP32S3.OUTPUT_5,   // Motor 1
+      ESP32S3.OUTPUT_6,   // Motor 2
+  };
+
+  static constexpr uint8_t NUMBER_SERVOS = static_cast<uint8_t>(sizeof(SERVO_PINS) / sizeof(SERVO_PINS[0]));
+  static constexpr uint8_t NUMBER_MOTORS = static_cast<uint8_t>(sizeof(MOTOR_PINS) / sizeof(MOTOR_PINS[0]));
 
   // Refresh rates for servos and motors.
   // Available options (defined in LedcServo.hpp):

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -18,9 +18,22 @@
 
 /**
 * @file   Config.hpp
-* @brief  This class contains program wide parameters used to configure operation of the PlainFlightController.
-* @note   Contained within Configuration namespace to limit scope.
+* @brief  Program-wide configuration for PlainFlightController.
+*
+* SECTION GUIDE
+* -------------
+* 1. BOARD & HARDWARE       - Define the physical ESP32S3 board.
+* 2. RECEIVER               - Define the radio protocol.
+* 3. MODEL TYPE             - Define the aircraft type.
+* 4. OUTPUT ASSIGNMENT      - Define the output connection to servos/motors.
+* 5. OUTPUT CONFIGURATION   - Change during physical installation (reversal, travel).
+* 6. FEATURE FLAGS          - Enable/disable optional features for this build.
+* 7. FLIGHT CHARACTERISTICS - Adjust during maiden flight and tuning.
+* 8. MULTICOPTER SETTINGS   - Motor idle and minimum throttle, multicopter builds only.
+* 9. BUILD & DEVELOPER      - Software version, debug flags. Most users should not need to edit this section.
+*
 */
+
 #pragma once
 
 #include <cstdint>
@@ -36,99 +49,184 @@
 class Config
 {
   public:
-    //Select board choice from: XIAO, ZERO, TINY
-    static constexpr BoardConfig::Board ESP32S3 = BoardConfig::XIAO;
 
-    //Select the receiver protocol: CRSF or SBUS
-    static constexpr RxBase::ReceiverType RECEIVER_TYPE       = RxBase::ReceiverType::CRSF;
+  //==========================================================================
+  // SECTION 1: BOARD & HARDWARE SELECTION
+  // Select the physical ESP32S3 board in use.
+  // Available options (defined in BoardConfig.hpp): XIAO, ZERO, TINY
+  //==========================================================================
 
-    //Model type to instantiate, set one to true...
-    static constexpr bool PLANE_FULL_HOUSE                    = true;
-    static constexpr bool PLANE_FULL_HOUSE_V_TAIL             = false;
-    static constexpr bool PLANE_ADVANCED_RUDDER_ELEVATOR      = false;
-    static constexpr bool PLANE_RUDDER_ELEVATOR               = false;
-    static constexpr bool PLANE_V_TAIL                        = false;
-    static constexpr bool PLANE_FLYING_WING                   = false;
-    static constexpr bool QUAD_X_COPTER                       = false;
-    static constexpr bool QUAD_P_COPTER                       = false;
-    static constexpr bool BI_COPTER                           = false;
-    static constexpr bool CHINOOK_COPTER                      = false;
-    static constexpr bool TRI_COPTER                          = false;
-    static constexpr bool DUAL_COPTER                         = false;
-    static constexpr bool SINGLE_COPTER                       = false;
+  static constexpr BoardConfig::Board ESP32S3                = BoardConfig::XIAO;
 
-    //Refresh rates of servos & motors, chose from the following but ensure you servos/ESC are capable of the rate set !
-    //IS_50Hz, IS_100Hz, IS_150Hz, IS_200Hz, IS_250Hz, IS_300Hz, IS_350Hz, IS_ONESHOT125
-    //If you are using analog servos use IS_50Hz. If configuring multicopter use IS_ONESHOT125 for BLHeli ESCs.
-    //Note: higher refresh rates give better output resolution and flight controller reponse.
-    static constexpr LedcServo::RefreshRate SERVO_REFRESH_RATE = LedcServo::RefreshRate::IS_150Hz;
-    static constexpr LedcServo::RefreshRate MOTOR_REFRESH_RATE = LedcServo::RefreshRate::IS_150Hz;
 
-    //Compile time configurable parameters/features
-    static constexpr bool USE_FLAPS                           = false;  //Set to true for flaps on Tx channel 7, use 2, or 3 position switch, or rotary pot
-    static constexpr bool USE_DIFFERENTIAL_THRUST             = false;  //Set to true for fixed wing twin engine differential thrust
-    static constexpr bool USE_HEADING_HOLD                    = false;  //Set to true for gyro based heading hold on Tx channel 8
-    static constexpr bool USE_LOW_VOLTS_CUT_OFF               = false;  //Set to true to actively limit throttle upon low battery voltage
-    static constexpr bool USE_250_DEGS_SECOND                 = true;   //Set to true for 250 degs/s (when true set USE_500_DEGS_SECOND to false)
-    static constexpr bool USE_500_DEGS_SECOND                 = false;  //Set to true for 500 degs/s (when true set USE_250_DEGS_SECOND to false)
-    static constexpr bool USE_EXTERNAL_LED                    = false;
-    static constexpr bool USE_ACRO_TRAINER                    = false;  //When pitch & roll sticks centred levelled mode, else rate mode.
-    static constexpr bool REVERSE_PITCH_CORRECTIONS           = false;  //Set REVERSE_x_CORRECTIONS to true to reverse gyro/levelling corrections
-    static constexpr bool REVERSE_ROLL_CORRECTIONS            = false;
-    static constexpr bool REVERSE_YAW_CORRECTIONS             = false;
-    static constexpr bool CALIBRATE_ESC                       = false;  //Remove all propellers before calibrating ESC's !
-    static constexpr bool REVERSE_OUTPUT_1                    = false;
-    static constexpr bool REVERSE_OUTPUT_2                    = false;
-    static constexpr bool REVERSE_OUTPUT_3                    = false;
-    static constexpr bool REVERSE_OUTPUT_4                    = false;
-    static constexpr bool REVERSE_OUTPUT_5                    = false;
-    static constexpr bool REVERSE_OUTPUT_6                    = false;
-    static constexpr bool REVERSE_OUTPUT_7                    = false;
-    static constexpr bool REVERSE_OUTPUT_8                    = false;
-    static constexpr bool EXTEND_SERVO_TRAVEL_RANGE           = false;  //Servo travel 1 to 2ms when false, 0.8 to 2.2ms when true. 
-    //Auto levelled prop hanging/tail sitting mode. You need to understand flight controllers well to configure this...
-    static constexpr bool USE_PROP_HANG_MODE                  = false;  //Experimental mode that applies self levelling algorithm to pitch/yaw for prop hanging via Tx channel 9
-    static constexpr bool REVERSE_PROP_HANG_PITCH_CORRECTIONS = false;  //Should pitch corrections operate in wrong sense in prophang then set to true
-    static constexpr bool REVERSE_PROP_HANG_YAW_CORRECTIONS   = false;  //Should yaw corrections operate in wrong snese in prophang then set to true
-    static constexpr bool PROP_HANG_TAIL_SITTER_MODE          = false;  //When true for tailsitter mode where roll stick commands models yaw, and yaw stick commands models roll when prop hanging.
-    static constexpr bool PROP_HANG_REVERSE_ROLL_DEMAND       = false;  //If self leveling roll corrections are correct but Tx stick command in wrong sense then set to true.
-    static constexpr bool PROP_HANG_REVERSE_YAW_DEMAND        = false;  //If self leveling yaw corrections are correct but Tx stick command in wrong sense then set to true.
-    //Configure changes in board orientation...
-    //CAUTION - These are experimental untested changes and need fully testing for correct operation before you fly!!
-    static constexpr bool IMU_ROLLED_RIGHT_90                 = false;  //IMU is rolled to the right 90 degrees of normal orientation
-    static constexpr bool IMU_ROLLED_180                      = false;  //IMU is rolled to 180 degrees of normal orientation i.e. flipped upside down on roll axis.
+  //==========================================================================
+  // SECTION 2: RECEIVER
+  // Select the receiver protocol matching your radio system.
+  // Available options (defined in RxBase.hpp): CRSF, SBUS
+  //==========================================================================
 
-    //Acro trainer maximum recovery rate (level strength).
-    //Caution - do not exceed the set gyro degs/sec. Do not set to high for multicopters to avoid overshoot instability.
-    static constexpr float ACRO_TRAINER_LEVEL_RATE            = 90.00f; //The degrees per second recovery rate.
+  static constexpr RxBase::ReceiverType RECEIVER_TYPE        = RxBase::ReceiverType::CRSF;
 
-    //Multicopter minimum motor speed settings
-    static constexpr int32_t IDLE_UP_VALUE                    = 300;    //Motor idle speed when armed. Adjust this if idle up RPM is too low/high
-    static constexpr int32_t MIN_THROTTLE_VALUE               = 100;    //Absolute minimum motor speed to prevent motors form stopping. Adjust this if idle up RPM is too low/high
 
-    //Tx stick deadband generally 0.5% of normalised span
-    static constexpr uint32_t TX_DEADBAND_NORM                = 10U;    // Post test - renamed to align to normalised values
+  //==========================================================================
+  // SECTION 3: MODEL TYPE
+  // Set exactly ONE model type to true; all others must be false.
+  //==========================================================================
 
-    //Debug constants that will allow debug data to be compiled in
-    static constexpr bool DEBUG_RX                            = false;
-    static constexpr bool DEBUG_RC_DATA                       = false;  //Note: Disarmed and high to low throttle transition purposely resets ESP32 after Wifi, you will see this on console.
-    static constexpr bool DEBUG_LOOP_RATE                     = false;
-    static constexpr bool DEBUG_BATTERY_MONITOR               = false;
-    static constexpr bool DEBUG_MADGWICK                      = false;
-    static constexpr bool DEBUG_GYRO_CALIBRATION              = false;
-    static constexpr bool DEBUG_CONFIGURATOR                  = false;
-    static constexpr bool DEBUG_MPU6050                       = false;
-    static constexpr bool DEBUG_OUTPUT                        = false;
+  static constexpr bool PLANE_FULL_HOUSE                     = true;
+  static constexpr bool PLANE_FULL_HOUSE_V_TAIL              = false;
+  static constexpr bool PLANE_ADVANCED_RUDDER_ELEVATOR       = false;
+  static constexpr bool PLANE_RUDDER_ELEVATOR                = false;
+  static constexpr bool PLANE_V_TAIL                         = false;
+  static constexpr bool PLANE_FLYING_WING                    = false;
+  static constexpr bool QUAD_X_COPTER                        = false;
+  static constexpr bool QUAD_P_COPTER                        = false;
+  static constexpr bool BI_COPTER                            = false;
+  static constexpr bool CHINOOK_COPTER                       = false;
+  static constexpr bool TRI_COPTER                           = false;
+  static constexpr bool DUAL_COPTER                          = false;
+  static constexpr bool SINGLE_COPTER                        = false;
 
-    //USB serial
-    static constexpr uint32_t USB_BAUD                        = 500000U;
-    static constexpr HardwareSerial* const RECEIVER_UART      = &Serial0;
+  // Derived flags — do not edit. Used throughout the project to compile in/out
+  // features specific to fixed-wing or multicopter model categories.
+  // Note: if you add more model types, update both of these lines accordingly.
+  static constexpr bool MODEL_IS_FIXED_WING                  = (PLANE_FULL_HOUSE || PLANE_FULL_HOUSE_V_TAIL || PLANE_ADVANCED_RUDDER_ELEVATOR || PLANE_RUDDER_ELEVATOR || PLANE_V_TAIL || PLANE_FLYING_WING);
+  static constexpr bool MODEL_IS_MULTICOPTER                 = (QUAD_X_COPTER || QUAD_P_COPTER || BI_COPTER || CHINOOK_COPTER || TRI_COPTER || DUAL_COPTER || SINGLE_COPTER);
 
-    //PlainFlightController build
-    static constexpr char SOFTWARE_VERSION[]                  = "V2.x.x";
 
-    //Used to compile in/out features of different model categories
-    //Note: if you add more model types make sure you add to these next 2 lines.
-    static constexpr bool MODEL_IS_FIXED_WING                 = (PLANE_FULL_HOUSE || PLANE_FULL_HOUSE_V_TAIL || PLANE_ADVANCED_RUDDER_ELEVATOR || PLANE_RUDDER_ELEVATOR || PLANE_V_TAIL || PLANE_FLYING_WING);
-    static constexpr bool MODEL_IS_MULTICOPTER                = (QUAD_X_COPTER || QUAD_P_COPTER || BI_COPTER ||CHINOOK_COPTER || TRI_COPTER || DUAL_COPTER || SINGLE_COPTER);
+  //==========================================================================
+  // SECTION 4: OUTPUT ASSIGNMENT
+  // Maps the logical servo/motor channels of the selected model type to
+  // physical output pins on the board.
+  //==========================================================================
+
+  // Work in progress
+
+  // Refresh rates for servos and motors.
+  // Available options (defined in LedcServo.hpp):
+  //   IS_50Hz, IS_100Hz, IS_150Hz, IS_200Hz, IS_250Hz, IS_300Hz, IS_350Hz, IS_ONESHOT125
+  // Use IS_50Hz for analogue servos.
+  // Use IS_ONESHOT125 for multicopter builds with BLHeli ESCs.
+  // Note: higher refresh rates give better output resolution and flight controller response.
+  // CAUTION: ensure your servos and ESCs are rated for the refresh rate you select.
+  static constexpr LedcServo::RefreshRate SERVO_REFRESH_RATE = LedcServo::RefreshRate::IS_150Hz;
+  static constexpr LedcServo::RefreshRate MOTOR_REFRESH_RATE = LedcServo::RefreshRate::IS_150Hz;
+
+
+  //==========================================================================
+  // SECTION 5: OUTPUT CONFIGURATION
+  // Set during physical installation to match your wiring and servo orientation.
+  //==========================================================================
+
+  // Reverse individual outputs. Set the corresponding channel to true if a
+  // servo moves in the wrong direction.
+  static constexpr bool REVERSE_OUTPUT_1                     = false;
+  static constexpr bool REVERSE_OUTPUT_2                     = false;
+  static constexpr bool REVERSE_OUTPUT_3                     = false;
+  static constexpr bool REVERSE_OUTPUT_4                     = false;
+  static constexpr bool REVERSE_OUTPUT_5                     = false;
+  static constexpr bool REVERSE_OUTPUT_6                     = false;
+  static constexpr bool REVERSE_OUTPUT_7                     = false;
+  static constexpr bool REVERSE_OUTPUT_8                     = false;
+
+  // Extend servo travel beyond the standard 1.0–2.0 ms pulse range.
+  // When true, travel is extended to 0.8–2.2 ms.
+  static constexpr bool EXTEND_SERVO_TRAVEL_RANGE            = false;
+
+  // Set to true to actively run the ESC calibration routine on next boot.
+  // CAUTION: Remove all propellers before calibrating ESCs!
+  // Set back to false after calibration is complete.
+  static constexpr bool CALIBRATE_ESC                        = false;
+
+
+  //==========================================================================
+  // SECTION 6: FEATURE FLAGS
+  // Enable or disable optional features for this aircraft build.
+  //==========================================================================
+
+  static constexpr bool USE_FLAPS                            = false;  // Flaps on Tx channel 7; use 2, 3 position switch or rotary pot.
+  static constexpr bool USE_DIFFERENTIAL_THRUST              = false;  // Fixed-wing twin engine differential thrust.
+  static constexpr bool USE_HEADING_HOLD                     = false;  // Gyro-based heading hold on Tx channel 8.
+  static constexpr bool USE_LOW_VOLTS_CUT_OFF                = false;  // Limit throttle upon low battery voltage.
+  static constexpr bool USE_EXTERNAL_LED                     = false;  // Enable external LED output.
+  static constexpr bool USE_ACRO_TRAINER                     = false;  // Level mode when pitch & roll sticks centred, rate mode otherwise.
+
+  // Prop hang / tail-sitter mode (experimental).
+  // You need to understand flight controllers well to configure this.
+  static constexpr bool USE_PROP_HANG_MODE                   = false;  // Self-levelling pitch/yaw for prop hanging via Tx channel 9.
+  static constexpr bool PROP_HANG_TAIL_SITTER_MODE           = false;  // Roll stick commands yaw, yaw stick commands roll when prop hanging.
+
+
+  //==========================================================================
+  // SECTION 7: FLIGHT CHARACTERISTICS
+  // Adjust these during maiden flight and subsequent tuning.
+  //==========================================================================
+
+  // Gyro rate range. Set exactly one to true.
+  static constexpr bool USE_250_DEGS_SECOND                  = true;   // 250 degrees/second gyro rate.
+  static constexpr bool USE_500_DEGS_SECOND                  = false;  // 500 degrees/second gyro rate.
+
+  // Gyro correction direction. Set to true to reverse the correction sense on
+  // the corresponding axis.
+  static constexpr bool REVERSE_PITCH_CORRECTIONS            = false;
+  static constexpr bool REVERSE_ROLL_CORRECTIONS             = false;
+  static constexpr bool REVERSE_YAW_CORRECTIONS              = false;
+
+  // Acro trainer recovery rate (degrees/second).
+  // Caution: do not exceed the gyro rate set above.
+  // Do not set too high on multicopters to avoid overshoot instability.
+  static constexpr float ACRO_TRAINER_LEVEL_RATE             = 90.00f;
+
+  // Prop hang correction direction. Adjust if corrections operate in the wrong sense.
+  static constexpr bool REVERSE_PROP_HANG_PITCH_CORRECTIONS  = false;
+  static constexpr bool REVERSE_PROP_HANG_YAW_CORRECTIONS    = false;
+  static constexpr bool PROP_HANG_REVERSE_ROLL_DEMAND        = false;  // Set true if Tx roll stick demand is in the wrong sense in prop-hang mode.
+  static constexpr bool PROP_HANG_REVERSE_YAW_DEMAND         = false;  // Set true if Tx yaw stick demand is in the wrong sense in prop-hang mode.
+
+  // IMU board orientation corrections.
+  // CAUTION: These are experimental and untested. Verify correct operation before flight.
+  static constexpr bool IMU_ROLLED_RIGHT_90                  = false;  // IMU is rolled 90 degrees to the right of normal orientation.
+  static constexpr bool IMU_ROLLED_180                       = false;  // IMU is flipped 180 degrees on the roll axis (upside down).
+
+  // Transmitter stick deadband (normalised units, approximately 0.5% of normalised span).
+  static constexpr uint32_t TX_DEADBAND_NORM                 = 10U;
+
+
+  //==========================================================================
+  // SECTION 8: MULTICOPTER MOTOR SETTINGS
+  // Relevant for multicopter builds only.
+  //==========================================================================
+
+  // Motor idle speed when armed. Increase if motors stop mid-flight at low throttle;
+  // decrease if idle RPM is too high.
+  static constexpr int32_t IDLE_UP_VALUE                     = 300;
+
+  // Absolute minimum motor command to prevent motors stopping under PID authority.
+  // Adjust if minimum RPM is too low or too high.
+  static constexpr int32_t MIN_THROTTLE_VALUE                = 100;
+
+
+  //==========================================================================
+  // SECTION 9: BUILD & DEVELOPER
+  // Most users should not normally need to edit this section.
+  //==========================================================================
+
+  // PlainFlightController firmware version string.
+  static constexpr char SOFTWARE_VERSION[]                   = "V2.x.x";
+
+  // USB serial baud rate and receiver UART port.
+  static constexpr uint32_t USB_BAUD                         = 500000U;
+  static constexpr HardwareSerial* const RECEIVER_UART       = &Serial0;
+
+  // Debug output flags. Setting any of these to true will compile in diagnostic
+  // serial output for the corresponding subsystem. Leave all false for normal use.
+  static constexpr bool DEBUG_RX                             = false;
+  static constexpr bool DEBUG_RC_DATA                        = false;  // Note: disarmed high-to-low throttle transition intentionally resets ESP32 after WiFi.
+  static constexpr bool DEBUG_LOOP_RATE                      = false;
+  static constexpr bool DEBUG_BATTERY_MONITOR                = false;
+  static constexpr bool DEBUG_MADGWICK                       = false;
+  static constexpr bool DEBUG_GYRO_CALIBRATION               = false;
+  static constexpr bool DEBUG_CONFIGURATOR                   = false;
+  static constexpr bool DEBUG_MPU6050                        = false;
+  static constexpr bool DEBUG_OUTPUT                         = false;
 };

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -30,7 +30,6 @@
 * 6. FEATURE FLAGS          - Enable/disable optional features for this build.
 * 7. FLIGHT CHARACTERISTICS - Adjust during maiden flight and tuning.
 * 8. MULTICOPTER SETTINGS   - Motor idle and minimum throttle, multicopter builds only.
-* 9. BUILD & DEVELOPER      - Software version, debug flags. Most users should not need to edit this section.
 *
 */
 
@@ -40,7 +39,7 @@
 #include <HardwareSerial.h>
 #include <Arduino.h>
 #include "LedcServo.hpp"
-#include "RxBase.hpp"
+#include "CommonTypes.hpp"
 #include "BoardConfig.hpp"
 
 /**
@@ -62,37 +61,18 @@ class Config
   //==========================================================================
   // SECTION 2: RECEIVER
   // Select the receiver protocol matching your radio system.
-  // Available options (defined in RxBase.hpp): CRSF, SBUS
+  // Available options (defined in CommonTypes.hpp): CRSF, SBUS
   //==========================================================================
 
-  static constexpr RxBase::ReceiverType RECEIVER_TYPE        = RxBase::ReceiverType::CRSF;
+  static constexpr ReceiverType RECEIVER_TYPE                = ReceiverType::CRSF;
 
 
   //==========================================================================
   // SECTION 3: MODEL TYPE
-  // Set exactly ONE model type to true; all others must be false.
+  // Select exactly ONE model type.
+  // Available options (defined in CommonTypes.hpp)
   //==========================================================================
-
-  static constexpr bool PLANE_FULL_HOUSE                     = true;
-  static constexpr bool PLANE_FULL_HOUSE_V_TAIL              = false;
-  static constexpr bool PLANE_ADVANCED_RUDDER_ELEVATOR       = false;
-  static constexpr bool PLANE_RUDDER_ELEVATOR                = false;
-  static constexpr bool PLANE_V_TAIL                         = false;
-  static constexpr bool PLANE_FLYING_WING                    = false;
-  static constexpr bool QUAD_X_COPTER                        = false;
-  static constexpr bool QUAD_P_COPTER                        = false;
-  static constexpr bool BI_COPTER                            = false;
-  static constexpr bool CHINOOK_COPTER                       = false;
-  static constexpr bool TRI_COPTER                           = false;
-  static constexpr bool DUAL_COPTER                          = false;
-  static constexpr bool SINGLE_COPTER                        = false;
-
-  // Derived flags — do not edit. Used throughout the project to compile in/out
-  // features specific to fixed-wing or multicopter model categories.
-  // Note: if you add more model types, update both of these lines accordingly.
-  static constexpr bool MODEL_IS_FIXED_WING                  = (PLANE_FULL_HOUSE || PLANE_FULL_HOUSE_V_TAIL || PLANE_ADVANCED_RUDDER_ELEVATOR || PLANE_RUDDER_ELEVATOR || PLANE_V_TAIL || PLANE_FLYING_WING);
-  static constexpr bool MODEL_IS_MULTICOPTER                 = (QUAD_X_COPTER || QUAD_P_COPTER || BI_COPTER || CHINOOK_COPTER || TRI_COPTER || DUAL_COPTER || SINGLE_COPTER);
-
+  static constexpr ModelType MODEL_TYPE                      = ModelType::PLANE_FULL_HOUSE;
 
   //==========================================================================
   // SECTION 4: OUTPUT ASSIGNMENT
@@ -125,9 +105,6 @@ class Config
       ESP32S3.OUTPUT_5,   // Motor 1
       ESP32S3.OUTPUT_6,   // Motor 2
   };
-
-  static constexpr uint8_t NUMBER_SERVOS = static_cast<uint8_t>(sizeof(SERVO_PINS) / sizeof(SERVO_PINS[0]));
-  static constexpr uint8_t NUMBER_MOTORS = static_cast<uint8_t>(sizeof(MOTOR_PINS) / sizeof(MOTOR_PINS[0]));
 
   // Refresh rates for servos and motors.
   // Available options (defined in LedcServo.hpp):
@@ -232,28 +209,4 @@ class Config
   // Adjust if minimum RPM is too low or too high.
   static constexpr int32_t MIN_THROTTLE_VALUE                = 100;
 
-
-  //==========================================================================
-  // SECTION 9: BUILD & DEVELOPER
-  // Most users should not normally need to edit this section.
-  //==========================================================================
-
-  // PlainFlightController firmware version string.
-  static constexpr char SOFTWARE_VERSION[]                   = "V2.x.x";
-
-  // USB serial baud rate and receiver UART port.
-  static constexpr uint32_t USB_BAUD                         = 500000U;
-  static constexpr HardwareSerial* const RECEIVER_UART       = &Serial0;
-
-  // Debug output flags. Setting any of these to true will compile in diagnostic
-  // serial output for the corresponding subsystem. Leave all false for normal use.
-  static constexpr bool DEBUG_RX                             = false;
-  static constexpr bool DEBUG_RC_DATA                        = false;  // Note: disarmed high-to-low throttle transition intentionally resets ESP32 after WiFi.
-  static constexpr bool DEBUG_LOOP_RATE                      = false;
-  static constexpr bool DEBUG_BATTERY_MONITOR                = false;
-  static constexpr bool DEBUG_MADGWICK                       = false;
-  static constexpr bool DEBUG_GYRO_CALIBRATION               = false;
-  static constexpr bool DEBUG_CONFIGURATOR                   = false;
-  static constexpr bool DEBUG_MPU6050                        = false;
-  static constexpr bool DEBUG_OUTPUT                         = false;
 };

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -181,11 +181,11 @@ class Config
   //==========================================================================
   // SECTION 7: FLIGHT CHARACTERISTICS
   // Adjust these during maiden flight and subsequent tuning.
+  // Available options (defined in CommonTypes.hpp) IS_250_DEG_SECOND, IS_500_DEG_SECOND
   //==========================================================================
 
   // Gyro rate range. Set exactly one to true.
-  static constexpr bool USE_250_DEGS_SECOND                  = true;   // 250 degrees/second gyro rate.
-  static constexpr bool USE_500_DEGS_SECOND                  = false;  // 500 degrees/second gyro rate.
+  static constexpr GyroRate GYRO_RATE                            = GyroRate::IS_250_DEGS_SECOND;
 
   // Gyro correction direction. Set to true to reverse the correction sense on
   // the corresponding axis.

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -70,8 +70,11 @@ class Config
   //==========================================================================
   // SECTION 3: MODEL TYPE
   // Select exactly ONE model type.
-  // Available options (defined in CommonTypes.hpp)
+  // Available options (defined in CommonTypes.hpp) PLANE_FULL_HOUSE, PLANE_FULL_HOUSE_V_TAIL,
+  // PLANE_ADVANCED_RUDDER_ELEVATOR, PLANE_RUDDER_ELEVATOR, PLANE_V_TAIL, PLANE_FLYING_WING,
+  // QUAD_X_COPTER, QUAD_P_COPTER, BI_COPTER, CHINOOK_COPTER, TRI_COPTER, DUAL_COPTER, SINGLE_COPTER
   //==========================================================================
+  
   static constexpr ModelType MODEL_TYPE                      = ModelType::PLANE_FULL_HOUSE;
 
   //==========================================================================
@@ -84,10 +87,19 @@ class Config
   // You must update these arrays when changing model type.
   //
   // Example mappings by model:
-  //   PlaneFullHouse:     4 servos, 2 motors
-  //   TriCopter:          1 servo,  3 motors
-  //   BiCopter:           2 servos, 2 motors
-  //   PlaneRudderElev:    3 servos, 1 motor
+  //   PlaneFullHouse:              4 servos, 2 motors
+  //   PlaneFullHouseVTail:         4 servos, 2 motors
+  //   PlaneAdvancedRudderElevator: 2 servos, 2 motors
+  //   PlaneRudderElevator:         2 servos, 2 motors
+  //   PlaneVTail:                  2 servos, 2 motors
+  //   PlaneFlyingWing:             3 servos, 2 motors
+  //   QuadXCopter:                 0 servos, 4 motors
+  //   QuadPlusCopter:              0 servos, 4 motors
+  //   ChinookCopter:               2 servos, 2 motors
+  //   BiCopter:                    2 servos, 2 motors
+  //   TriCopter:                   1 servo,  3 motors
+  //   DualCopter:                  2 servos, 2 motors
+  //   SingleCopter:                4 servos, 1 motor
   // See specific aircraft class in ModelTypes for further documentation
   // =========================================================================
 
@@ -102,8 +114,10 @@ class Config
 
   static constexpr uint8_t MOTOR_PINS[] =
   {
-      ESP32S3.OUTPUT_5,   // Motor 1
-      ESP32S3.OUTPUT_6,   // Motor 2
+      // PlaneFullHouse expects two motors here even when not physically fitted 
+      // as the code support differential thrust.
+      ESP32S3.OUTPUT_5,   // Motor 1 - e.g. left/single motor  (PlaneFullHouse)
+      ESP32S3.OUTPUT_6,   // Motor 2 - e.g. right motor (PlaneFullHouse)
   };
 
   // Refresh rates for servos and motors.
@@ -122,8 +136,9 @@ class Config
   // Set during physical installation to match your wiring and servo orientation.
   //==========================================================================
 
-  // Reverse individual outputs. Set the corresponding channel to true if a
-  // servo moves in the wrong direction.
+  // Reverse individual outputs. Last resort! Intended for correction of symmetric 
+  // aileron/elevon servo installation and the like.  Ensure gyro orientation is 
+  // correct and try reversing TX channel first.
   static constexpr bool REVERSE_OUTPUT_1                     = false;
   static constexpr bool REVERSE_OUTPUT_2                     = false;
   static constexpr bool REVERSE_OUTPUT_3                     = false;
@@ -134,6 +149,8 @@ class Config
   static constexpr bool REVERSE_OUTPUT_8                     = false;
 
   // Extend servo travel beyond the standard 1.0–2.0 ms pulse range.
+  // Use when WiFi GUI trims have been used to offset servo centre position
+  // in order to regain the full range of servo travel.
   // When true, travel is extended to 0.8–2.2 ms.
   static constexpr bool EXTEND_SERVO_TRAVEL_RANGE            = false;
 

--- a/PlainFlightController/Configurator.cpp
+++ b/PlainFlightController/Configurator.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "Configurator.hpp"
+#include "InternalConfig.hpp"
 
 
 /**
@@ -43,11 +44,11 @@ Configurator::begin()
     }
     else
     {      
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("No file exists so create one...");}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("No file exists so create one...");}
       
       if (!fileSys.createFile())
       {
-        if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Failed to create file");}
+        if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Failed to create file");}
         return false;
       }
 
@@ -55,12 +56,12 @@ Configurator::begin()
       const bool ok2 = writeConfig();
       if (!ok2)
       {
-        if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Error writting Config.");}
+        if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Error writting Config.");}
         return false;
       }
       else
       {
-        if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Wrote Config.");}
+        if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Wrote Config.");}
       }
 
       //File data successfully written, no need to read as we wrote defaults which will be used in main program.
@@ -69,7 +70,7 @@ Configurator::begin()
   } 
   else
   {
-    if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("LitteFS failed to start ?!");}
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("LitteFS failed to start ?!");}
     return false;
   }   
 }
@@ -87,7 +88,7 @@ Configurator::operate()
   {
     const bool ok = writeConfig();
 
-    if constexpr(Config::DEBUG_CONFIGURATOR)
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR)
     {
       if (ok)
       {
@@ -113,7 +114,7 @@ Configurator::readConfig()
   const bool ok = fileSys.readDataFromFile(&fileData);
   const uint32_t configFileSize = fileData.length();
 
-  if constexpr(Config::DEBUG_CONFIGURATOR)
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR)
   {
     Serial.print("File size: ");
     Serial.println(configFileSize);
@@ -122,19 +123,19 @@ Configurator::readConfig()
 
   if (!ok)
   {
-    if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Failed to read Json from file");}
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Failed to read Json from file");}
     return false;
   }
   else
   {
-    if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Read Json from file :-)");}
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Read Json from file :-)");}
     // Allocate a temporary JsonDocument
     JsonDocument jsonDoc;
     // Deserialize the JSON document    
     DeserializationError error = deserializeJson(jsonDoc, fileData);
     if (error)
     {
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Json deserializeJson error");}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Json deserializeJson error");}
       return false;
     }
     else
@@ -228,7 +229,6 @@ Configurator::writeConfig()
     return true;
   }
 
-  if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Failed to write Json to file");}
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Failed to write Json to file");}
   return false;
 }
-

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "Crsf.hpp"
+#include "InternalConfig.hpp"
 #include "Utilities.hpp"
 
 
@@ -109,7 +110,7 @@ Crsf::getDemands()
             lossOfCommsTimer.set(COMMS_TIME_OUT_PERIOD);
             m_rxData.lostComms = false;
 
-            if constexpr(Config::DEBUG_RX)
+            if constexpr(InternalConfig::DEBUG_RX)
             {
               printData();
             }

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "DemandProcessor.hpp"
+#include "InternalConfig.hpp"
 
 
 /**
@@ -30,13 +31,13 @@
 DemandProcessor::DemandProcessor()
 {
   // Add instantiation code here for new receiver protocols
-  if constexpr (Config::RECEIVER_TYPE == RxBase::ReceiverType::SBUS)
+  if constexpr (Config::RECEIVER_TYPE == ReceiverType::SBUS)
   {
-    radioCtrl = new SBus(Config::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
+    radioCtrl = new SBus(InternalConfig::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
   } 
-  else if constexpr (Config::RECEIVER_TYPE == RxBase::ReceiverType::CRSF)
+  else if constexpr (Config::RECEIVER_TYPE == ReceiverType::CRSF)
   {
-    radioCtrl = new Crsf(Config::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
+    radioCtrl = new Crsf(InternalConfig::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
   }
   else
   {
@@ -196,7 +197,7 @@ DemandProcessor::decodeOperatingMode(FlightState* const flightState, FlightState
   {
     DemandProcessor::FlightState demandedFlightMode;
 
-    if constexpr(Config::MODEL_IS_FIXED_WING)
+    if constexpr(InternalConfig::MODEL_IS_FIXED_WING)
     {
       demandedFlightMode = getDemandedFlightModeFixedWing();
     }

--- a/PlainFlightController/FileSystem.cpp
+++ b/PlainFlightController/FileSystem.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "FileSystem.hpp"
+#include "InternalConfig.hpp"
 
 /**
 * @brief  Start the file system.
@@ -61,14 +62,14 @@ FileSystem::fileExists()
 bool 
 FileSystem::createFile()
 {
-  if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Formating.");}
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Formating.");}
   LittleFS.format();
-  if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Create directory.");}
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Create directory.");}
   LittleFS.mkdir(FILE_DIRECTORY);
 
   if (!LittleFS.exists(FILE_DIRECTORY)) 
   {
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("directory not created");}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("directory not created");}
       return false;
   }
 
@@ -101,11 +102,11 @@ FileSystem::readDataFromFile(String *const fileData)
 
   if (!file || file.isDirectory()) 
   {
-    if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("- failed to open file for reading");}
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("- failed to open file for reading");}
     return false;
   }
 
-  if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("- read from file:");}
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("- read from file:");}
 
   while (file.available()) 
   {
@@ -129,12 +130,12 @@ FileSystem::writeDataToFile(String const * const fileData)
 
   if (!file) 
   {
-    if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Failed to open file for writing");}
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Failed to open file for writing");}
     return false;
   }
   
   //write default gains here
-  if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("write default gains");}
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("write default gains");}
   file.print(*fileData);
   file.close();
   return true;

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "FlightControl.hpp"
+#include "InternalConfig.hpp"
 
 
 
@@ -33,12 +34,12 @@ FlightControl::begin()
 {
   modelConfig();
 
-  Serial.begin(Config::USB_BAUD);
+  Serial.begin(InternalConfig::USB_BAUD);
   if (Serial)
   {
     delay(3000);  //Need to wait by this magic number or some console data will be lost while PC is connecting.
     Serial.print("PlainFlightController: ");
-    Serial.println(Config::SOFTWARE_VERSION);
+    Serial.println(InternalConfig::SOFTWARE_VERSION);
   }
 
   imu.begin();
@@ -84,73 +85,57 @@ FlightControl::begin()
 void
 FlightControl::modelConfig()
 {
-  if constexpr(Config::PLANE_FULL_HOUSE)
+  if constexpr(Config::MODEL_TYPE == ModelType::PLANE_FULL_HOUSE)
   {
     myModel = new PlaneFullHouse();
   }
-  else if constexpr(Config::PLANE_FULL_HOUSE_V_TAIL)
+  else if constexpr(Config::MODEL_TYPE == ModelType::PLANE_FULL_HOUSE_V_TAIL)
   {
     myModel = new PlaneFullHouseVTail();
   }
-  else if constexpr(Config::PLANE_ADVANCED_RUDDER_ELEVATOR)
+  else if constexpr(Config::MODEL_TYPE == ModelType::PLANE_ADVANCED_RUDDER_ELEVATOR)
   {
     myModel = new PlaneAdvancedRudderElevator();
   }
-  else if constexpr(Config::PLANE_RUDDER_ELEVATOR)
+  else if constexpr(Config::MODEL_TYPE == ModelType::PLANE_RUDDER_ELEVATOR)
   {
     myModel = new PlaneRudderElevator();
   }
-  else if constexpr(Config::PLANE_V_TAIL)
+  else if constexpr(Config::MODEL_TYPE == ModelType::PLANE_V_TAIL)
   {
     myModel = new PlaneVTail();
   }
-  else if constexpr(Config::PLANE_FLYING_WING)
+  else if constexpr(Config::MODEL_TYPE == ModelType::PLANE_FLYING_WING)
   {
     myModel = new PlaneFlyingWing();
   }
-  else if constexpr(Config::QUAD_X_COPTER)
+  else if constexpr(Config::MODEL_TYPE == ModelType::QUAD_X_COPTER)
   {
     myModel = new QuadXCopter();
   }
-  else if constexpr(Config::QUAD_P_COPTER)
+  else if constexpr(Config::MODEL_TYPE == ModelType::QUAD_P_COPTER)
   {
     myModel = new QuadPlusCopter();
   }
-  else if constexpr(Config::BI_COPTER)
+  else if constexpr(Config::MODEL_TYPE == ModelType::BI_COPTER)
   {
     myModel = new BiCopter();
   }
-  else if constexpr(Config::CHINOOK_COPTER)
+  else if constexpr(Config::MODEL_TYPE == ModelType::CHINOOK_COPTER)
   {
     myModel = new ChinookCopter();
   }
-  else if constexpr(Config::TRI_COPTER)
+  else if constexpr(Config::MODEL_TYPE == ModelType::TRI_COPTER)
   {
     myModel = new TriCopter();
   }
-  else if constexpr(Config::DUAL_COPTER)
+  else if constexpr(Config::MODEL_TYPE == ModelType::DUAL_COPTER)
   {
     myModel = new DualCopter();
   }
-  else if constexpr(Config::SINGLE_COPTER)
+  else if constexpr(Config::MODEL_TYPE == ModelType::SINGLE_COPTER)
   {
     myModel = new SingleCopter();
-  }
-  else
-  {
-    static_assert(  (Config::PLANE_FULL_HOUSE ||
-                    Config::PLANE_FULL_HOUSE_V_TAIL ||
-                    Config::PLANE_ADVANCED_RUDDER_ELEVATOR ||
-                    Config::PLANE_RUDDER_ELEVATOR ||
-                    Config::PLANE_V_TAIL ||
-                    Config::PLANE_FLYING_WING ||
-                    Config::QUAD_X_COPTER ||
-                    Config::BI_COPTER ||
-                    Config::CHINOOK_COPTER ||
-                    Config::TRI_COPTER ||
-                    Config::DUAL_COPTER ||
-                    Config::SINGLE_COPTER),
-                    "No model type selected by user. Set one in Config.hpp");
   }
 }
 
@@ -232,15 +217,15 @@ FlightControl::operate()
   }
 
   //Compile in/out debug data
-  if constexpr(Config::DEBUG_RC_DATA)
+  if constexpr(InternalConfig::DEBUG_RC_DATA)
   {
     rc.printData();
   }
-  else if constexpr(Config::DEBUG_LOOP_RATE)
+  else if constexpr(InternalConfig::DEBUG_LOOP_RATE)
   {
     printLoopRateData();
   }
-  else if constexpr(Config::DEBUG_BATTERY_MONITOR)
+  else if constexpr(InternalConfig::DEBUG_BATTERY_MONITOR)
   {
     batteryMonitor.debug();
   }
@@ -324,7 +309,7 @@ FlightControl::doRateState()
 void
 FlightControl::doFailSafeState()
 {
-  if  (Config::MODEL_IS_MULTICOPTER)
+  if constexpr (InternalConfig::MODEL_IS_MULTICOPTER)
   {
     //TODO - auto level & reduce throttle rather than just drop
     //For multicopters default demands to stop all motors from spinning.
@@ -559,7 +544,7 @@ FlightControl::processPIDF(DemandProcessor::Demands * const demands)
     gyro_Z = -gyro_Z;
   }
 
-  if constexpr(Config::MODEL_IS_MULTICOPTER)
+  if constexpr(InternalConfig::MODEL_IS_MULTICOPTER)
   {
     //Multicopter only
     demands->yaw = yawPIDF.pidfController(demands->yaw, static_cast<int32_t>(gyro_Z * 100.0f), config.getYawGains());

--- a/PlainFlightController/IMU.cpp
+++ b/PlainFlightController/IMU.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "IMU.hpp"
+#include "InternalConfig.hpp"
 
 
 /**
@@ -204,7 +205,7 @@ IMU::Madgwick6DOF(const DemandProcessor::FlightState * const flightState)
     m_imu.yaw = -m_imu.yaw;
   }
 
-  if constexpr(Config::DEBUG_MADGWICK)
+  if constexpr(InternalConfig::DEBUG_MADGWICK)
   {
     const uint64_t nowTime = millis();  
 
@@ -235,7 +236,7 @@ IMU::Madgwick6DOF(const DemandProcessor::FlightState * const flightState)
 bool
 IMU::calibrateGyro()
 {
-  if constexpr (Config::DEBUG_GYRO_CALIBRATION)
+  if constexpr (InternalConfig::DEBUG_GYRO_CALIBRATION)
   {
     //Loop rate is 1ms so only print out 10 times a second...
     if (0U == (m_calCount % 100U))
@@ -277,7 +278,7 @@ IMU::calibrateGyro()
     totalM2 = m_xGyroM2 + m_yGyroM2 + m_zGyroM2;
     varianceScaled = totalM2 / static_cast<int64_t>(m_calCount);
 
-    if constexpr (Config::DEBUG_GYRO_CALIBRATION)
+    if constexpr (InternalConfig::DEBUG_GYRO_CALIBRATION)
     {
       Serial.print("Variance (LSB^2): ");
       Serial.println(varianceScaled >> Q16_SHIFT);
@@ -285,7 +286,7 @@ IMU::calibrateGyro()
 
     if (varianceScaled > (static_cast<int64_t>(CALIBRATE_MAX_VARIANCE_THRESHOLD) << Q16_SHIFT))
     {
-      if constexpr (Config::DEBUG_GYRO_CALIBRATION)
+      if constexpr (InternalConfig::DEBUG_GYRO_CALIBRATION)
       {
         Serial.println("Motion detected — restarting calibration");
       }
@@ -315,7 +316,7 @@ IMU::calibrateGyro()
     m_imu.mpu6050.gyroOffset_Z =
       static_cast<int16_t>((m_zGyroMean + Q16_HALF) >> Q16_SHIFT);
 
-    if constexpr (Config::DEBUG_GYRO_CALIBRATION)
+    if constexpr (InternalConfig::DEBUG_GYRO_CALIBRATION)
     {
       Serial.println("Calibration complete...");
       Serial.print("x: "); Serial.print(m_imu.mpu6050.gyroOffset_X);

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -56,6 +56,9 @@ namespace InternalConfig
   static constexpr uint8_t NUMBER_MOTORS = 
     static_cast<uint8_t>(sizeof(Config::MOTOR_PINS) / sizeof(Config::MOTOR_PINS[0]));
 
+  static_assert(NUMBER_SERVOS + NUMBER_MOTORS <= 8U, 
+    "Configuration Error: Combined total of servos and motors cannot exceed 8.");
+
   //==========================================================================
   // DEBUG SETTINGS
   //==========================================================================

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "Config.hpp"
+#include "CommonTypes.hpp"
+
+/**
+ * @namespace InternalConfig
+ * @brief Derived configuration flags and architectural logic.
+ */
+namespace InternalConfig
+{
+  static constexpr bool isFixedWing(ModelType type)
+  {
+    switch (type)
+    {
+      case ModelType::PLANE_FULL_HOUSE:
+      case ModelType::PLANE_FULL_HOUSE_V_TAIL:
+      case ModelType::PLANE_ADVANCED_RUDDER_ELEVATOR:
+      case ModelType::PLANE_RUDDER_ELEVATOR:
+      case ModelType::PLANE_V_TAIL:
+      case ModelType::PLANE_FLYING_WING:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  static constexpr bool isMulticopter(ModelType type)
+  {
+    switch (type)
+    {
+      case ModelType::QUAD_X_COPTER:
+      case ModelType::QUAD_P_COPTER:
+      case ModelType::BI_COPTER:
+      case ModelType::CHINOOK_COPTER:
+      case ModelType::TRI_COPTER:
+      case ModelType::DUAL_COPTER:
+      case ModelType::SINGLE_COPTER:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  // Public architectural flags derived from user Config
+  static constexpr bool MODEL_IS_FIXED_WING  = isFixedWing(Config::MODEL_TYPE);
+  static constexpr bool MODEL_IS_MULTICOPTER = isMulticopter(Config::MODEL_TYPE);
+
+  // Verify that every model is categorized
+  static_assert(MODEL_IS_FIXED_WING != MODEL_IS_MULTICOPTER, 
+    "Architectural Error: ModelType must be assigned to exactly ONE category (Fixed Wing or Multicopter).");
+
+  // Derived counts for outputs
+  static constexpr uint8_t NUMBER_SERVOS = 
+    static_cast<uint8_t>(sizeof(Config::SERVO_PINS) / sizeof(Config::SERVO_PINS[0]));
+  static constexpr uint8_t NUMBER_MOTORS = 
+    static_cast<uint8_t>(sizeof(Config::MOTOR_PINS) / sizeof(Config::MOTOR_PINS[0]));
+
+  //==========================================================================
+  // DEBUG SETTINGS
+  //==========================================================================
+
+  // Debug output flags. Setting any of these to true will compile in diagnostic
+  // serial output for the corresponding subsystem. Leave all false for normal use.
+  static constexpr bool DEBUG_RX                             = false;
+  static constexpr bool DEBUG_RC_DATA                        = false;  // Note: disarmed high-to-low throttle transition intentionally resets ESP32 after WiFi.
+  static constexpr bool DEBUG_LOOP_RATE                      = false;
+  static constexpr bool DEBUG_BATTERY_MONITOR                = false;
+  static constexpr bool DEBUG_MADGWICK                       = false;
+  static constexpr bool DEBUG_GYRO_CALIBRATION               = false;
+  static constexpr bool DEBUG_CONFIGURATOR                   = false;
+  static constexpr bool DEBUG_MPU6050                        = false;
+  static constexpr bool DEBUG_OUTPUT                         = false;
+
+  //==========================================================================
+  // BUILD SETTINGS
+  //==========================================================================
+
+  // PlainFlightController firmware version string.
+  static constexpr char SOFTWARE_VERSION[]                   = "V2.x.x";
+
+  // USB serial baud rate and receiver UART port.
+  static constexpr uint32_t USB_BAUD                         = 500000U;
+  static constexpr HardwareSerial* const RECEIVER_UART       = &Serial0;
+}

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -28,6 +28,7 @@
 #include "PIDF.hpp"
 #include "Config.hpp"
 #include "DemandProcessor.hpp"
+#include "InternalConfig.hpp"
 
 /**
 * @brief    Base class for all model types.
@@ -166,14 +167,14 @@ private:
       for (uint8_t i = 0; i < LedcServo::MAX_LEDC_CHANNELS; i++)
           cfg.outputPins[i] = PIN_UNUSED;
 
-      for (uint8_t i = 0; i < Config::NUMBER_SERVOS; i++)
+      for (uint8_t i = 0; i < InternalConfig::NUMBER_SERVOS; i++)
           cfg.outputPins[i] = Config::SERVO_PINS[i];
 
-      for (uint8_t i = 0; i < Config::NUMBER_MOTORS; i++)
-          cfg.outputPins[Config::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
+      for (uint8_t i = 0; i < InternalConfig::NUMBER_MOTORS; i++)
+          cfg.outputPins[InternalConfig::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
 
-      cfg.numberServos = Config::NUMBER_SERVOS;
-      cfg.numberMotors = Config::NUMBER_MOTORS;
+      cfg.numberServos = InternalConfig::NUMBER_SERVOS;
+      cfg.numberMotors = InternalConfig::NUMBER_MOTORS;
       cfg.servoRefresh = Config::SERVO_REFRESH_RATE;
       cfg.motorRefresh = Config::MOTOR_REFRESH_RATE;
 
@@ -199,12 +200,12 @@ private:
     ModelConfig cfg = {};
     for (uint8_t i = 0; i < LedcServo::MAX_LEDC_CHANNELS; i++)
         cfg.outputPins[i] = PIN_UNUSED;
-    for (uint8_t i = 0; i < Config::NUMBER_SERVOS; i++)
+    for (uint8_t i = 0; i < InternalConfig::NUMBER_SERVOS; i++)
         cfg.outputPins[i] = Config::SERVO_PINS[i];
-    for (uint8_t i = 0; i < Config::NUMBER_MOTORS; i++)
-        cfg.outputPins[Config::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
-    cfg.numberServos = Config::NUMBER_SERVOS;
-    cfg.numberMotors = Config::NUMBER_MOTORS;
+    for (uint8_t i = 0; i < InternalConfig::NUMBER_MOTORS; i++)
+        cfg.outputPins[InternalConfig::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
+    cfg.numberServos = InternalConfig::NUMBER_SERVOS;
+    cfg.numberMotors = InternalConfig::NUMBER_MOTORS;
     cfg.servoRefresh = Config::SERVO_REFRESH_RATE;
     cfg.motorRefresh = Config::MOTOR_REFRESH_RATE;
     return cfg;
@@ -246,7 +247,7 @@ protected:
           outputs[startIndex + i++].setTimerTicks(v);
       }
 
-      if constexpr (Config::DEBUG_OUTPUT)
+      if constexpr (InternalConfig::DEBUG_OUTPUT)
       {
           const uint64_t nowTime = millis();
           if (debugUpdateTime <= nowTime)

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -37,6 +37,7 @@
 class ModelBase : public Utilities
 {
 public:
+  static constexpr uint8_t PIN_UNUSED = 0xFFU;  // Marker for unused outputs
   //Structure used to define model type and actuators required.
   struct ModelConfig
   {
@@ -49,11 +50,10 @@ public:
     uint8_t numberServos;
   };
 
-  ModelBase(ModelConfig modelConfig) 
-    : m_modelConfig(modelConfig),
-      m_idleUp(IDLE_UP),
+  ModelBase() 
+    : m_idleUp(IDLE_UP),
       m_minThrottle(MIN_THROTTLE),
-      m_totalOutputs(modelConfig.numberServos + modelConfig.numberMotors)
+      m_totalOutputs(m_modelConfig.numberServos + m_modelConfig.numberMotors)
   {
     // Ensure not too many outputs are declared
     assert(m_totalOutputs <= LedcServo::MAX_LEDC_CHANNELS);
@@ -158,8 +158,29 @@ public:
   int32_t getTrimMultiplier() const {return servoAt(0).getTrimMultiplier();}
 
 private:
+  // Helper function
+  static constexpr ModelConfig makeModelConfig()
+  {
+      ModelConfig cfg = {};
+
+      for (uint8_t i = 0; i < LedcServo::MAX_LEDC_CHANNELS; i++)
+          cfg.outputPins[i] = PIN_UNUSED;
+
+      for (uint8_t i = 0; i < Config::NUMBER_SERVOS; i++)
+          cfg.outputPins[i] = Config::SERVO_PINS[i];
+
+      for (uint8_t i = 0; i < Config::NUMBER_MOTORS; i++)
+          cfg.outputPins[Config::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
+
+      cfg.numberServos = Config::NUMBER_SERVOS;
+      cfg.numberMotors = Config::NUMBER_MOTORS;
+      cfg.servoRefresh = Config::SERVO_REFRESH_RATE;
+      cfg.motorRefresh = Config::MOTOR_REFRESH_RATE;
+
+      return cfg;
+  }
+
   //Variables
-  ModelConfig m_modelConfig;
   int32_t m_minServoTimerTicks;
   int32_t m_maxServoTimerTicks;
   int32_t m_minMotorTimerTicks;
@@ -173,10 +194,25 @@ private:
   LedcServo& motorAt(uint8_t i) { return outputs[m_modelConfig.numberServos + i]; }
   const LedcServo& motorAt(uint8_t i) const { return outputs[m_modelConfig.numberServos + i]; }
 
+  inline static constexpr ModelConfig m_modelConfig = []() 
+  {
+    ModelConfig cfg = {};
+    for (uint8_t i = 0; i < LedcServo::MAX_LEDC_CHANNELS; i++)
+        cfg.outputPins[i] = PIN_UNUSED;
+    for (uint8_t i = 0; i < Config::NUMBER_SERVOS; i++)
+        cfg.outputPins[i] = Config::SERVO_PINS[i];
+    for (uint8_t i = 0; i < Config::NUMBER_MOTORS; i++)
+        cfg.outputPins[Config::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
+    cfg.numberServos = Config::NUMBER_SERVOS;
+    cfg.numberMotors = Config::NUMBER_MOTORS;
+    cfg.servoRefresh = Config::SERVO_REFRESH_RATE;
+    cfg.motorRefresh = Config::MOTOR_REFRESH_RATE;
+    return cfg;
+  }();
+
 protected:
   static constexpr int32_t IDLE_UP = RxBase::MIN_NORMALISED + Config::IDLE_UP_VALUE;
   static constexpr int32_t MIN_THROTTLE = RxBase::MIN_NORMALISED + Config::MIN_THROTTLE_VALUE;
-  static constexpr uint8_t PIN_UNUSED = 0xFFU;  // Marker for unused outputs
 
   enum class Actuator : uint32_t
   {
@@ -372,33 +408,31 @@ protected:
 };
 
 /**
-* @brief    Plane with wing ailerons/flaperons, rudder and elevator. 
-* @note     Channel output map: Left aileron, right aileron elevator, rudder, motor 1, motor 2
-* @note     3 position flaps work with this model.
+ * @brief  Plane with wing ailerons/flaperons, rudder and elevator.
+ *
+ * For this model, Config.hpp must declare:
+ *
+ *   static constexpr uint8_t SERVO_PINS[] =
+ *   {
+ *       ESP32S3.OUTPUT_x,   // Servo 1 - left aileron
+ *       ESP32S3.OUTPUT_x,   // Servo 2 - right aileron
+ *       ESP32S3.OUTPUT_x,   // Servo 3 - elevator
+ *       ESP32S3.OUTPUT_x,   // Servo 4 - rudder
+ *   };
+ *
+ *   static constexpr uint8_t MOTOR_PINS[] =
+ *   {
+ *       ESP32S3.OUTPUT_x,   // Motor 1
+ *       ESP32S3.OUTPUT_x,   // Motor 2  (Include always as this plane has optional dual motors)
+ *   };
+ *
+ * 3 position flaps work with this model (Config::USE_FLAPS).
+ * Differential thrust works with this model (Config::USE_DIFFERENTIAL_THRUST).
 */
 class PlaneFullHouse : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 4U;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t SERVO_3_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t SERVO_4_PIN    = Config::ESP32S3.OUTPUT_4;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_5;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_6;
-
-  //Configure this model as PlaneFullHouse ...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  PlaneFullHouse() : ModelBase(m_modelConfig){};
+  PlaneFullHouse() : ModelBase(){};
   ~PlaneFullHouse(){};
 
   /**
@@ -507,26 +541,7 @@ public:
 class PlaneFullHouseVTail : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 4U;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t SERVO_3_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t SERVO_4_PIN    = Config::ESP32S3.OUTPUT_4;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_5;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_6;
-
-  //Configure this model as PlaneFullHouseVTail...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  PlaneFullHouseVTail() : ModelBase(m_modelConfig){};
+  PlaneFullHouseVTail() : ModelBase(){};
   ~PlaneFullHouseVTail(){};
 
   /**
@@ -638,24 +653,7 @@ public:
 class PlaneAdvancedRudderElevator : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_4;
-
-  //Configure this model as PlaneAdvancedRudderElevator...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  PlaneAdvancedRudderElevator() : ModelBase(m_modelConfig){};
+  PlaneAdvancedRudderElevator() : ModelBase(){};
   ~PlaneAdvancedRudderElevator(){};
 
   /**
@@ -742,24 +740,7 @@ public:
 class PlaneRudderElevator : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_4;
-
-  //Configure this model as PlaneRudderElevator...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  PlaneRudderElevator() : ModelBase(m_modelConfig){};
+  PlaneRudderElevator() : ModelBase(){};
   ~PlaneRudderElevator(){};
 
   /**
@@ -841,24 +822,7 @@ public:
 class PlaneVTail : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_4;
-
-  //Configure this model as PlaneVTail...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  PlaneVTail() : ModelBase(m_modelConfig){};
+  PlaneVTail() : ModelBase(){};
   ~PlaneVTail(){};
 
   /**
@@ -946,26 +910,7 @@ public:
 class PlaneFlyingWing : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 4U;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t SERVO_3_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t SERVO_4_PIN    = Config::ESP32S3.OUTPUT_4;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_5;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_6;
-
-  //Configure this model as flying wing...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  PlaneFlyingWing() : ModelBase(m_modelConfig){};
+  PlaneFlyingWing() : ModelBase(){};
   ~PlaneFlyingWing(){};
 
   /**
@@ -1063,24 +1008,7 @@ public:
 class QuadXCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 4U;
-  static constexpr uint8_t NUMBER_SERVOS  = 0U;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t MOTOR_3_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t MOTOR_4_PIN    = Config::ESP32S3.OUTPUT_4;
-
-  //Configure this model as a quadcopter...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  QuadXCopter() : ModelBase(m_modelConfig){};
+  QuadXCopter() : ModelBase(){};
 
   ~QuadXCopter(){};
 
@@ -1126,24 +1054,7 @@ public:
 class QuadPlusCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 4U;
-  static constexpr uint8_t NUMBER_SERVOS  = 0U;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t MOTOR_3_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t MOTOR_4_PIN    = Config::ESP32S3.OUTPUT_4;
-
-  //Configure this model as a quadcopter +...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  QuadPlusCopter() : ModelBase(m_modelConfig){};
+  QuadPlusCopter() : ModelBase(){};
 
   ~QuadPlusCopter(){};
 
@@ -1185,24 +1096,7 @@ public:
 class ChinookCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_4;
-
-  //Configure this model as chinook...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  ChinookCopter() : ModelBase(m_modelConfig){};
+  ChinookCopter() : ModelBase(){};
 
   ~ChinookCopter(){};
 
@@ -1260,24 +1154,7 @@ public:
 class BiCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_4;
-
-  //Configure this model as a bicopter...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  BiCopter() : ModelBase(m_modelConfig){};
+  BiCopter() : ModelBase(){};
 
   ~BiCopter(){};
 
@@ -1334,26 +1211,7 @@ public:
 class TriCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 4U; //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
-  static constexpr uint8_t NUMBER_SERVOS  = 2U; //Purposely defining 2 as LEDc channles are pairs.
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t MOTOR_3_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t MOTOR_4_PIN    = Config::ESP32S3.OUTPUT_4; //Puposely defining 4 as LEDc channels are pairs. We need 2 motor pairs then a lower refresh rate servo.
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_5;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_6;
-
-  //Configure this model as a tricopter...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, MOTOR_3_PIN, MOTOR_4_PIN, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  TriCopter() : ModelBase(m_modelConfig){};
+  TriCopter() : ModelBase(){};
 
   ~TriCopter(){};
 
@@ -1410,24 +1268,7 @@ public:
 class DualCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 2U;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_4;
-
-  //Configure this model as a dualcopter...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  DualCopter() : ModelBase(m_modelConfig){};
+  DualCopter() : ModelBase(){};
 
   ~DualCopter(){};
 
@@ -1481,26 +1322,7 @@ public:
 class SingleCopter : public ModelBase
 {
 public:
-  static constexpr uint8_t NUMBER_MOTORS  = 2U;
-  static constexpr uint8_t NUMBER_SERVOS  = 4U;
-  static constexpr uint8_t MOTOR_1_PIN    = Config::ESP32S3.OUTPUT_1;
-  static constexpr uint8_t MOTOR_2_PIN    = Config::ESP32S3.OUTPUT_2;
-  static constexpr uint8_t SERVO_1_PIN    = Config::ESP32S3.OUTPUT_3;
-  static constexpr uint8_t SERVO_2_PIN    = Config::ESP32S3.OUTPUT_4;
-  static constexpr uint8_t SERVO_3_PIN    = Config::ESP32S3.OUTPUT_5;
-  static constexpr uint8_t SERVO_4_PIN    = Config::ESP32S3.OUTPUT_6;
-
-  //Configure this model as a singlecopter...
-  static constexpr ModelBase::ModelConfig m_modelConfig =
-      {
-          {SERVO_1_PIN, SERVO_2_PIN, SERVO_3_PIN, SERVO_4_PIN, MOTOR_1_PIN, MOTOR_2_PIN, PIN_UNUSED, PIN_UNUSED},
-          Config::MOTOR_REFRESH_RATE,
-          Config::SERVO_REFRESH_RATE,
-          NUMBER_MOTORS,
-          NUMBER_SERVOS,
-      };
-
-  SingleCopter() : ModelBase(m_modelConfig){};
+  SingleCopter() : ModelBase(){};
 
   ~SingleCopter(){};
 

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -433,8 +433,15 @@ protected:
 class PlaneFullHouse : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 4U;
+  static constexpr uint8_t MOTORS = 2U;
+
   PlaneFullHouse() : ModelBase(){};
   ~PlaneFullHouse(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::PLANE_FULL_HOUSE || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: PlaneFullHouse requires 4 servos and 2 motors in Config.hpp.");
 
   /**
     * @brief  Servo mixer
@@ -559,8 +566,15 @@ public:
 class PlaneFullHouseVTail : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 4U;
+  static constexpr uint8_t MOTORS = 2U;
+
   PlaneFullHouseVTail() : ModelBase(){};
   ~PlaneFullHouseVTail(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::PLANE_FULL_HOUSE_V_TAIL || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: PlaneFullHouseVTail requires 4 servos and 2 motors in Config.hpp.");
 
   /**
     * @brief  Servo mixer
@@ -686,8 +700,15 @@ public:
 class PlaneAdvancedRudderElevator : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 2U;
+  static constexpr uint8_t MOTORS = 2U;
+
   PlaneAdvancedRudderElevator() : ModelBase(){};
   ~PlaneAdvancedRudderElevator(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::PLANE_ADVANCED_RUDDER_ELEVATOR || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: PlaneAdvancedRudderElevator requires 2 servos and 2 motors in Config.hpp.");
 
   /**
     * @brief  Servo mixer
@@ -788,8 +809,15 @@ public:
 class PlaneRudderElevator : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 2U;
+  static constexpr uint8_t MOTORS = 2U;
+
   PlaneRudderElevator() : ModelBase(){};
   ~PlaneRudderElevator(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::PLANE_RUDDER_ELEVATOR || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: PlaneRudderElevator requires 2 servos and 2 motors in Config.hpp.");
 
   /**
     * @brief  Servo mixer
@@ -885,8 +913,15 @@ public:
 class PlaneVTail : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 2U;
+  static constexpr uint8_t MOTORS = 2U;
+
   PlaneVTail() : ModelBase(){};
   ~PlaneVTail(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::PLANE_V_TAIL || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: PlaneVTail requires 2 servos and 2 motors in Config.hpp.");
 
   /**
     * @brief  Servo mixer
@@ -989,8 +1024,15 @@ public:
 class PlaneFlyingWing : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 3U;
+  static constexpr uint8_t MOTORS = 2U;
+
   PlaneFlyingWing() : ModelBase(){};
   ~PlaneFlyingWing(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::PLANE_FLYING_WING || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: PlaneFlyingWing requires 3 servos and 2 motors in Config.hpp.");
 
   /**
     * @brief  Servo mixer
@@ -1102,9 +1144,16 @@ public:
 class QuadXCopter : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 0U;
+  static constexpr uint8_t MOTORS = 4U;
+
   QuadXCopter() : ModelBase(){};
 
   ~QuadXCopter(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::QUAD_X_COPTER || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: QuadXCopter requires 0 servos and 4 motors in Config.hpp.");
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
@@ -1163,9 +1212,16 @@ public:
 class QuadPlusCopter : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 0U;
+  static constexpr uint8_t MOTORS = 4U;
+
   QuadPlusCopter() : ModelBase(){};
 
   ~QuadPlusCopter(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::QUAD_P_COPTER || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: QuadPlusCopter requires 0 servos and 4 motors in Config.hpp.");
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
@@ -1220,9 +1276,16 @@ public:
 class ChinookCopter : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 2U;
+  static constexpr uint8_t MOTORS = 2U;
+
   ChinookCopter() : ModelBase(){};
 
   ~ChinookCopter(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::CHINOOK_COPTER || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: ChinookCopter requires 2 servos and 2 motors in Config.hpp.");
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
@@ -1293,9 +1356,16 @@ public:
 class BiCopter : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 2U;
+  static constexpr uint8_t MOTORS = 2U;
+
   BiCopter() : ModelBase(){};
 
   ~BiCopter(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::BI_COPTER || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: BiCopter requires 2 servos and 2 motors in Config.hpp.");
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
@@ -1365,9 +1435,16 @@ public:
 class TriCopter : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 1U;
+  static constexpr uint8_t MOTORS = 3U;
+
   TriCopter() : ModelBase(){};
 
   ~TriCopter(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::TRI_COPTER || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: TriCopter requires 1 servo and 3 motors in Config.hpp.");
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
@@ -1435,9 +1512,16 @@ public:
 class DualCopter : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 2U;
+  static constexpr uint8_t MOTORS = 2U;
+
   DualCopter() : ModelBase(){};
 
   ~DualCopter(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::DUAL_COPTER || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: DualCopter requires 2 servos and 2 motors in Config.hpp.");
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
@@ -1505,9 +1589,16 @@ public:
 class SingleCopter : public ModelBase
 {
 public:
+  static constexpr uint8_t SERVOS = 4U;
+  static constexpr uint8_t MOTORS = 1U;
+
   SingleCopter() : ModelBase(){};
 
   ~SingleCopter(){};
+
+  static_assert(Config::MODEL_TYPE != ModelType::SINGLE_COPTER || 
+    (InternalConfig::NUMBER_SERVOS == SERVOS && InternalConfig::NUMBER_MOTORS == MOTORS),
+    "Configuration Error: SingleCopter requires 4 servos and 1 motor in Config.hpp.");
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -159,28 +159,6 @@ public:
   int32_t getTrimMultiplier() const {return servoAt(0).getTrimMultiplier();}
 
 private:
-  // Helper function
-  static constexpr ModelConfig makeModelConfig()
-  {
-      ModelConfig cfg = {};
-
-      for (uint8_t i = 0; i < LedcServo::MAX_LEDC_CHANNELS; i++)
-          cfg.outputPins[i] = PIN_UNUSED;
-
-      for (uint8_t i = 0; i < InternalConfig::NUMBER_SERVOS; i++)
-          cfg.outputPins[i] = Config::SERVO_PINS[i];
-
-      for (uint8_t i = 0; i < InternalConfig::NUMBER_MOTORS; i++)
-          cfg.outputPins[InternalConfig::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
-
-      cfg.numberServos = InternalConfig::NUMBER_SERVOS;
-      cfg.numberMotors = InternalConfig::NUMBER_MOTORS;
-      cfg.servoRefresh = Config::SERVO_REFRESH_RATE;
-      cfg.motorRefresh = Config::MOTOR_REFRESH_RATE;
-
-      return cfg;
-  }
-
   //Variables
   int32_t m_minServoTimerTicks;
   int32_t m_maxServoTimerTicks;
@@ -198,11 +176,11 @@ private:
   inline static constexpr ModelConfig m_modelConfig = []() 
   {
     ModelConfig cfg = {};
-    for (uint8_t i = 0; i < LedcServo::MAX_LEDC_CHANNELS; i++)
+    for (uint8_t i = 0U; i < LedcServo::MAX_LEDC_CHANNELS; i++)
         cfg.outputPins[i] = PIN_UNUSED;
-    for (uint8_t i = 0; i < InternalConfig::NUMBER_SERVOS; i++)
+    for (uint8_t i = 0U; i < InternalConfig::NUMBER_SERVOS; i++)
         cfg.outputPins[i] = Config::SERVO_PINS[i];
-    for (uint8_t i = 0; i < InternalConfig::NUMBER_MOTORS; i++)
+    for (uint8_t i = 0U; i < InternalConfig::NUMBER_MOTORS; i++)
         cfg.outputPins[InternalConfig::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
     cfg.numberServos = InternalConfig::NUMBER_SERVOS;
     cfg.numberMotors = InternalConfig::NUMBER_MOTORS;
@@ -428,7 +406,9 @@ protected:
  *   };
  *
  * 3 position flaps work with this model (Config::USE_FLAPS).
- * Differential thrust works with this model (Config::USE_DIFFERENTIAL_THRUST).
+ * Differential thrust (Config::USE_DIFFERENTIAL_THRUST),
+ * Prop hang (Config::USE_PROP_HANG_MODE) and
+ * Heading hold (Config::USE_HEADING_HOLD) work with this model
 */
 class PlaneFullHouse : public ModelBase
 {

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -215,16 +215,16 @@ protected:
   static constexpr int32_t IDLE_UP = RxBase::MIN_NORMALISED + Config::IDLE_UP_VALUE;
   static constexpr int32_t MIN_THROTTLE = RxBase::MIN_NORMALISED + Config::MIN_THROTTLE_VALUE;
 
-  enum class Actuator : uint32_t
+  enum class Actuator : uint8_t
   {
-    CHANNEL_1 = 0U,
-    CHANNEL_2,
-    CHANNEL_3,
-    CHANNEL_4,
-    CHANNEL_5,
-    CHANNEL_6,
-    CHANNEL_7,
-    CHANNEL_8
+    INDEX_1 = 0U,
+    INDEX_2,
+    INDEX_3,
+    INDEX_4,
+    INDEX_5,
+    INDEX_6,
+    INDEX_7,
+    INDEX_8
   };
 
   //Variables
@@ -536,6 +536,23 @@ public:
 
 /**
 * @brief    Plane with wing ailerons/flaperons, with rudder and elevator mixed for V-tail i.e.'Talon' type model. 
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - left aileron
+*       ESP32S3.OUTPUT_x,   // Servo 2 - right aileron
+*       ESP32S3.OUTPUT_x,   // Servo 3 - elevator
+*       ESP32S3.OUTPUT_x,   // Servo 4 - rudder
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2  (Include always as this plane has optional dual motors)
+*   };
+*
 * @note     Channel output map: left aileron, right aileron, Left taileron, right taileron, motor 1, motor 2
 * @note     3 position flaps work with this model.
 */
@@ -648,6 +665,21 @@ public:
 /**
 * @brief    Plane with rudder elevator only. 
 * @note     Roll and yaw corrections are mapped to rudder control. This makes for better rudder/elevator aerobatics but harder to tune.
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - rudder
+*       ESP32S3.OUTPUT_x,   // Servo 2 - elevator
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2  (Include always as this plane has optional dual motors)
+*   };
+*
 * @note     Channel output map: rudder, elevator, motor 1, motor 2
 * @note     Both roll and yaw gyro corrections are mixeded to rudder, this makes for better aerobatics but is harder to tune.
 */
@@ -736,6 +768,21 @@ public:
 /**
 * @brief    Plane with rudder elevator only. 
 * @note     Roll correction are mapped to rudder control.
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - rudder
+*       ESP32S3.OUTPUT_x,   // Servo 2 - elevator
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2  (Include always as this plane has optional dual motors)
+*   };
+*
 * @note     Channel output map: rudder, elevator, motor 1, motor 2
 */
 class PlaneRudderElevator : public ModelBase
@@ -818,6 +865,21 @@ public:
 
 /**
 * @brief    Plane with V-tail controls only. 
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - left taileron
+*       ESP32S3.OUTPUT_x,   // Servo 2 - right taileron
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2  (Include always as this plane has optional dual motors)
+*   };
+*
 * @note     Channel output map: left taileron, right taileron, motor 1, motor 2
 */
 class PlaneVTail : public ModelBase
@@ -906,6 +968,22 @@ public:
 
 /**
 * @brief    Flying wing class with 2 elevons and rudder if required. 
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - left elevon
+*       ESP32S3.OUTPUT_x,   // Servo 2 - right elevon
+*       ESP32S3.OUTPUT_x,   // Servo 3 - rudder
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2  (Include always as this plane has optional dual motors)
+*   };
+*
 * @note     Channel output map: left elevon, right elevon, rudder, LEDc unused, motor 1, motor 2
 */
 class PlaneFlyingWing : public ModelBase
@@ -927,7 +1005,7 @@ public:
     const uint32_t leftElevonTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightElevonTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t rudderTicks = static_cast<uint32_t>(mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo3 * getTrimMultiplier()));
-    writeServos({leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4)});
+    writeServos({leftElevonTicks, rightElevonTicks, rudderTicks});
   }
 
   /**
@@ -943,7 +1021,7 @@ public:
     const uint32_t leftElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollPlusPitch) + (trim->servo1 * getTrimMultiplier()));
     const uint32_t rightElevonTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(rollMinusPitch) + (trim->servo2 * getTrimMultiplier()));
     const uint32_t rudderTicks = static_cast<uint32_t>(mapRateServoToTimerTicks(demands->yaw) + (trim->servo3 * getTrimMultiplier()));
-    writeServos({leftElevonTicks, rightElevonTicks, rudderTicks, getDefaultServoTicks(Actuator::CHANNEL_4)});
+    writeServos({leftElevonTicks, rightElevonTicks, rudderTicks});
   }
 
   /**
@@ -1004,6 +1082,21 @@ public:
 * @note     4   2
 * @note       x
 * @note     3   1
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2
+*       ESP32S3.OUTPUT_x,   // Motor 3
+*       ESP32S3.OUTPUT_x,   // Motor 4
+*   };
+*
 * @note     Channel output map: motor 1, motor 2, motor 3, motor 4
 */
 class QuadXCopter : public ModelBase
@@ -1015,7 +1108,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4)});
+    writeMotors({getDefaultMotorTicks(Actuator::INDEX_1), getDefaultMotorTicks(Actuator::INDEX_2), getDefaultMotorTicks(Actuator::INDEX_3), getDefaultMotorTicks(Actuator::INDEX_4)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1050,6 +1143,21 @@ public:
 * @note       1
 * @note     4 + 2
 * @note       3
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2
+*       ESP32S3.OUTPUT_x,   // Motor 3
+*       ESP32S3.OUTPUT_x,   // Motor 4
+*   };
+*
 * @note     Channel output map: motor 1, motor 2, motor 3, motor 4
 */
 class QuadPlusCopter : public ModelBase
@@ -1061,7 +1169,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4)});
+    writeMotors({getDefaultMotorTicks(Actuator::INDEX_1), getDefaultMotorTicks(Actuator::INDEX_2), getDefaultMotorTicks(Actuator::INDEX_3), getDefaultMotorTicks(Actuator::INDEX_4)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1092,6 +1200,21 @@ public:
 
 /**
 * @brief    Chinook class. 
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - front servo
+*       ESP32S3.OUTPUT_x,   // Servo 2 - back servo
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2
+*   };
+*
 * @note     Channel output map: Front servo, rear servo, motor 1, motor 2
 */
 class ChinookCopter : public ModelBase
@@ -1103,7 +1226,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2)});
+    writeMotors({getDefaultMotorTicks(Actuator::INDEX_1), getDefaultMotorTicks(Actuator::INDEX_2)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1150,6 +1273,21 @@ public:
 
 /**
 * @brief    Bicopter class. 
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - left servo
+*       ESP32S3.OUTPUT_x,   // Servo 2 - right servo
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2
+*   };
+*
 * @note     Channel output left servo: right servo, motor 1, motor 2
 */
 class BiCopter : public ModelBase
@@ -1161,7 +1299,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2)});
+    writeMotors({getDefaultMotorTicks(Actuator::INDEX_1), getDefaultMotorTicks(Actuator::INDEX_2)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1207,7 +1345,22 @@ public:
 
 /**
 * @brief    Tricopter class. 
-* @note     Channel output map: tail servo, LEDc unused, motor 1, motor 2, motor 3
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - tail servo
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2
+*       ESP32S3.OUTPUT_x,   // Motor 3
+*   };
+*
+* @note     Channel output map: tail servo, motor 1, motor 2, motor 3
 */
 class TriCopter : public ModelBase
 {
@@ -1218,7 +1371,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2), getDefaultMotorTicks(Actuator::CHANNEL_3), getDefaultMotorTicks(Actuator::CHANNEL_4)});
+    writeMotors({getDefaultMotorTicks(Actuator::INDEX_1), getDefaultMotorTicks(Actuator::INDEX_2), getDefaultMotorTicks(Actuator::INDEX_3)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1234,29 +1387,27 @@ public:
     uint32_t motor1 = mapRateMotorToTimerTicks(throttle + oneThirdPitch);                   //Rear motor
     uint32_t motor2 = mapRateMotorToTimerTicks(throttle + demands->roll - twoThirdPitch);   //Left motor
     uint32_t motor3 = mapRateMotorToTimerTicks(throttle - demands->roll - twoThirdPitch);   //Right motor
-    uint32_t motor4 = getDefaultMotorTicks(Actuator::CHANNEL_4);
 
-    multicopterMotorMagic({&motor1, &motor2, &motor3, &motor4});
+    multicopterMotorMagic({&motor1, &motor2, &motor3});
 
     motor1 = constrain(motor1, getRateMinThrottleTicks(), getMaxMotorTicks());
     motor2 = constrain(motor2, getRateMinThrottleTicks(), getMaxMotorTicks());
     motor3 = constrain(motor3, getRateMinThrottleTicks(), getMaxMotorTicks());
-    motor4 = constrain(motor4, getRateMinThrottleTicks(), getMaxMotorTicks());
-    writeMotors({motor1, motor2, motor3, motor4});
+    writeMotors({motor1, motor2, motor3});
   };
 
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
     //When disarmed
     const uint32_t servo1 = mapNormalisedServoToTimerTicks(demands->yaw) + (trim->servo1 * getTrimMultiplier());
-    writeServos({servo1, getDefaultServoTicks(Actuator::CHANNEL_2)});
+    writeServos({servo1});
   }
 
   virtual void servoRateMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final
   {
     //When armed
     const uint32_t servo1 = mapRateServoToTimerTicks(demands->yaw) + (trim->servo1 * getTrimMultiplier());
-    writeServos({servo1, getDefaultServoTicks(Actuator::CHANNEL_2)});
+    writeServos({servo1});
   }
 };
 
@@ -1264,6 +1415,21 @@ public:
 
 /**
 * @brief    Dualcopter class. 
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1 - roll servo
+*       ESP32S3.OUTPUT_x,   // Servo 2 - pitch servo
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*       ESP32S3.OUTPUT_x,   // Motor 2
+*   };
+*
 * @note     Channel output map: roll servo, pitch servo, motor 1, motor 2
 */
 class DualCopter : public ModelBase
@@ -1275,7 +1441,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2)});
+    writeMotors({getDefaultMotorTicks(Actuator::INDEX_1), getDefaultMotorTicks(Actuator::INDEX_2)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1318,7 +1484,23 @@ public:
 /**
 * @brief    Singlecopter class. 
 * @note     4 servos arranged with 90 degree separation.
-* @note     Channel output map: servo 1, servo 2, servo 3, servo 4, motor 1, LEDc unused
+*
+* For this model, Config.hpp must declare:
+*
+*   static constexpr uint8_t SERVO_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Servo 1
+*       ESP32S3.OUTPUT_x,   // Servo 2
+*       ESP32S3.OUTPUT_x,   // Servo 3
+*       ESP32S3.OUTPUT_x,   // Servo 4
+*   };
+*
+*   static constexpr uint8_t MOTOR_PINS[] =
+*   {
+*       ESP32S3.OUTPUT_x,   // Motor 1
+*   };
+*
+* @note     Channel output map: servo 1, servo 2, servo 3, servo 4, motor 1
 */
 class SingleCopter : public ModelBase
 {
@@ -1329,7 +1511,7 @@ public:
 
   virtual void motorMixer(DemandProcessor::Demands const * const demands) final
   {
-    writeMotors({getDefaultMotorTicks(Actuator::CHANNEL_1), getDefaultMotorTicks(Actuator::CHANNEL_2)});
+    writeMotors({getDefaultMotorTicks(Actuator::INDEX_1)});
   }
 
   virtual void motorRateMixer(DemandProcessor::Demands const * const demands) final
@@ -1341,7 +1523,7 @@ public:
 
     //Set control mix and convert demands to timer ticks
     uint32_t motor1 = mapRateMotorToTimerTicks(throttle);
-    writeMotors({motor1, getDefaultMotorTicks(Actuator::CHANNEL_2)});
+    writeMotors({motor1});
   };
 
   virtual void servoMixer(DemandProcessor::Demands const * const demands, FileSystem::ServoTrims const * const trim) final

--- a/PlainFlightController/Mpu6050.cpp
+++ b/PlainFlightController/Mpu6050.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "Mpu6050.hpp"
+#include "InternalConfig.hpp"
 
 /**
 * @brief    Constructor that sets the desired gyro rate.
@@ -186,7 +187,7 @@ Mpu6050::readData(MpuData* const data)
     data->gyro_Z = static_cast<float>(data->rawGyro_Z - data->gyroOffset_Z) / m_scaleFactor;
     data->accel_Z = static_cast<float>(data->rawAccel_Z) / ACCEL_SCALE_FACTOR_16G;
   
-    if constexpr(Config::DEBUG_MPU6050)
+    if constexpr(InternalConfig::DEBUG_MPU6050)
     {
       Serial.print("\t gx:");
       Serial.print(data->gyro_X);
@@ -206,7 +207,7 @@ Mpu6050::readData(MpuData* const data)
   }
   else
   {
-    if constexpr(Config::DEBUG_MPU6050)
+    if constexpr(InternalConfig::DEBUG_MPU6050)
     {
       Serial.println("MPU6050 read error  !");
     }

--- a/PlainFlightController/Mpu6050.cpp
+++ b/PlainFlightController/Mpu6050.cpp
@@ -23,18 +23,19 @@
 
 #include "Mpu6050.hpp"
 #include "InternalConfig.hpp"
+#include "CommonTypes.hpp"
 
 /**
 * @brief    Constructor that sets the desired gyro rate.
 */
 Mpu6050::Mpu6050()
 {
-  if constexpr(Config::USE_250_DEGS_SECOND)
+  if constexpr(Config::GYRO_RATE == GyroRate::IS_250_DEGS_SECOND)
   {
     m_scaleFactor = GYRO_SCALE_FACTOR_250;
   }
 
-  if constexpr(Config::USE_500_DEGS_SECOND)
+  if constexpr(Config::GYRO_RATE == GyroRate::IS_500_DEGS_SECOND)
   {
     m_scaleFactor = GYRO_SCALE_FACTOR_500;
   }
@@ -53,12 +54,12 @@ Mpu6050::initialise()
 
   setConfig(CONFIG);
 
-  if constexpr(Config::USE_250_DEGS_SECOND)
+  if constexpr(Config::GYRO_RATE == GyroRate::IS_250_DEGS_SECOND)
   {
     setGyroConfig(GYRO_CONFIG_250);
   }
 
-  if constexpr(Config::USE_500_DEGS_SECOND)
+  if constexpr(Config::GYRO_RATE == GyroRate::IS_500_DEGS_SECOND)
   {
     setGyroConfig(GYRO_CONFIG_500);
   }

--- a/PlainFlightController/Mpu6050.hpp
+++ b/PlainFlightController/Mpu6050.hpp
@@ -96,7 +96,4 @@ class Mpu6050
       //Objects
       SoftWire i2c;
 
-      //Compile time check to see if user has set at least one, but not both...
-      static_assert((Config::USE_250_DEGS_SECOND || Config::USE_500_DEGS_SECOND), "You must set either USE_250_DEGS_SECOND or USE_500_DEGS_SECOND in Config.hpp");
-      static_assert((!Config::USE_250_DEGS_SECOND || !Config::USE_500_DEGS_SECOND), "Only set USE_250_DEGS_SECOND or USE_500_DEGS_SECOND not both in Config.hpp");
 };

--- a/PlainFlightController/RxBase.hpp
+++ b/PlainFlightController/RxBase.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <inttypes.h>
+#include "CommonTypes.hpp"
 
 /**
  * @class RxBase
@@ -39,16 +40,6 @@ class RxBase
       static constexpr int32_t SWITCH_HIGH_NORM    = 512;
       static constexpr int32_t SWITCH_LOW_NORM     = -512;
       static constexpr int32_t LOW_THROTTLE_NORM   = -922;  // Changed to be 5% of range - post test fix
-
-      /**
-      * @enum ReceiverType
-      * @brief Class of receiver.  Add to this list when new receiver protocols defined
-      */
-      enum class ReceiverType
-      {
-         SBUS,
-         CRSF
-      };
 
       /**
       * @enum ChannelName

--- a/PlainFlightController/SBus.cpp
+++ b/PlainFlightController/SBus.cpp
@@ -31,6 +31,7 @@
 */
 
 #include "SBus.hpp"
+#include "InternalConfig.hpp"
 #include "Utilities.hpp"
 
 
@@ -142,7 +143,7 @@ SBus::getDemands()
         lossOfCommsTimer.set(COMMS_TIME_OUT_PERIOD);
         m_rxData.lostComms = false;
 
-        if constexpr(Config::DEBUG_RX)
+        if constexpr(InternalConfig::DEBUG_RX)
         {
           printData();
         }

--- a/PlainFlightController/WifiConfig.cpp
+++ b/PlainFlightController/WifiConfig.cpp
@@ -23,6 +23,7 @@
 
 #include "WifiConfig.hpp"
 #include "Config.hpp"
+#include "InternalConfig.hpp"
 
 
 /**
@@ -49,12 +50,12 @@ WifiConfig::doWiFiStateMachine()
   switch (m_state)
   {
     case WifiState::OFF:
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("wifi_off");}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("wifi_off");}
       break;
 
     case WifiState::START:
     {
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("start_wifi");}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("start_wifi");}
       const bool ok = startWifiConfigurator();
       m_state = (ok) ? WifiState::SERV_CLIENT : WifiState::OFF;
       break;
@@ -62,7 +63,7 @@ WifiConfig::doWiFiStateMachine()
 
     default:
     case WifiState::STOP:
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("stop_wifi");}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("stop_wifi");}
       stopWifiConfigurator();
       m_state = WifiState::OFF;
       break;
@@ -83,7 +84,7 @@ WifiConfig::doWiFiStateMachine()
 bool 
 WifiConfig::startWifiConfigurator() 
 {
-  if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Configuring access point...");}
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Configuring access point...");}
 
   IPAddress m_localIP(192,168,4,1);
   IPAddress m_gateway(192,168,4,1);
@@ -95,20 +96,20 @@ WifiConfig::startWifiConfigurator()
   // a valid password must have more than 7 characters
   if (!WiFi.softAP(SSID, PASSWORD)) 
   {
-    if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Soft AP creation failed.");}
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Soft AP creation failed.");}
     return false;
   }
   else
   {
     IPAddress myIP = WiFi.softAPIP();
-    if constexpr(Config::DEBUG_CONFIGURATOR)
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR)
     {
       Serial.print("AP IP address: ");
       Serial.println(myIP);
     }
     
     server.begin();
-    if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Server started");}    
+    if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Server started");}    
     return true;
   }
 }
@@ -122,10 +123,10 @@ void
 WifiConfig::stopWifiConfigurator() 
 {
   client.stop();
-  if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Client Disconnected.");}
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Client Disconnected.");}
   WiFi.softAPdisconnect();
   WiFi.mode(WIFI_OFF);
-  if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Wifi stopped");}
+  if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Wifi stopped");}
 }
 
 
@@ -161,12 +162,12 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
           {
             // HTTP headers always start with a response code (e.g. HTTP/1.1 200 OK)
             // and a content-type so the client knows what's coming, then a blank line:
-            if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Send HTML doc.");}
+            if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Send HTML doc.");}
             sendHtml(&client);
             // The HTTP response ends with another blank line:
             client.println();
             client.stop();
-            if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Client Disconnected.");}
+            if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Client Disconnected.");}
           }          
           else 
           {     
@@ -175,9 +176,9 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
             if (m_currentLine.startsWith(STR_PITCH))
             {       
               strData.message = m_currentLine;
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Received pitch PID.");}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Received pitch PID.");}
               removeHeadTail(&strData, STR_PITCH.length());
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
 
               if (updatePidf(&strData, &m_webData->gains.pitch))
               {
@@ -187,9 +188,9 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
             else if (m_currentLine.startsWith(STR_ROLL))
             {
               strData.message = m_currentLine;
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Received roll PID.");}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Received roll PID.");}
               removeHeadTail(&strData, STR_ROLL.length());
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
 
               if (updatePidf(&strData, &m_webData->gains.roll))
               {
@@ -199,9 +200,9 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
             else if (m_currentLine.startsWith(STR_YAW))
             {
               strData.message = m_currentLine;
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Received Yaw PID.");}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Received Yaw PID.");}
               removeHeadTail(&strData, STR_YAW.length());
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
 
               if (updatePidf(&strData, &m_webData->gains.yaw))
               {
@@ -211,9 +212,9 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
             else if (m_currentLine.startsWith(STR_RATES))
             {
               strData.message = m_currentLine;
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Received Rates.");}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Received Rates.");}
               removeHeadTail(&strData, STR_RATES.length());
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
 
               if (updateRates(&strData))
               {
@@ -223,9 +224,9 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
             else if (m_currentLine.startsWith(STR_ANGLES))
             {
               strData.message = m_currentLine;
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Received max angles PID.");}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Received max angles PID.");}
               removeHeadTail(&strData, STR_ANGLES.length());
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
  
               if (updateMaxAngles(&strData))
               {
@@ -235,9 +236,9 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
             else if (m_currentLine.startsWith(STR_LEVEL_TRIMS))
             {
               strData.message = m_currentLine;
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Received level trims.");}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Received level trims.");}
               removeHeadTail(&strData, STR_LEVEL_TRIMS.length());
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
 
               if (updateLevelTrims(&strData))
               {
@@ -247,9 +248,9 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
             else if (m_currentLine.startsWith(STR_SERVO_TRIMS))
             {
               strData.message = m_currentLine;
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Received level trims.");}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Received level trims.");}
               removeHeadTail(&strData, STR_SERVO_TRIMS.length());
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
 
               if (updateServoTrims(&strData))
               {
@@ -259,9 +260,9 @@ WifiConfig::serviceWifiConfigurator()//FileSystem::NonVolatileData * const fileD
             else if (m_currentLine.startsWith(STR_VOLT_TRIM))
             {
               strData.message = m_currentLine;
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println("Received battery.");}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println("Received battery.");}
               removeHeadTail(&strData, STR_VOLT_TRIM.length());
-              if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
+              if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(strData.message);}
 
               if (updateBatteryTrims(&strData))
               {
@@ -341,7 +342,7 @@ WifiConfig::sendHtml(WiFiClient* const theClient)
   }
 
   const int32_t n = snprintf (m_html, HTML_DOC_BUFF_SIZE, INDEX_HTML, 
-                          Config::SOFTWARE_VERSION,
+                          InternalConfig::SOFTWARE_VERSION,
                           m_webData->gains.pitch.p, m_webData->gains.pitch.i, m_webData->gains.pitch.d, m_webData->gains.pitch.ff,
                           m_webData->gains.roll.p, m_webData->gains.roll.i, m_webData->gains.roll.d, m_webData->gains.roll.ff,
                           m_webData->gains.yaw.p, m_webData->gains.yaw.i, m_webData->gains.yaw.d, m_webData->gains.yaw.ff,
@@ -382,28 +383,28 @@ WifiConfig::updatePidf(StringHandler* const str, PIDF::Gains* const theGains)
     {    
       str->tokens[i].remove(0,2);
       theGains->p = str->tokens[i].toInt();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(theGains->p);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(theGains->p);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("I="))
     {    
       str->tokens[i].remove(0,2);
       theGains->i = str->tokens[i].toInt();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(theGains->i);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(theGains->i);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("D="))
     {    
       str->tokens[i].remove(0,2);
       theGains->d = str->tokens[i].toInt();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(theGains->d);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(theGains->d);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("F="))
     {    
       str->tokens[i].remove(0,2);
       theGains->ff = str->tokens[i].toInt();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(theGains->ff);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(theGains->ff);}
       updated = true;
     }
     else
@@ -435,21 +436,21 @@ WifiConfig::updateRates(StringHandler* const str)
     {    
       str->tokens[i].remove(0,6);
       m_webData->rates.pitch = str->tokens[i].toInt() * 100;
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->rates.pitch);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->rates.pitch);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("roll="))
     {    
       str->tokens[i].remove(0,5);
       m_webData->rates.roll = str->tokens[i].toInt() * 100;
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->rates.roll);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->rates.roll);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("yaw="))
     {    
       str->tokens[i].remove(0,4);
       m_webData->rates.yaw = str->tokens[i].toInt() * 100;
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->rates.yaw);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->rates.yaw);}
       updated = true;
     }
     else
@@ -481,14 +482,14 @@ WifiConfig::updateLevelTrims(StringHandler* const str)
     {    
       str->tokens[i].remove(0,6);
       m_webData->levelTrim.pitch = str->tokens[i].toFloat();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->levelTrim.pitch);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->levelTrim.pitch);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("roll="))
     {    
       str->tokens[i].remove(0,5);
       m_webData->levelTrim.roll = str->tokens[i].toFloat();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->levelTrim.roll);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->levelTrim.roll);}
       updated = true;
     }
     else
@@ -497,7 +498,7 @@ WifiConfig::updateLevelTrims(StringHandler* const str)
       {    
         str->tokens[i].remove(0,4);
         m_webData->levelTrim.yaw = str->tokens[i].toFloat();
-        if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->levelTrim.yaw);}
+        if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->levelTrim.yaw);}
         updated = true;
       }
     }
@@ -526,14 +527,14 @@ WifiConfig::updateMaxAngles(StringHandler* const str)
     {    
       str->tokens[i].remove(0,6);
       m_webData->maxAngle.pitch = str->tokens[i].toInt() * 100;
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->maxAngle.pitch);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->maxAngle.pitch);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("roll="))
     {    
       str->tokens[i].remove(0,5);
       m_webData->maxAngle.roll = str->tokens[i].toInt() * 100;
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->maxAngle.roll);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->maxAngle.roll);}
       updated = true;
     }
     else
@@ -565,28 +566,28 @@ WifiConfig::updateServoTrims(StringHandler* const str)
     {    
       str->tokens[i].remove(0,7);
       m_webData->servoTrim.servo1 = str->tokens[i].toInt();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->servoTrim.servo1);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->servoTrim.servo1);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("Servo2="))
     {    
       str->tokens[i].remove(0,7);
       m_webData->servoTrim.servo2 = str->tokens[i].toInt();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->servoTrim.servo2);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->servoTrim.servo2);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("Servo3="))
     {    
       str->tokens[i].remove(0,7);
       m_webData->servoTrim.servo3 = str->tokens[i].toInt();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->servoTrim.servo3);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->servoTrim.servo3);}
       updated = true;
     }
     else if(str->tokens[i].startsWith("Servo4="))
     {    
       str->tokens[i].remove(0,7);
       m_webData->servoTrim.servo4 = str->tokens[i].toInt();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->servoTrim.servo4);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->servoTrim.servo4);}
       updated = true;
     }
     else
@@ -618,7 +619,7 @@ WifiConfig::updateBatteryTrims(StringHandler* const str)//, float* const battery
     { 
       str->tokens[i].remove(0,6);
       m_webData->batteryScaler = str->tokens[i].toFloat();
-      if constexpr(Config::DEBUG_CONFIGURATOR){Serial.println(m_webData->batteryScaler, 5);}
+      if constexpr(InternalConfig::DEBUG_CONFIGURATOR){Serial.println(m_webData->batteryScaler, 5);}
       updated = true;
     }
   }

--- a/PlainFlightController/WifiConfig.cpp
+++ b/PlainFlightController/WifiConfig.cpp
@@ -331,12 +331,12 @@ WifiConfig::sendHtml(WiFiClient* const theClient)
 {  
   int32_t degreesPerSec = 0;
 
-  if constexpr(Config::USE_250_DEGS_SECOND)
+  if constexpr(Config::GYRO_RATE == GyroRate::IS_250_DEGS_SECOND)
   {
     degreesPerSec = 250;
   }
 
-  if constexpr(Config::USE_500_DEGS_SECOND)
+  if constexpr(Config::GYRO_RATE == GyroRate::IS_500_DEGS_SECOND)
   {
     degreesPerSec = 500;
   }


### PR DESCRIPTION
This PR addresses parts 1 and 2 of Issue #32. Note that part one has not been completely implemented.  The purpose of this PR is to further the discussion of how the configuration of output pins might be managed.

In the version presented here and in Issue #32 ModelBase now holds ModelConfig and the contents of ModelConfig are completely derived from the configuration in Config.hpp.  The documentation that will be required for each model class has only been implemented for the PlaneFullHouse model.  If this way forward is adopted then all models will require documentation.

Part 2 of Issue #32 is completely implemented in the first commit, "Config file restructured"