### PR TITLE
An alternate solution to issue #35

### DIFF
--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -170,7 +170,6 @@ private:
   uint32_t m_rateMinThrottleTicks;
 
   //Objects
-  uint64_t m_debugUpdateTime[LedcServo::MAX_LEDC_CHANNELS] = {};
   LedcServo outputs[LedcServo::MAX_LEDC_CHANNELS];
   LedcServo& servoAt(uint8_t i) { return outputs[i]; }
   const LedcServo& servoAt(uint8_t i) const { return outputs[i]; }
@@ -220,7 +219,7 @@ protected:
    * @param  values     The list of timer ticks to apply.
    * @param  label      String label for debug output ("Motor" or "Servo").
    */
-  void writeToOutputs(uint8_t startIndex, std::initializer_list<uint32_t> values, const char* label)
+  void writeToOutputs(const uint8_t startIndex, const std::initializer_list<uint32_t> values, const char* label)
   {
       uint8_t i = 0U;
       for (uint32_t v : values)
@@ -230,15 +229,16 @@ protected:
 
       if constexpr (InternalConfig::DEBUG_OUTPUT)
       {
+          static uint64_t debugUpdateTime[LedcServo::MAX_LEDC_CHANNELS] = {};
           const uint64_t nowTime = millis();
-          if (m_debugUpdateTime[startIndex] <= nowTime)
+          if (debugUpdateTime[startIndex] <= nowTime)
           {
               uint8_t j = 0U;
               for (uint32_t v : values) 
               {
                   Serial.printf("%s %d: %u\n", label, j++, v);
               }
-              m_debugUpdateTime[startIndex] = nowTime + DEBUG_UPDATE_DELAY;
+              debugUpdateTime[startIndex] = nowTime + DEBUG_UPDATE_DELAY;
           }
       }
   }

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -159,6 +159,9 @@ public:
   int32_t getTrimMultiplier() const {return servoAt(0).getTrimMultiplier();}
 
 private:
+  //Constants
+  static constexpr uint64_t DEBUG_UPDATE_DELAY = 100U;
+
   //Variables
   int32_t m_minServoTimerTicks;
   int32_t m_maxServoTimerTicks;
@@ -167,6 +170,7 @@ private:
   uint32_t m_rateMinThrottleTicks;
 
   //Objects
+  uint64_t m_debugUpdateTime[LedcServo::MAX_LEDC_CHANNELS] = {};
   LedcServo outputs[LedcServo::MAX_LEDC_CHANNELS];
   LedcServo& servoAt(uint8_t i) { return outputs[i]; }
   const LedcServo& servoAt(uint8_t i) const { return outputs[i]; }
@@ -218,7 +222,6 @@ protected:
    */
   void writeToOutputs(uint8_t startIndex, std::initializer_list<uint32_t> values, const char* label)
   {
-      static uint64_t debugUpdateTime = 0U;
       uint8_t i = 0U;
       for (uint32_t v : values)
       {
@@ -228,14 +231,14 @@ protected:
       if constexpr (InternalConfig::DEBUG_OUTPUT)
       {
           const uint64_t nowTime = millis();
-          if (debugUpdateTime <= nowTime)
+          if (m_debugUpdateTime[startIndex] <= nowTime)
           {
               uint8_t j = 0U;
               for (uint32_t v : values) 
               {
                   Serial.printf("%s %d: %u\n", label, j++, v);
               }
-              debugUpdateTime = nowTime + 100U;
+              m_debugUpdateTime[startIndex] = nowTime + DEBUG_UPDATE_DELAY;
           }
       }
   }


### PR DESCRIPTION
I know that you have a solution for this but if you wanted to keep the trimmed down write functions this is a way that does that.

The issue was caused by my assumption that no one would be trying to print both servo and motor values at the same time.  I just hadn't thought things through. As both the servo and motor values are output within milliseconds of each other when the motor writes arrive sufficient time has not elapse for another print since the servo writes and the motor values never appear.

This solution gives servos and motors their own time counter.  It is very slightly wasteful in that 8 x 64 bits are allocated and only 2 * 64 bits are used but indexing with startIndex is bullet proof.  I think that any mangling of the index to produce a 2 entry time array would reduce readability to save what is a tiny amount of ram.

I have added the DEBUG_UPDATE_DELAY constant as per your solution.