### PR TITLE
pr/35 debug fix

### DIFF
--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -159,6 +159,9 @@ public:
   int32_t getTrimMultiplier() const {return servoAt(0).getTrimMultiplier();}
 
 private:
+  //Constants
+  static constexpr uint64_t DEBUG_UPDATE_DELAY = 100U;
+
   //Variables
   int32_t m_minServoTimerTicks;
   int32_t m_maxServoTimerTicks;
@@ -214,29 +217,13 @@ protected:
    * @brief  Internal helper to write values to a subset of outputs.
    * @param  startIndex The starting index in the 'outputs' array.
    * @param  values     The list of timer ticks to apply.
-   * @param  label      String label for debug output ("Motor" or "Servo").
    */
-  void writeToOutputs(uint8_t startIndex, std::initializer_list<uint32_t> values, const char* label)
+  void writeToOutputs(uint8_t startIndex, std::initializer_list<uint32_t> values)
   {
-      static uint64_t debugUpdateTime = 0U;
       uint8_t i = 0U;
       for (uint32_t v : values)
       {
           outputs[startIndex + i++].setTimerTicks(v);
-      }
-
-      if constexpr (InternalConfig::DEBUG_OUTPUT)
-      {
-          const uint64_t nowTime = millis();
-          if (debugUpdateTime <= nowTime)
-          {
-              uint8_t j = 0U;
-              for (uint32_t v : values) 
-              {
-                  Serial.printf("%s %d: %u\n", label, j++, v);
-              }
-              debugUpdateTime = nowTime + 100U;
-          }
       }
   }
 
@@ -245,7 +232,22 @@ protected:
    */
   void writeMotors(std::initializer_list<uint32_t> values)
   {
-      writeToOutputs(m_modelConfig.numberServos, values, "Motor");
+    writeToOutputs(m_modelConfig.numberServos, values);
+
+    if constexpr (InternalConfig::DEBUG_OUTPUT)
+    {
+        static uint64_t debugMotorUpdateTime = 0U;
+        const uint64_t nowTime = millis();
+        if (debugMotorUpdateTime <= nowTime)
+        {
+            uint8_t j = 0U;
+            for (uint32_t v : values) 
+            {
+                Serial.printf("%s %d: %u\n", "Motor", j++, v);
+            }
+            debugMotorUpdateTime = nowTime + DEBUG_UPDATE_DELAY;
+        }
+    }
   }
 
   /**
@@ -253,7 +255,22 @@ protected:
    */
   void writeServos(std::initializer_list<uint32_t> values)
   {
-      writeToOutputs(0U, values, "Servo");
+    writeToOutputs(0U, values);
+
+    if constexpr (InternalConfig::DEBUG_OUTPUT)
+    {
+        static uint64_t debugServoUpdateTime = 0U;
+        const uint64_t nowTime = millis();
+        if (debugServoUpdateTime <= nowTime)
+        {
+            uint8_t j = 0U;
+            for (uint32_t v : values) 
+            {
+                Serial.printf("%s %d: %u\n", "Servo", j++, v);
+            }
+            debugServoUpdateTime = nowTime + DEBUG_UPDATE_DELAY;
+        }
+    }
   }
 
   /**


### PR DESCRIPTION
@Cyberslug - Fix to make motor debug work. This has resulted in duplicated code in writeMotors() and writeServos(), the alternative that I could see was to push the timers down to writeToOutputs() from the higher write method which seemed a more messy approach to me. If you see a more obvious elegant solution let me know. 