### PR TITLE
Refactor CRSF

### DIFF
--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -51,7 +51,7 @@
 * @param    rxPin  GPIO pin number for the UART RX line.
 * @param    txPin  GPIO pin number for the UART TX line.
 */
-Crsf::Crsf(HardwareSerial* uart, uint8_t rxPin, uint8_t txPin)
+Crsf::Crsf(HardwareSerial* const uart, const uint8_t rxPin, const uint8_t txPin)
 {
   m_uart = uart;
   m_uart->begin(CRSF_BAUD, SERIAL_8N1, rxPin, txPin, false);

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -18,7 +18,24 @@
 
 /**
 * @file   Crsf.cpp
-* @brief  This class handles communications with a CRSF/ELRS RC receiver.
+* @brief  CRSF/ELRS receiver implementation.
+*
+* Changes from the original Crsf.cpp
+* ------------------------------------
+* - crc8_dvb_s2() and calculateCrc() removed; replaced by calls to the
+*   equivalent static methods in CrsfCodec.
+*
+* - All wire-format constants (frame offsets, device addresses, frame type
+*   bytes, channel ranges) replaced with CrsfCodec:: qualified names; only
+*   transport and application-policy constants remain local to this class.
+*
+* - parseRcChannels(): the inline 11-bit channel unpacking replaced by a
+*   single call to CrsfCodec::unpackChannels().  The frame-length guard was
+*   also corrected (see the function's implementation comment for details).
+*
+* - parseLinkStatistics(): parameter renamed payloadLength → frameLength for
+*   accuracy (the value is the CRSF frame-length field, not a raw payload byte
+*   count).  Guard updated to use CrsfCodec::LINK_STATS_MIN_FRAME_LENGTH.
 */
 
 #include "Crsf.hpp"
@@ -28,11 +45,13 @@
 
 /**
 * @brief    CRSF constructor.
-* @param    uart - Pointer to hardware serial port.
-* @param    rxPin - RX pin number.
-* @param    txPin - TX pin number.
+* @details  Initialises the UART at CRSF_BAUD (420000 for ELRS) and flushes any
+*           stale bytes so that getDemands() begins with a clean stream.
+* @param    uart   Pointer to the hardware serial port to use.
+* @param    rxPin  GPIO pin number for the UART RX line.
+* @param    txPin  GPIO pin number for the UART TX line.
 */
-Crsf::Crsf(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin)
+Crsf::Crsf(HardwareSerial* uart, uint8_t rxPin, uint8_t txPin)
 {
   m_uart = uart;
   m_uart->begin(CRSF_BAUD, SERIAL_8N1, rxPin, txPin, false);
@@ -42,7 +61,18 @@ Crsf::Crsf(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin)
 
 /**
 * @brief    Decodes the CRSF serial stream into usable channel and flag data.
-* @return   Returns true when new data is available.
+* @details  Implements a three-state byte-stream parser.  Reads at most
+*           MAX_BYTES_PER_LOOP bytes per call so the main loop is never blocked
+*           for longer than a bounded time (~190 µs at 420000 baud).
+*
+*           State 0: hunt for a valid sync byte (ADDR_FLIGHT_CONTROLLER or
+*                    ADDR_RECEIVER — either address may appear on a shared bus).
+*           State 1: read and range-check the frame-length byte.
+*           State 2+: accumulate bytes; when the expected number have arrived,
+*                    validate the CRC and dispatch to the appropriate parser.
+*
+* @return   true when a new, valid RC channels frame has been decoded and
+*           m_rxData updated; false on all other calls.
 */
 bool
 Crsf::getDemands()
@@ -50,63 +80,70 @@ Crsf::getDemands()
   uint32_t currentByte;
   uint32_t rxCount = 0U;
 
-  // We loop for a maximum of MAX_BYTES_PER_LOOP bytes then get out of here to avoid blocking main loop.
   while (m_uart->available() && (rxCount < MAX_BYTES_PER_LOOP))
   {
     currentByte = m_uart->read();
     rxCount++;
 
-    // State 0: Looking for sync byte (device address)
+    // State 0: hunt for a valid sync byte.
+    // Both the FC address (0xC8) and the receiver address (0xEC) are accepted
+    // because either may appear as the sync byte on a shared bus.
     if (0U == m_bufferIndex)
     {
-      if ((currentByte == CRSF_ADDRESS_FLIGHT_CONTROLLER) ||
-          (currentByte == CRSF_ADDRESS_ALTERNATIVE))
+      if ((currentByte == static_cast<uint32_t>(CrsfCodec::ADDR_FLIGHT_CONTROLLER)) ||
+          (currentByte == static_cast<uint32_t>(CrsfCodec::ADDR_RECEIVER)))
       {
-        m_buffer[m_bufferIndex] = currentByte;
+        m_buffer[m_bufferIndex] = static_cast<uint8_t>(currentByte);
         m_bufferIndex++;
       }
     }
-    // State 1: Get frame length
+    // State 1: read the frame-length byte.
+    // Valid range: 2 to (MAX_FRAME_SIZE - 2).  The lower bound (2) represents
+    // the minimum meaningful frame (type + CRC, no payload).  The upper bound
+    // leaves room for the sync and length bytes themselves.
     else if (1U == m_bufferIndex)
     {
-      // Frame length includes type + payload + crc, should be reasonable
-      if ((currentByte >= 2U) && (currentByte <= (CRSF_MAX_FRAME_SIZE - 2U)))
+      if ((currentByte >= 2U) && (currentByte <= (CrsfCodec::MAX_FRAME_SIZE - 2U)))
       {
-        m_buffer[m_bufferIndex] = currentByte;
+        m_buffer[m_bufferIndex] = static_cast<uint8_t>(currentByte);
         m_bufferIndex++;
       }
       else
       {
-        // Invalid length, reset state machine
+        // Length out of range — discard and restart hunt
         m_bufferIndex = 0U;
       }
     }
-    // State 2+: Collect frame data
+    // State 2+: accumulate bytes until the full frame is buffered.
     else
     {
-      m_buffer[m_bufferIndex] = currentByte;
+      m_buffer[m_bufferIndex] = static_cast<uint8_t>(currentByte);
       m_bufferIndex++;
-      
-      // Check if we have complete frame (ADDR + LEN + frame_length bytes)
-      uint32_t frameLength = m_buffer[CRSF_LENGTH_OFFSET];
-      if (m_bufferIndex >= (frameLength + 2U))
-      {
-        // Validate CRC
-        uint32_t crcIndex = frameLength + 1U;
-        uint32_t calculatedCrc = calculateCrc(&m_buffer[CRSF_FRAMETYPE_OFFSET], frameLength - 1U);
 
-        if (calculatedCrc == m_buffer[crcIndex])
+      // Total frame buffer occupancy = sync(1) + length(1) + frame_length bytes.
+      // Wait until all of them have arrived before attempting to validate.
+      const uint32_t frameLength = static_cast<uint32_t>(m_buffer[CrsfCodec::LENGTH_OFFSET]);
+      if (static_cast<uint32_t>(m_bufferIndex) >= (frameLength + 2U))
+      {
+        // CRC covers the type byte and all payload bytes; it excludes sync and length.
+        // frame_length = type(1) + payload bytes + CRC(1), so (frame_length - 1)
+        // is the number of bytes to pass to calculateCrc (type + payload).
+        const uint32_t crcByteIndex  = frameLength + 1U;
+        const uint8_t  calculatedCrc = CrsfCodec::calculateCrc(
+                                         &m_buffer[CrsfCodec::TYPE_OFFSET],
+                                         static_cast<uint8_t>(frameLength - 1U));
+
+        if (calculatedCrc == m_buffer[crcByteIndex])
         {
-          // Valid frame - process based on type
-          uint32_t frameType = m_buffer[CRSF_FRAMETYPE_OFFSET];
-          const uint8_t *payload = &m_buffer[CRSF_PAYLOAD_OFFSET];
-          uint8_t payloadLength = m_buffer[CRSF_LENGTH_OFFSET];
-          
-          if (CRSF_FRAMETYPE_RC_CHANNELS == frameType)
+          // CRC valid — identify frame type and dispatch
+          const uint32_t  frameType = static_cast<uint32_t>(m_buffer[CrsfCodec::TYPE_OFFSET]);
+          const uint8_t*  payload   = &m_buffer[CrsfCodec::PAYLOAD_OFFSET];
+
+          if (static_cast<uint32_t>(CrsfCodec::FRAMETYPE_RC_CHANNELS) == frameType)
           {
-            parseRcChannels(payload, payloadLength);
-            
-            // Reset communications timer
+            parseRcChannels(payload, static_cast<uint8_t>(frameLength));
+
+            // Valid RC frame received — reset the loss-of-comms timer
             lossOfCommsTimer.set(COMMS_TIME_OUT_PERIOD);
             m_rxData.lostComms = false;
 
@@ -115,27 +152,26 @@ Crsf::getDemands()
               printData();
             }
 
-            // Reset buffer for next frame
             m_bufferIndex = 0U;
-            
             return true;
           }
-          else if (CRSF_FRAMETYPE_LINK_STATS == frameType)
+          else if (static_cast<uint32_t>(CrsfCodec::FRAMETYPE_LINK_STATS) == frameType)
           {
-            parseLinkStatistics(payload, payloadLength);
+            parseLinkStatistics(payload, static_cast<uint8_t>(frameLength));
           }
           else
           {
-            // Unknown frame type - ignore
+            // Unknown or unhandled frame type — discard silently
           }
         }
-        
-        // Reset buffer for next frame
+
+        // Frame complete (valid or invalid CRC) — reset for next frame
         m_bufferIndex = 0U;
       }
-      
-      // Prevent buffer overflow
-      if (m_bufferIndex >= CRSF_MAX_FRAME_SIZE)
+
+      // Safety guard: if somehow bufferIndex reaches the buffer limit without
+      // a complete frame being detected, reset rather than overflow the buffer.
+      if (static_cast<uint32_t>(m_bufferIndex) >= CrsfCodec::MAX_FRAME_SIZE)
       {
         m_bufferIndex = 0U;
       }
@@ -152,119 +188,99 @@ Crsf::getDemands()
 
 
 /**
-* @brief    Parses and normalises RC channels from CRSF payload.
-* @param    payload - Pointer to RC channels payload (22 bytes).
-* @param    payloadLength - Length of payload.
+* @brief    Parse a CRSF RC channels payload (frame type 0x16) and update m_rxData.
+* @details  Guards against short frames, delegates 11-bit channel unpacking to
+*           CrsfCodec::unpackChannels(), normalises the raw values into the
+*           application range, and updates the multi-level failsafe flag.
+*
+*           Frame-length guard correction
+*           ------------------------------
+*           The original code checked `frameLength < RC_PAYLOAD_BYTES (22)`.
+*           However, frameLength is the CRSF frame-length field, which equals
+*           type(1) + payload_bytes + CRC(1).  For a valid RC frame this value
+*           is 24, not 22.  A frame with frameLength = 22 would only carry 20
+*           bytes of payload — not enough for 16 channels.  The guard is now
+*           `frameLength < (RC_PAYLOAD_BYTES + 2U)` (i.e., < 24) which is the
+*           correct minimum for a complete RC channels frame.
+*
+* @param    payload      Pointer to the first payload byte in the frame buffer.
+* @param    frameLength  The CRSF frame-length field value (type + payload + CRC).
 */
 void
-Crsf::parseRcChannels(const uint8_t *payload, uint8_t payloadLength)
+Crsf::parseRcChannels(const uint8_t* payload, uint8_t frameLength)
 {
-  uint32_t rawChannels[NUM_CRSF_CH];
-
-  // Verify we have enough data for 16 channels (22 bytes)
-  if (payloadLength < CRSF_RC_FRAME_SIZE)
+  // Minimum frame-length field value for a valid RC channels frame:
+  // type(1) + 22 payload bytes + CRC(1) = 24.
+  if (frameLength < (CrsfCodec::RC_PAYLOAD_BYTES + 2U))
   {
     return;
   }
 
-  // Unpack 11-bit channels from packed byte array
-  // CRSF channel packing is little-endian, LSB first
-  rawChannels[0]  = ((payload[0]       | (payload[1]  << 8U))                           & 0x07FFU);
-  rawChannels[1]  = (((payload[1] >> 3U) | (payload[2]  << 5U))                         & 0x07FFU);
-  rawChannels[2]  = (((payload[2] >> 6U) | (payload[3]  << 2U) | (payload[4] << 10U))  & 0x07FFU);
-  rawChannels[3]  = (((payload[4] >> 1U) | (payload[5]  << 7U))                         & 0x07FFU);
-  rawChannels[4]  = (((payload[5] >> 4U) | (payload[6]  << 4U))                         & 0x07FFU);
-  rawChannels[5]  = (((payload[6] >> 7U) | (payload[7]  << 1U) | (payload[8] << 9U))   & 0x07FFU);
-  rawChannels[6]  = (((payload[8] >> 2U) | (payload[9]  << 6U))                         & 0x07FFU);
-  rawChannels[7]  = (((payload[9] >> 5U) | (payload[10] << 3U))                         & 0x07FFU);
-  rawChannels[8]  = ((payload[11]      | (payload[12] << 8U))                           & 0x07FFU);
-  rawChannels[9]  = (((payload[12] >> 3U) | (payload[13] << 5U))                        & 0x07FFU);
-  rawChannels[10] = (((payload[13] >> 6U) | (payload[14] << 2U) | (payload[15] << 10U)) & 0x07FFU);
-  rawChannels[11] = (((payload[15] >> 1U) | (payload[16] << 7U))                        & 0x07FFU);
-  rawChannels[12] = (((payload[16] >> 4U) | (payload[17] << 4U))                        & 0x07FFU);
-  rawChannels[13] = (((payload[17] >> 7U) | (payload[18] << 1U) | (payload[19] << 9U))  & 0x07FFU);
-  rawChannels[14] = (((payload[19] >> 2U) | (payload[20] << 6U))                        & 0x07FFU);
-  rawChannels[15] = (((payload[20] >> 5U) | (payload[21] << 3U))                        & 0x07FFU);
+  uint32_t rawChannels[CrsfCodec::NUM_CHANNELS];
 
-  // Normalise all channels to -1024/+1024 range
-  for (uint32_t i = 0U; i < NUM_CRSF_CH; i++)
+  // Unpack 16 x 11-bit channel values from the 22-byte little-endian bitstream.
+  // All bit manipulation is encapsulated in CrsfCodec::unpackChannels(); see
+  // CrsfCodec.cpp for a detailed explanation of the packing scheme.
+  CrsfCodec::unpackChannels(payload, rawChannels);
+
+  // Normalise each raw value from the CRSF range [172..1811] into the
+  // application range [MIN_NORMALISED..MAX_NORMALISED] (-1024..+1024).
+  for (uint32_t i = 0U; i < CrsfCodec::NUM_CHANNELS; i++)
   {
-    m_rxData.ch[i] = map32(rawChannels[i], MIN_CRSF_US, MAX_CRSF_US, MIN_NORMALISED, MAX_NORMALISED);
+    m_rxData.ch[i] = map32(rawChannels[i],
+                           CrsfCodec::MIN_CHANNEL_VALUE,
+                           CrsfCodec::MAX_CHANNEL_VALUE,
+                           MIN_NORMALISED,
+                           MAX_NORMALISED);
   }
 
-  // Multi-level failsafe detection
-  m_rxData.failsafe = m_rxData.lostComms || (m_crsfLinkStats.linkQuality < FAILSAFE_LQ_THRESHOLD);
+  // Multi-level failsafe: assert if communications are lost OR if link quality
+  // has dropped below the threshold even though frames are still arriving.
+  m_rxData.failsafe = m_rxData.lostComms ||
+                      (m_crsfLinkStats.linkQuality < FAILSAFE_LQ_THRESHOLD);
 }
 
 
 /**
-* @brief    Parses link statistics from CRSF payload.
-* @param    payload - Pointer to link statistics payload.
-* @param    payloadLength - Length of payload.
+* @brief    Parse a CRSF link statistics payload (frame type 0x14) and update
+*           m_crsfLinkStats.
+* @details  Reads the uplink RSSI, link quality, SNR, and TX power fields from
+*           the payload at the byte offsets defined by the CRSF 0x14 frame spec.
+*           The link quality value is subsequently used by parseRcChannels() for
+*           the secondary failsafe threshold check.
+*
+* @param    payload      Pointer to the first payload byte in the frame buffer.
+* @param    frameLength  The CRSF frame-length field value (type + payload + CRC).
 */
 void
-Crsf::parseLinkStatistics(const uint8_t *payload, uint8_t payloadLength)
+Crsf::parseLinkStatistics(const uint8_t* payload, uint8_t frameLength)
 {
-  // Verify we have enough data for link statistics (10 bytes minimum)
-  if (payloadLength < CRSF_LINK_FRAME_SIZE)
+  // Minimum frame-length field value for a valid link statistics frame:
+  // type(1) + 10 payload bytes + CRC(1) = 12.
+  if (frameLength < CrsfCodec::LINK_STATS_MIN_FRAME_LENGTH)
   {
     return;
   }
 
-  // Store uplink (receiver to transmitter) statistics
-  m_crsfLinkStats.rssiDbm = static_cast<int8_t>(payload[0]);
+  // Byte offsets within the 0x14 payload (CRSF spec: Link Statistics)
+  //   [0] up_rssi_ant1     — uplink RSSI antenna 1 (dBm * -1, so negate to get dBm)
+  //   [1] up_rssi_ant2     — uplink RSSI antenna 2 (unused here)
+  //   [2] up_link_quality  — uplink packet success rate (%)
+  //   [3] up_snr           — uplink SNR (dB, signed)
+  //   [4] active_antenna   — unused here
+  //   [5] rf_profile       — unused here
+  //   [6] up_rf_power      — transmitter power index
+  m_crsfLinkStats.rssiDbm     = static_cast<int8_t>(payload[0]);
   m_crsfLinkStats.linkQuality = static_cast<uint8_t>(payload[2]);
-  m_crsfLinkStats.snrDb = static_cast<int8_t>(payload[3]);
-  m_crsfLinkStats.txPower = static_cast<uint8_t>(payload[6]);
+  m_crsfLinkStats.snrDb       = static_cast<int8_t>(payload[3]);
+  m_crsfLinkStats.txPower     = static_cast<uint8_t>(payload[6]);
 }
 
 
 /**
-* @brief    Calculate CRC8 for a single byte (DVB-S2 polynomial).
-* @param    crc - Current CRC value.
-* @param    a - Byte to process.
-* @return   Updated CRC8 value.
-*/
-uint8_t
-Crsf::crc8_dvb_s2(uint8_t crc, uint8_t a) const
-{
-  crc ^= a;
-  for (uint32_t i = 0U; i < 8U; i++)
-  {
-    if ((crc & 0x80U) != 0U)
-    {
-      crc = (crc << 1U) ^ 0xD5U;
-    }
-    else
-    {
-      crc = crc << 1U;
-    }
-  }
-  return crc;
-}
-
-
-/**
-* @brief    Calculate CRC8 for a data buffer.
-* @param    data - Pointer to data buffer.
-* @param    length - Length of data.
-* @return   CRC8 value.
-*/
-uint8_t
-Crsf::calculateCrc(const uint8_t *data, uint8_t length) const
-{
-  uint32_t crc = 0U;
-  for (uint32_t i = 0U; i < length; i++)
-  {
-    crc = crc8_dvb_s2(crc, data[i]);
-  }
-  return crc;
-}
-
-
-/**
-* @brief    Returns the most recent receiver data.
-* @return   RxPacket containing failsafe, communication status, and normalised channel data.
+* @brief    Returns the most recent receiver data packet.
+* @return   RxPacket containing failsafe flag, lostComms flag, and normalised
+*           channel data in range [MIN_NORMALISED .. MAX_NORMALISED].
 */
 const RxBase::RxPacket
 Crsf::getData() const
@@ -274,8 +290,9 @@ Crsf::getData() const
 
 
 /**
-* @brief    Check if communications have been lost.
-* @return   true when CRSF comms has been lost, false otherwise.
+* @brief    Report whether CRSF communications have been lost.
+* @return   true if no valid RC channels frame has been received within
+*           COMMS_TIME_OUT_PERIOD milliseconds.
 */
 const bool
 Crsf::hasLostCommunications() const
@@ -285,8 +302,8 @@ Crsf::hasLostCommunications() const
 
 
 /**
-* @brief    Returns the CRSF-specific link statistics.
-* @return   CrsfLinkStats structure containing link quality data.
+* @brief    Returns the most recently received CRSF link quality statistics.
+* @return   CrsfLinkStats populated from the last valid 0x14 frame.
 */
 Crsf::CrsfLinkStats
 Crsf::getLinkStats() const
@@ -296,29 +313,32 @@ Crsf::getLinkStats() const
 
 
 /**
-* @brief    Prints CRSF data to console for debugging.
+* @brief    Prints channel data and status flags to Serial for debugging.
+* @details  Rate-limited by comparing against the last print time so that the
+*           output remains readable at high RC frame rates.  The update rate in
+*           Hz is derived from the inter-call delta and printed first.
+*           Only active when InternalConfig::DEBUG_RX is true (checked by the
+*           caller via if constexpr in getDemands()).
 */
 void
 Crsf::printData(void)
 {
-  static uint64_t lastPrintTime = 0U;     //Use of static ok here as there will only ever be one CRSF class.
-  const uint64_t now = esp_timer_get_time();
-  const uint64_t delta = now - lastPrintTime;
+  static uint64_t lastPrintTime = 0U;   // Static is safe: only one Crsf instance exists.
+  const uint64_t  now   = esp_timer_get_time();
+  const uint64_t  delta = now - lastPrintTime;
   lastPrintTime = now;
 
-  // Display update time delta in microseconds
   const uint32_t hz = static_cast<uint32_t>((delta > 0U) ? (1000000U / delta) : 0U);
   Serial.print("Hz=");
   Serial.print(hz, 1);
   Serial.print("\t");
-  
-  // Display the received normalised data
-  for (uint32_t i = 0U; i < NUM_CRSF_CH; i++)
+
+  for (uint32_t i = 0U; i < CrsfCodec::NUM_CHANNELS; i++)
   {
     Serial.print(m_rxData.ch[i]);
     Serial.print("\t");
   }
-  // Display failsafe and communications status
+
   Serial.print(m_rxData.failsafe);
   Serial.print("\t");
   Serial.println(m_rxData.lostComms);

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -103,7 +103,7 @@ class Crsf : public RxBase
     * @param   rxPin   GPIO pin number connected to the receiver's TX line.
     * @param   txPin   GPIO pin number connected to the receiver's RX line.
     */
-    Crsf(HardwareSerial* uart, uint8_t rxPin, uint8_t txPin);
+    Crsf(HardwareSerial* const uart, const uint8_t rxPin, const uint8_t txPin);
 
     /**
     * @brief   Read and decode incoming CRSF stream bytes.
@@ -198,6 +198,8 @@ class Crsf : public RxBase
     // Member variables
     // -------------------------------------------------------------------------
 
+    // Variables
+    /** Pointer to the underlying HardwareSerial peripheral. */
     HardwareSerial* m_uart;
 
     /** Index of the next byte to write into m_buffer; also encodes parser state. */
@@ -209,6 +211,7 @@ class Crsf : public RxBase
     /** Most recently received link statistics; initialised to worst-case values. */
     CrsfLinkStats   m_crsfLinkStats                          = {0U, -128, 0U, -128};
 
+    // Objects
     /** Timer used to detect loss of communications. */
     CTimer          lossOfCommsTimer                         = CTimer(0);
 

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -18,7 +18,22 @@
 
 /**
 * @file   Crsf.hpp
-* @brief  This class handles communications with a CRSF/ELRS RC receiver.
+* @brief  CRSF/ELRS receiver implementation.
+*
+* This class handles the CRSF/ELRS receive path: it decodes the CRSF byte
+* stream from the receiver into normalised RC channel data, accessible via
+* the RxBase interface.
+*
+* All protocol encoding/decoding and wire-format constants live in CrsfCodec.
+* This class owns only the UART transport, the receive state machine, and
+* the application-level policy constants (timeouts, thresholds).
+*
+* Telemetry transmit capability
+* ------------------------------
+* Telemetry transmission (ITelemetry interface) will be added in a subsequent
+* PR alongside the first concrete telemetry data source.  At that point Crsf
+* will inherit from both RxBase and ITelemetry, and the flight controller will
+* hold a second pointer of type ITelemetry* alongside its existing RxBase*.
 */
 
 #pragma once
@@ -29,151 +44,198 @@
 #include "Timer.hpp"
 #include "Config.hpp"
 #include "RxBase.hpp"
+#include "CrsfCodec.hpp"
 
 
 /**
- * @class Crsf
- * @brief CRSF protocol decoder implementation derived from RxBase.
- */
+* @class  Crsf
+* @brief  CRSF/ELRS protocol implementation providing RC channel input via RxBase.
+*
+* Protocol knowledge (frame format, CRC, channel packing) is delegated entirely
+* to CrsfCodec; this class owns only transport and application state.
+*/
 class Crsf : public RxBase
 {
   public:
-    static constexpr uint32_t MIN_CRSF_US        = 172U;
-    static constexpr uint32_t MID_CRSF_US        = 992U;
-    static constexpr uint32_t MAX_CRSF_US        = 1811U;
 
     /**
-     * @brief Channel mapping for CRSF protocol (AETR ordering).
-     * Maps standard channel names to physical CRSF channel positions.
-     * CRSF native ordering: Aileron, Elevator, Throttle, Rudder
-     */
-    static constexpr uint32_t CHANNEL_MAP[9] = 
+    * @brief Channel mapping for CRSF/ELRS protocol (AETR ordering).
+    *
+    * Maps logical ChannelName values to their physical CRSF channel indices.
+    * CRSF transmits channels in Aileron(0), Elevator(1), Throttle(2), Rudder(3)
+    * order; this table re-orders them to the flight controller's convention.
+    */
+    static constexpr uint32_t CHANNEL_MAP[9] =
     {
-      2U,  // THROTTLE
-      0U,  // ROLL (Aileron)
-      1U,  // PITCH (Elevator)
-      3U,  // YAW (Rudder)
-      4U,  // ARM
-      5U,  // MODE
-      6U,  // AUX1
-      7U,  // AUX2
-      8U   // AUX3
+      2U,   // THROTTLE → CRSF channel 2
+      0U,   // ROLL     → CRSF channel 0 (Aileron)
+      1U,   // PITCH    → CRSF channel 1 (Elevator)
+      3U,   // YAW      → CRSF channel 3 (Rudder)
+      4U,   // ARM      → CRSF channel 4
+      5U,   // MODE     → CRSF channel 5
+      6U,   // AUX1     → CRSF channel 6
+      7U,   // AUX2     → CRSF channel 7
+      8U    // AUX3     → CRSF channel 8
     };
 
     /**
-     * @struct CrsfLinkStats
-     * @brief CRSF-specific link quality statistics.
-     */
+    * @struct CrsfLinkStats
+    * @brief  CRSF uplink quality statistics decoded from frame type 0x14.
+    *
+    * Updated each time a valid link statistics frame is received.
+    * linkQuality is also used by parseRcChannels() for multi-level failsafe
+    * detection — if it falls below FAILSAFE_LQ_THRESHOLD the failsafe flag
+    * is asserted even if frames are still arriving.
+    */
     struct CrsfLinkStats
     {
-      uint8_t linkQuality;  // Link quality percentage (0-100)
-      int8_t rssiDbm;       // RSSI in dBm (-128 to 0)
-      uint8_t txPower;      // TX power index
-      int8_t snrDb;         // SNR in dB
+      uint8_t linkQuality;   ///< Uplink packet success rate, percent (0–100)
+      int8_t  rssiDbm;       ///< Uplink RSSI in dBm (negative; closer to 0 = stronger)
+      uint8_t txPower;       ///< Transmitter power index (see CRSF spec 0x14)
+      int8_t  snrDb;         ///< Uplink signal-to-noise ratio in dB
     };
-    
-    /**
-     * @brief Constructor for CRSF receiver.
-     * @param uart Pointer to hardware serial port.
-     * @param rxPin RX pin number.
-     * @param txPin TX pin number.
-     */
-    Crsf(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin);
 
     /**
-     * @brief Get new data from CRSF receiver.
-     * @return true when new data is available, false otherwise.
-     */
+    * @brief   Constructor.
+    * @details Initialises the UART at CRSF_BAUD (420000 baud for ELRS) and
+    *          flushes any stale bytes before the first getDemands() call.
+    * @param   uart    Pointer to the HardwareSerial port to use.
+    * @param   rxPin   GPIO pin number connected to the receiver's TX line.
+    * @param   txPin   GPIO pin number connected to the receiver's RX line.
+    */
+    Crsf(HardwareSerial* uart, uint8_t rxPin, uint8_t txPin);
+
+    /**
+    * @brief   Read and decode incoming CRSF stream bytes.
+    * @details Implements a three-state byte-stream parser:
+    *            State 0 — hunt for a valid sync byte.
+    *            State 1 — read and validate the frame-length byte.
+    *            State 2+ — accumulate bytes until the complete frame is buffered,
+    *                       validate CRC, then dispatch to the appropriate parser.
+    *          At most MAX_BYTES_PER_LOOP bytes are consumed per call so that
+    *          the main loop is never blocked for longer than a bounded time.
+    * @return  true when a new, valid RC channels frame has been decoded and
+    *          m_rxData updated; false on all other calls.
+    */
     bool getDemands() override;
 
     /**
-     * @brief Print receiver data to console for debugging.
-     */
+    * @brief Prints channel data and status flags to Serial for debugging.
+    * @note  Rate-limited internally; active only when InternalConfig::DEBUG_RX
+    *        is true (checked by the caller via if constexpr).
+    */
     void printData();
 
     /**
-     * @brief Get receiver data packet.
-     * @return RxPacket containing failsafe status, communication status, and normalised channel data.
-     */
+    * @brief   Return the most recently decoded RC data packet.
+    * @return  RxPacket with failsafe flag, lostComms flag, and 16 normalised
+    *          channel values in the range [MIN_NORMALISED .. MAX_NORMALISED].
+    */
     const RxPacket getData() const override;
 
     /**
-     * @brief Check if communications have been lost.
-     * @return true if communications lost, false otherwise.
-     */
+    * @brief   Report whether CRSF communications have been lost.
+    * @return  true if no valid RC channels frame has been received within
+    *          COMMS_TIME_OUT_PERIOD milliseconds.
+    */
     const bool hasLostCommunications() const override;
 
     /**
-     * @brief Get channel index from channel name.
-     * @param name The channel name enum.
-     * @return Channel index (0-based).
-     */
+    * @brief   Resolve a logical ChannelName to its physical CRSF channel index.
+    * @param   name  Logical channel name enum value.
+    * @return  Physical channel index (0-based) for use with RxPacket::ch[].
+    */
     uint32_t getChannelIndex(ChannelName name) const override
     {
       return CHANNEL_MAP[static_cast<uint32_t>(name)];
     }
 
     /**
-     * @brief Get CRSF-specific link statistics.
-     * @return CrsfLinkStats structure containing link quality data.
-     */
+    * @brief   Return the most recently received CRSF link quality statistics.
+    * @return  CrsfLinkStats populated from the last valid 0x14 frame.
+    *          Values are initialised to worst-case on construction.
+    */
     CrsfLinkStats getLinkStats() const;
 
+
   private:
-    static constexpr uint32_t CRSF_BAUD                 = 420000U;
-    static constexpr uint32_t CRSF_MAX_FRAME_SIZE       = 64U;
-    static constexpr uint32_t CRSF_PAYLOAD_OFFSET       = 3U;
-    static constexpr uint32_t CRSF_FRAMETYPE_OFFSET     = 2U;
-    static constexpr uint32_t CRSF_LENGTH_OFFSET        = 1U;
-    static constexpr uint32_t NUM_CRSF_CH               = 16U;
-    static constexpr uint32_t MAX_BYTES_PER_LOOP        = 10U;
-    static constexpr uint32_t CRSF_RC_FRAME_SIZE        = 22U;
-    static constexpr uint32_t CRSF_LINK_FRAME_SIZE      = 12U;
-    static constexpr uint64_t COMMS_TIME_OUT_PERIOD     = 100U;
-    static constexpr uint8_t  FAILSAFE_LQ_THRESHOLD     = 20U;
-    
-    // CRSF Device Addresses
-    static constexpr uint8_t CRSF_ADDRESS_FLIGHT_CONTROLLER = 0xC8U;
-    static constexpr uint8_t CRSF_ADDRESS_ALTERNATIVE       = 0xECU;
-    
-    // CRSF Frame Types
-    static constexpr uint8_t CRSF_FRAMETYPE_RC_CHANNELS = 0x16U;
-    static constexpr uint8_t CRSF_FRAMETYPE_LINK_STATS  = 0x14U;
 
-    HardwareSerial *m_uart;
-    uint8_t m_bufferIndex = 0U;
-    uint8_t m_buffer[CRSF_MAX_FRAME_SIZE] = {};
-    CrsfLinkStats m_crsfLinkStats = {0U, -128, 0U, -128};
-
-    CTimer lossOfCommsTimer = CTimer(0);
+    // -------------------------------------------------------------------------
+    // Transport and application-policy constants.
+    // Protocol wire-format constants (frame structure, addresses, frame types,
+    // channel ranges) have moved to CrsfCodec and are accessed via CrsfCodec::.
+    // -------------------------------------------------------------------------
 
     /**
-     * @brief Parse RC channels from CRSF payload.
-     * @param payload Pointer to RC channels payload (22 bytes).
-     * @param payloadLength Length of payload.
-     */
-    void parseRcChannels(const uint8_t *payload, uint8_t payloadLength);
+    * UART baud rate for CRSF/ELRS.
+    * ExpressLRS uses 420000 baud.  The original CRSF specification states
+    * 416666 baud for the flying-platform UART; 420000 is correct for ELRS.
+    */
+    static constexpr uint32_t CRSF_BAUD             = 420000U;
 
     /**
-     * @brief Parse link statistics from CRSF payload.
-     * @param payload Pointer to link statistics payload.
-     * @param payloadLength Length of payload.
-     */
-    void parseLinkStatistics(const uint8_t *payload, uint8_t payloadLength);
+    * Maximum number of bytes consumed from the UART per getDemands() call.
+    * Caps the worst-case time spent in getDemands() to keep the main loop
+    * bounded.  At 420000 baud, 10 bytes takes approximately 190 µs.
+    */
+    static constexpr uint32_t MAX_BYTES_PER_LOOP    = 10U;
 
     /**
-     * @brief Calculate CRC8 for a single byte (DVB-S2 polynomial).
-     * @param crc Current CRC value.
-     * @param a Byte to process.
-     * @return Updated CRC8 value.
-     */
-    uint8_t crc8_dvb_s2(uint8_t crc, uint8_t a) const;
+    * Time in milliseconds after which, if no valid RC channels frame has been
+    * received, lostComms is set true and failsafe is asserted.
+    */
+    static constexpr uint64_t COMMS_TIME_OUT_PERIOD = 100U;
 
     /**
-     * @brief Calculate CRC8 for a data buffer.
-     * @param data Pointer to data buffer.
-     * @param length Length of data.
-     * @return CRC8 value.
-     */
-    uint8_t calculateCrc(const uint8_t *data, uint8_t length) const;
+    * Link quality percentage below which the failsafe flag is asserted even
+    * if frames are still arriving.  Provides an early-warning failsafe before
+    * total signal loss occurs.
+    */
+    static constexpr uint8_t  FAILSAFE_LQ_THRESHOLD = 20U;
+
+
+    // -------------------------------------------------------------------------
+    // Member variables
+    // -------------------------------------------------------------------------
+
+    HardwareSerial* m_uart;
+
+    /** Index of the next byte to write into m_buffer; also encodes parser state. */
+    uint8_t         m_bufferIndex                            = 0U;
+
+    /** Receive frame assembly buffer.  Sized to the maximum CRSF frame length. */
+    uint8_t         m_buffer[CrsfCodec::MAX_FRAME_SIZE]      = {};
+
+    /** Most recently received link statistics; initialised to worst-case values. */
+    CrsfLinkStats   m_crsfLinkStats                          = {0U, -128, 0U, -128};
+
+    /** Timer used to detect loss of communications. */
+    CTimer          lossOfCommsTimer                         = CTimer(0);
+
+
+    // -------------------------------------------------------------------------
+    // Private methods
+    // -------------------------------------------------------------------------
+
+    /**
+    * @brief   Parse a CRSF RC channels payload and update m_rxData.
+    * @details Validates that frameLength indicates a full 22-byte payload,
+    *          delegates 11-bit channel unpacking to CrsfCodec::unpackChannels(),
+    *          normalises each raw value to [MIN_NORMALISED .. MAX_NORMALISED]
+    *          via map32(), and updates the multi-level failsafe flag.
+    * @param   payload      Pointer to the first payload byte in m_buffer.
+    * @param   frameLength  The CRSF frame-length field value
+    *                       (= type byte + payload bytes + CRC byte).
+    */
+    void parseRcChannels(const uint8_t* payload, uint8_t frameLength);
+
+    /**
+    * @brief   Parse a CRSF link statistics payload and update m_crsfLinkStats.
+    * @details Validates that frameLength indicates a sufficiently long payload,
+    *          then reads RSSI, link quality, SNR, and TX power from the payload
+    *          bytes at the offsets defined by the CRSF 0x14 frame specification.
+    * @param   payload      Pointer to the first payload byte in m_buffer.
+    * @param   frameLength  The CRSF frame-length field value.
+    */
+    void parseLinkStatistics(const uint8_t* payload, uint8_t frameLength);
 };

--- a/PlainFlightController/CrsfCodec.cpp
+++ b/PlainFlightController/CrsfCodec.cpp
@@ -62,22 +62,24 @@
 * @return  Updated CRC8 value.
 */
 uint8_t
-CrsfCodec::crc8DvbS2(uint8_t crc, uint8_t a)
+CrsfCodec::crc8DvbS2(const uint8_t crc, const uint8_t a)
 {
-  crc ^= a;
+  // Use a local variable for the calculation to keep input parameters immutable.
+  uint8_t crcResult = static_cast<uint8_t>(static_cast<uint32_t>(crc) ^ static_cast<uint32_t>(a));
+
   for (uint32_t i = 0U; i < 8U; i++)
   {
-    if ((crc & 0x80U) != 0U)
+    if ((crcResult & 0x80U) != 0U)
     {
       // Cast to uint32_t before shifting to avoid signed-int promotion of uint8_t.
-      crc = static_cast<uint8_t>((static_cast<uint32_t>(crc) << 1U) ^ 0xD5U);
+      crcResult = static_cast<uint8_t>((static_cast<uint32_t>(crcResult) << 1U) ^ 0xD5U);
     }
     else
     {
-      crc = static_cast<uint8_t>(static_cast<uint32_t>(crc) << 1U);
+      crcResult = static_cast<uint8_t>(static_cast<uint32_t>(crcResult) << 1U);
     }
   }
-  return crc;
+  return crcResult;
 }
 
 
@@ -90,7 +92,7 @@ CrsfCodec::crc8DvbS2(uint8_t crc, uint8_t a)
 * @return  Final CRC8 value.
 */
 uint8_t
-CrsfCodec::calculateCrc(const uint8_t* data, uint8_t length)
+CrsfCodec::calculateCrc(const uint8_t* const data, const uint8_t length)
 {
   uint8_t crc = 0U;
   for (uint32_t i = 0U; i < static_cast<uint32_t>(length); i++)
@@ -119,7 +121,7 @@ CrsfCodec::calculateCrc(const uint8_t* data, uint8_t length)
 *            bit 22 = payload[2] bit 6  -> payload[2] >> 6  (2 bits)
 *            bit 24 = payload[3] bit 0  -> payload[3] << 2  (8 bits, shifted up 2)
 *            bit 32 = payload[4] bit 0  -> payload[4] << 10 (1 bit,  shifted up 10)
-*            result = ((p[2]>>6) | (p[3]<<2) | (p[4]<<10)) & 0x7FF
+*            result = ((p[2]>>6) | (p[3]<<2) | (p[4]<<10)) & CHANNEL_VALUE_MASK
 *
 *          All payload bytes are cast to uint32_t before shifting to avoid the
 *          implicit promotion to signed int that C++ applies to uint8_t operands.
@@ -133,77 +135,77 @@ CrsfCodec::calculateCrc(const uint8_t* data, uint8_t length)
 *                      [MIN_CHANNEL_VALUE .. MAX_CHANNEL_VALUE].
 */
 void
-CrsfCodec::unpackChannels(const uint8_t* payload, uint32_t (&rawChannels)[NUM_CHANNELS])
+CrsfCodec::unpackChannels(const uint8_t* const payload, uint32_t (&rawChannels)[NUM_CHANNELS])
 {
   // Channels 0-7 (payload bytes 0-10)
   rawChannels[0]  =  (static_cast<uint32_t>(payload[0])
                    | (static_cast<uint32_t>(payload[1])  << 8U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[1]  =  ((static_cast<uint32_t>(payload[1])  >> 3U)
                    |  (static_cast<uint32_t>(payload[2])  << 5U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[2]  =  ((static_cast<uint32_t>(payload[2])  >> 6U)
                    |  (static_cast<uint32_t>(payload[3])  << 2U)
                    |  (static_cast<uint32_t>(payload[4])  << 10U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[3]  =  ((static_cast<uint32_t>(payload[4])  >> 1U)
                    |  (static_cast<uint32_t>(payload[5])  << 7U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[4]  =  ((static_cast<uint32_t>(payload[5])  >> 4U)
                    |  (static_cast<uint32_t>(payload[6])  << 4U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[5]  =  ((static_cast<uint32_t>(payload[6])  >> 7U)
                    |  (static_cast<uint32_t>(payload[7])  << 1U)
                    |  (static_cast<uint32_t>(payload[8])  << 9U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[6]  =  ((static_cast<uint32_t>(payload[8])  >> 2U)
                    |  (static_cast<uint32_t>(payload[9])  << 6U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[7]  =  ((static_cast<uint32_t>(payload[9])  >> 5U)
                    |  (static_cast<uint32_t>(payload[10]) << 3U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   // Channels 8-15 (payload bytes 11-21)
   // Note: channel 8 starts at payload[11], not payload[10].  payload[10] carries
   // the upper bits of channel 7 (bits 80-87).  Channel 8 begins at bit 88.
   rawChannels[8]  =  (static_cast<uint32_t>(payload[11])
                    | (static_cast<uint32_t>(payload[12]) << 8U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[9]  =  ((static_cast<uint32_t>(payload[12]) >> 3U)
                    |  (static_cast<uint32_t>(payload[13]) << 5U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[10] =  ((static_cast<uint32_t>(payload[13]) >> 6U)
                    |  (static_cast<uint32_t>(payload[14]) << 2U)
                    |  (static_cast<uint32_t>(payload[15]) << 10U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[11] =  ((static_cast<uint32_t>(payload[15]) >> 1U)
                    |  (static_cast<uint32_t>(payload[16]) << 7U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[12] =  ((static_cast<uint32_t>(payload[16]) >> 4U)
                    |  (static_cast<uint32_t>(payload[17]) << 4U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[13] =  ((static_cast<uint32_t>(payload[17]) >> 7U)
                    |  (static_cast<uint32_t>(payload[18]) << 1U)
                    |  (static_cast<uint32_t>(payload[19]) << 9U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[14] =  ((static_cast<uint32_t>(payload[19]) >> 2U)
                    |  (static_cast<uint32_t>(payload[20]) << 6U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 
   rawChannels[15] =  ((static_cast<uint32_t>(payload[20]) >> 5U)
                    |  (static_cast<uint32_t>(payload[21]) << 3U))
-                   & 0x07FFU;
+                   & CHANNEL_VALUE_MASK;
 }

--- a/PlainFlightController/CrsfCodec.cpp
+++ b/PlainFlightController/CrsfCodec.cpp
@@ -1,0 +1,209 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   CrsfCodec.cpp
+* @brief  CRSF protocol codec implementation: CRC calculation and RC channel unpacking.
+*
+* Implementation notes
+* --------------------
+* CRC
+*   All CRSF frames use CRC8 with the DVB-S2 polynomial (0xD5).  The CRC
+*   covers the frame-type byte and all payload bytes; it excludes the sync
+*   byte and the frame-length byte.  calculateCrc() and crc8DvbS2() implement
+*   this for use by both the receive-side CRC validator in Crsf::getDemands()
+*   and, in future, the transmit-side frame builders.
+*
+* MISRA alignment
+*   Explicit static_cast<> is used throughout in preference to relying on
+*   implicit arithmetic promotions.  In particular:
+*     - uint8_t operands are cast to uint32_t before shift operations to
+*       avoid the implicit promotion to signed int that the C++ standard
+*       applies to sub-int types.
+*     - Results of arithmetic on wider types are explicitly narrowed back to
+*       uint8_t when stored into byte-array slots or uint8_t variables.
+*
+* Telemetry frame builders
+* ------------------------
+* buildGpsFrame(), buildBatteryFrame() and their supporting helpers
+* (writeFrameHeader, finaliseFrame) are intentionally absent from this PR.
+* They will be added by dedicated feature PRs for each telemetry data source.
+*/
+
+#include "CrsfCodec.hpp"
+
+
+// =============================================================================
+// CRC functions
+// =============================================================================
+
+/**
+* @brief   Process one byte through the CRC8 DVB-S2 algorithm (polynomial 0xD5).
+* @details The algorithm XORs the input byte into the running CRC and then
+*          processes each bit, conditionally applying the 0xD5 polynomial on
+*          each '1' bit shifted out of the MSB.
+* @param   crc  Running CRC accumulator (0x00 on first call).
+* @param   a    Byte to fold into the CRC.
+* @return  Updated CRC8 value.
+*/
+uint8_t
+CrsfCodec::crc8DvbS2(uint8_t crc, uint8_t a)
+{
+  crc ^= a;
+  for (uint32_t i = 0U; i < 8U; i++)
+  {
+    if ((crc & 0x80U) != 0U)
+    {
+      // Cast to uint32_t before shifting to avoid signed-int promotion of uint8_t.
+      crc = static_cast<uint8_t>((static_cast<uint32_t>(crc) << 1U) ^ 0xD5U);
+    }
+    else
+    {
+      crc = static_cast<uint8_t>(static_cast<uint32_t>(crc) << 1U);
+    }
+  }
+  return crc;
+}
+
+
+/**
+* @brief   Calculate CRC8 (DVB-S2, polynomial 0xD5) over a data buffer.
+* @details Iterates over each byte in the buffer, folding it into the CRC
+*          accumulator via crc8DvbS2().
+* @param   data    Pointer to the first byte to include (must not be nullptr).
+* @param   length  Number of bytes to process.
+* @return  Final CRC8 value.
+*/
+uint8_t
+CrsfCodec::calculateCrc(const uint8_t* data, uint8_t length)
+{
+  uint8_t crc = 0U;
+  for (uint32_t i = 0U; i < static_cast<uint32_t>(length); i++)
+  {
+    crc = crc8DvbS2(crc, data[i]);
+  }
+  return crc;
+}
+
+
+// =============================================================================
+// Channel unpacking
+// =============================================================================
+
+/**
+* @brief   Unpack 16 raw 11-bit RC channel values from a CRSF packed-channels payload.
+* @details CRSF packs 16 channels at 11 bits each into a 22-byte little-endian
+*          bitstream (176 bits total).  Each channel value occupies 11 consecutive
+*          bits starting at bit offset (channel_index * 11) counting from bit 0 of
+*          payload[0].
+*
+*          The bit manipulation for each channel is:
+*            channel_n = bits[(n*11) .. (n*11 + 10)]
+*
+*          Worked example for channel 2 (bits 22-32):
+*            bit 22 = payload[2] bit 6  -> payload[2] >> 6  (2 bits)
+*            bit 24 = payload[3] bit 0  -> payload[3] << 2  (8 bits, shifted up 2)
+*            bit 32 = payload[4] bit 0  -> payload[4] << 10 (1 bit,  shifted up 10)
+*            result = ((p[2]>>6) | (p[3]<<2) | (p[4]<<10)) & 0x7FF
+*
+*          All payload bytes are cast to uint32_t before shifting to avoid the
+*          implicit promotion to signed int that C++ applies to uint8_t operands.
+*
+*          No length validation is performed here; the caller (Crsf::parseRcChannels)
+*          must verify that the payload is at least RC_PAYLOAD_BYTES long before
+*          calling this function.
+*
+* @param   payload     Pointer to the first byte of the RC channels payload.
+* @param   rawChannels Output array; receives 16 raw values in range
+*                      [MIN_CHANNEL_VALUE .. MAX_CHANNEL_VALUE].
+*/
+void
+CrsfCodec::unpackChannels(const uint8_t* payload, uint32_t (&rawChannels)[NUM_CHANNELS])
+{
+  // Channels 0-7 (payload bytes 0-10)
+  rawChannels[0]  =  (static_cast<uint32_t>(payload[0])
+                   | (static_cast<uint32_t>(payload[1])  << 8U))
+                   & 0x07FFU;
+
+  rawChannels[1]  =  ((static_cast<uint32_t>(payload[1])  >> 3U)
+                   |  (static_cast<uint32_t>(payload[2])  << 5U))
+                   & 0x07FFU;
+
+  rawChannels[2]  =  ((static_cast<uint32_t>(payload[2])  >> 6U)
+                   |  (static_cast<uint32_t>(payload[3])  << 2U)
+                   |  (static_cast<uint32_t>(payload[4])  << 10U))
+                   & 0x07FFU;
+
+  rawChannels[3]  =  ((static_cast<uint32_t>(payload[4])  >> 1U)
+                   |  (static_cast<uint32_t>(payload[5])  << 7U))
+                   & 0x07FFU;
+
+  rawChannels[4]  =  ((static_cast<uint32_t>(payload[5])  >> 4U)
+                   |  (static_cast<uint32_t>(payload[6])  << 4U))
+                   & 0x07FFU;
+
+  rawChannels[5]  =  ((static_cast<uint32_t>(payload[6])  >> 7U)
+                   |  (static_cast<uint32_t>(payload[7])  << 1U)
+                   |  (static_cast<uint32_t>(payload[8])  << 9U))
+                   & 0x07FFU;
+
+  rawChannels[6]  =  ((static_cast<uint32_t>(payload[8])  >> 2U)
+                   |  (static_cast<uint32_t>(payload[9])  << 6U))
+                   & 0x07FFU;
+
+  rawChannels[7]  =  ((static_cast<uint32_t>(payload[9])  >> 5U)
+                   |  (static_cast<uint32_t>(payload[10]) << 3U))
+                   & 0x07FFU;
+
+  // Channels 8-15 (payload bytes 11-21)
+  // Note: channel 8 starts at payload[11], not payload[10].  payload[10] carries
+  // the upper bits of channel 7 (bits 80-87).  Channel 8 begins at bit 88.
+  rawChannels[8]  =  (static_cast<uint32_t>(payload[11])
+                   | (static_cast<uint32_t>(payload[12]) << 8U))
+                   & 0x07FFU;
+
+  rawChannels[9]  =  ((static_cast<uint32_t>(payload[12]) >> 3U)
+                   |  (static_cast<uint32_t>(payload[13]) << 5U))
+                   & 0x07FFU;
+
+  rawChannels[10] =  ((static_cast<uint32_t>(payload[13]) >> 6U)
+                   |  (static_cast<uint32_t>(payload[14]) << 2U)
+                   |  (static_cast<uint32_t>(payload[15]) << 10U))
+                   & 0x07FFU;
+
+  rawChannels[11] =  ((static_cast<uint32_t>(payload[15]) >> 1U)
+                   |  (static_cast<uint32_t>(payload[16]) << 7U))
+                   & 0x07FFU;
+
+  rawChannels[12] =  ((static_cast<uint32_t>(payload[16]) >> 4U)
+                   |  (static_cast<uint32_t>(payload[17]) << 4U))
+                   & 0x07FFU;
+
+  rawChannels[13] =  ((static_cast<uint32_t>(payload[17]) >> 7U)
+                   |  (static_cast<uint32_t>(payload[18]) << 1U)
+                   |  (static_cast<uint32_t>(payload[19]) << 9U))
+                   & 0x07FFU;
+
+  rawChannels[14] =  ((static_cast<uint32_t>(payload[19]) >> 2U)
+                   |  (static_cast<uint32_t>(payload[20]) << 6U))
+                   & 0x07FFU;
+
+  rawChannels[15] =  ((static_cast<uint32_t>(payload[20]) >> 5U)
+                   |  (static_cast<uint32_t>(payload[21]) << 3U))
+                   & 0x07FFU;
+}

--- a/PlainFlightController/CrsfCodec.cpp
+++ b/PlainFlightController/CrsfCodec.cpp
@@ -29,7 +29,7 @@
 *   this for use by both the receive-side CRC validator in Crsf::getDemands()
 *   and, in future, the transmit-side frame builders.
 *
-* MISRA alignment
+* MISRA alignment  (Is this over the top?)
 *   Explicit static_cast<> is used throughout in preference to relying on
 *   implicit arithmetic promotions.  In particular:
 *     - uint8_t operands are cast to uint32_t before shift operations to
@@ -38,11 +38,6 @@
 *     - Results of arithmetic on wider types are explicitly narrowed back to
 *       uint8_t when stored into byte-array slots or uint8_t variables.
 *
-* Telemetry frame builders
-* ------------------------
-* buildGpsFrame(), buildBatteryFrame() and their supporting helpers
-* (writeFrameHeader, finaliseFrame) are intentionally absent from this PR.
-* They will be added by dedicated feature PRs for each telemetry data source.
 */
 
 #include "CrsfCodec.hpp"

--- a/PlainFlightController/CrsfCodec.hpp
+++ b/PlainFlightController/CrsfCodec.hpp
@@ -164,7 +164,7 @@ class CrsfCodec
     * @param   length  Number of bytes to process.
     * @return  Calculated CRC8 value.
     */
-    static uint8_t calculateCrc(const uint8_t* data, const uint8_t length);
+    static uint8_t calculateCrc(const uint8_t* const data, const uint8_t length);
 
 
   private:

--- a/PlainFlightController/CrsfCodec.hpp
+++ b/PlainFlightController/CrsfCodec.hpp
@@ -1,0 +1,186 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   CrsfCodec.hpp
+* @brief  Stateless CRSF protocol codec: CRC, channel unpacking, and all
+*         CRSF wire-format constants required for frame reception.
+*
+* Design rationale
+* ----------------
+* This class is deliberately separated from Crsf (the UART transport implementation)
+* for two reasons:
+*
+*   1. Bearer independence: the protocol knowledge can be shared by future bearer
+*      implementations (e.g. ESP-NOW) without duplication.  Each bearer handles its
+*      own framing/transport; all of them call CrsfCodec for encoding and decoding.
+*
+*   2. Testability: stateless pure functions are easy to unit-test in isolation,
+*      without requiring a live UART or hardware mock.
+*
+* All methods are static and the class cannot be instantiated (constructor is deleted).
+*
+* Telemetry frame builders
+* ------------------------
+* Frame encoding methods (buildGpsFrame, buildBatteryFrame) and their supporting
+* private helpers (writeFrameHeader, finaliseFrame) and return type (TelemetryFrame)
+* are intentionally absent from this PR.  They will be added by dedicated feature PRs
+* for each telemetry data source.  The frame-type constants FRAMETYPE_GPS and
+* FRAMETYPE_BATTERY are retained here as wire-format documentation.
+*/
+
+#pragma once
+
+#include <inttypes.h>
+
+
+/**
+* @class  CrsfCodec
+* @brief  Static utility class for CRSF frame decoding and CRC calculation.
+*         Cannot be instantiated; all members are static.
+*/
+class CrsfCodec
+{
+  public:
+
+    // -------------------------------------------------------------------------
+    // Frame structure constants
+    // Byte offsets within any CRSF frame buffer.
+    // -------------------------------------------------------------------------
+
+    /** Maximum CRSF frame size in bytes (includes sync byte and CRC). */
+    static constexpr uint32_t MAX_FRAME_SIZE          = 64U;
+
+    /** Byte offset of the sync / device-address byte within a frame buffer. */
+    static constexpr uint32_t SYNC_OFFSET             = 0U;
+
+    /** Byte offset of the frame-length field within a frame buffer.
+     *  The frame-length value = type(1) + payload bytes + CRC(1). */
+    static constexpr uint32_t LENGTH_OFFSET           = 1U;
+
+    /** Byte offset of the frame-type byte within a frame buffer. */
+    static constexpr uint32_t TYPE_OFFSET             = 2U;
+
+    /** Byte offset of the first payload byte within a frame buffer. */
+    static constexpr uint32_t PAYLOAD_OFFSET          = 3U;
+
+
+    // -------------------------------------------------------------------------
+    // Device address constants  (CRSF spec: Device Addresses)
+    // -------------------------------------------------------------------------
+
+    /** Flight controller device address; also used as the sync byte for frames
+     *  sent to / from the FC. */
+    static constexpr uint8_t  ADDR_FLIGHT_CONTROLLER  = 0xC8U;
+
+    /** RC receiver device address. */
+    static constexpr uint8_t  ADDR_RECEIVER           = 0xECU;
+
+
+    // -------------------------------------------------------------------------
+    // Frame type constants  (CRSF spec: Broadcast Frame Types)
+    // -------------------------------------------------------------------------
+
+    /** GPS telemetry frame type (spec section 0x02).
+     *  Reserved; frame builder to be added in the GPS telemetry feature PR. */
+    static constexpr uint8_t  FRAMETYPE_GPS           = 0x02U;
+
+    /** Battery sensor telemetry frame type (spec section 0x08).
+     *  Reserved; frame builder to be added in the battery telemetry feature PR. */
+    static constexpr uint8_t  FRAMETYPE_BATTERY       = 0x08U;
+
+    /** Link statistics frame type (spec section 0x14). */
+    static constexpr uint8_t  FRAMETYPE_LINK_STATS    = 0x14U;
+
+    /** Packed RC channels frame type (spec section 0x16). */
+    static constexpr uint8_t  FRAMETYPE_RC_CHANNELS   = 0x16U;
+
+
+    // -------------------------------------------------------------------------
+    // RC channel constants
+    // -------------------------------------------------------------------------
+
+    /** Number of RC channels carried in a single packed channels frame. */
+    static constexpr uint32_t NUM_CHANNELS            = 16U;
+
+    /** Raw CRSF channel value at full-low stick position. */
+    static constexpr uint32_t MIN_CHANNEL_VALUE       = 172U;
+
+    /** Raw CRSF channel value at centre-stick position. */
+    static constexpr uint32_t MID_CHANNEL_VALUE       = 992U;
+
+    /** Raw CRSF channel value at full-high stick position. */
+    static constexpr uint32_t MAX_CHANNEL_VALUE       = 1811U;
+
+    /** Number of payload bytes in a packed RC channels frame.
+     *  16 channels x 11 bits = 176 bits = 22 bytes. */
+    static constexpr uint32_t RC_PAYLOAD_BYTES        = 22U;
+
+
+    // -------------------------------------------------------------------------
+    // Receive-side frame length guard
+    // -------------------------------------------------------------------------
+
+    /**
+     * Minimum frame-length field value for a valid link statistics frame.
+     * type(1) + 10 payload bytes + CRC(1) = 12.
+     * Used by Crsf::parseLinkStatistics() to guard against short frames.
+     */
+    static constexpr uint32_t LINK_STATS_MIN_FRAME_LENGTH = 12U;
+
+
+    // -------------------------------------------------------------------------
+    // Public static methods
+    // -------------------------------------------------------------------------
+
+    /**
+    * @brief   Unpack 16 raw 11-bit RC channel values from a CRSF packed-channels payload.
+    * @details CRSF packs 16 channels at 11 bits each into 22 bytes, little-endian LSB-first.
+    *          The extracted values are raw wire values (range MIN_CHANNEL_VALUE to
+    *          MAX_CHANNEL_VALUE); normalisation to the application range is the
+    *          caller's responsibility.
+    * @param   payload     Pointer to the first byte of the RC channels payload.
+    *                      Must point to at least RC_PAYLOAD_BYTES of valid data.
+    * @param   rawChannels Output: array of NUM_CHANNELS raw channel values.
+    */
+    static void unpackChannels(const uint8_t* payload, uint32_t (&rawChannels)[NUM_CHANNELS]);
+
+    /**
+    * @brief   Calculate CRC8 (DVB-S2, polynomial 0xD5) over a data buffer.
+    * @details Per the CRSF spec, CRC covers the frame-type byte and all payload
+    *          bytes.  It does not include the sync byte or the frame-length byte.
+    * @param   data    Pointer to the first byte to include (typically &buffer[TYPE_OFFSET]).
+    * @param   length  Number of bytes to process.
+    * @return  Calculated CRC8 value.
+    */
+    static uint8_t calculateCrc(const uint8_t* data, uint8_t length);
+
+
+  private:
+
+    /** Prevent instantiation — this is a static-only utility class. */
+    CrsfCodec() = delete;
+
+    /**
+    * @brief   Process one byte through the CRC8 DVB-S2 algorithm (polynomial 0xD5).
+    * @param   crc  Running CRC accumulator.
+    * @param   a    Byte to fold into the CRC.
+    * @return  Updated CRC8 value.
+    */
+    static uint8_t crc8DvbS2(uint8_t crc, uint8_t a);
+};

--- a/PlainFlightController/CrsfCodec.hpp
+++ b/PlainFlightController/CrsfCodec.hpp
@@ -127,6 +127,9 @@ class CrsfCodec
     /** Raw CRSF channel value at full-high stick position. */
     static constexpr uint32_t MAX_CHANNEL_VALUE       = 1811U;
 
+    /** Bitmask for an 11-bit channel value. */
+    static constexpr uint32_t CHANNEL_VALUE_MASK      = 0x07FFU;
+
     /** Number of payload bytes in a packed RC channels frame.
      *  16 channels x 11 bits = 176 bits = 22 bytes. */
     static constexpr uint32_t RC_PAYLOAD_BYTES        = 22U;
@@ -158,7 +161,7 @@ class CrsfCodec
     *                      Must point to at least RC_PAYLOAD_BYTES of valid data.
     * @param   rawChannels Output: array of NUM_CHANNELS raw channel values.
     */
-    static void unpackChannels(const uint8_t* payload, uint32_t (&rawChannels)[NUM_CHANNELS]);
+    static void unpackChannels(const uint8_t* const payload, uint32_t (&rawChannels)[NUM_CHANNELS]);
 
     /**
     * @brief   Calculate CRC8 (DVB-S2, polynomial 0xD5) over a data buffer.
@@ -168,7 +171,7 @@ class CrsfCodec
     * @param   length  Number of bytes to process.
     * @return  Calculated CRC8 value.
     */
-    static uint8_t calculateCrc(const uint8_t* data, uint8_t length);
+    static uint8_t calculateCrc(const uint8_t* data, const uint8_t length);
 
 
   private:
@@ -178,9 +181,9 @@ class CrsfCodec
 
     /**
     * @brief   Process one byte through the CRC8 DVB-S2 algorithm (polynomial 0xD5).
-    * @param   crc  Running CRC accumulator.
+    * @param   crc  Initial CRC value.
     * @param   a    Byte to fold into the CRC.
     * @return  Updated CRC8 value.
     */
-    static uint8_t crc8DvbS2(uint8_t crc, uint8_t a);
+    static uint8_t crc8DvbS2(const uint8_t crc, const uint8_t a);
 };

--- a/PlainFlightController/CrsfCodec.hpp
+++ b/PlainFlightController/CrsfCodec.hpp
@@ -35,13 +35,6 @@
 *
 * All methods are static and the class cannot be instantiated (constructor is deleted).
 *
-* Telemetry frame builders
-* ------------------------
-* Frame encoding methods (buildGpsFrame, buildBatteryFrame) and their supporting
-* private helpers (writeFrameHeader, finaliseFrame) and return type (TelemetryFrame)
-* are intentionally absent from this PR.  They will be added by dedicated feature PRs
-* for each telemetry data source.  The frame-type constants FRAMETYPE_GPS and
-* FRAMETYPE_BATTERY are retained here as wire-format documentation.
 */
 
 #pragma once


### PR DESCRIPTION
This PR is the first stage in adding a telemetry capability to the CRSF radio link.  Note that it is also necessary should a future packet based protocol using the CRSF protocol be implemented.

Two files CrsfCodec.hpp / CrsfCodec.cpp are added and two Crsf.hpp / Crsf.cpp are modified. 

CrsfCodec is a static-only utility class.  Cannot be instantiated.  It owns:

All CRSF wire-format constants: frame offsets, device addresses, frame type
bytes, RC channel range values, payload size guards
unpackChannels() — unpacks 16 × 11-bit channel values from the 22-byte
little-endian packed-channels payload
calculateCrc() / crc8DvbS2() — CRC8 DVB-S2 (polynomial 0xD5) used to
validate received frames

Consequently all references to these functions have been removed from Crsf