### PR TITLE
Initial entry battery telemetry and infrastructure

### DIFF
--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -171,6 +171,7 @@ class Config
   static constexpr bool USE_LOW_VOLTS_CUT_OFF                = false;  // Limit throttle upon low battery voltage.
   static constexpr bool USE_EXTERNAL_LED                     = false;  // Enable external LED output.
   static constexpr bool USE_ACRO_TRAINER                     = false;  // Level mode when pitch & roll sticks centred, rate mode otherwise.
+  static constexpr bool HAS_TELEMETRY                        = true;   // Enable telemetry downlink to the RC transmitter.
 
   // Prop hang / tail-sitter mode (experimental).
   // You need to understand flight controllers well to configure this.

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -346,3 +346,21 @@ Crsf::printData(void)
     Serial.println(m_rxData.lostComms);
   }
 }
+
+/**
+* @brief   Encode a battery voltage frame and transmit it over the CRSF UART.
+* @details All wire-format work — unit conversion, field packing, and CRC — is
+*          delegated to CrsfCodec::buildBatteryFrame().  The resulting frame is
+*          written directly to the UART driver.
+*
+*          This method does no rate limiting; TelemetryManager is responsible
+*          for ensuring it is called only when the transmit window has elapsed.
+*
+* @param   voltageVolts  Battery pack voltage in volts, forwarded to the codec.
+*/
+void
+Crsf::sendBatteryTelemetry(const float voltageVolts)
+{
+  const uint8_t len = CrsfCodec::buildBatteryFrame(m_txFrameBuffer, voltageVolts);
+  m_uart->write(m_txFrameBuffer, len);
+}

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -359,7 +359,7 @@ Crsf::printData(void)
 * @param   voltageVolts  Battery pack voltage in volts, forwarded to the codec.
 */
 void
-Crsf::sendBatteryTelemetry(const float voltageVolts)
+Crsf::sendBatteryTelemetry(const float& voltageVolts)
 {
   const uint8_t len = CrsfCodec::buildBatteryFrame(m_txFrameBuffer, voltageVolts);
   m_uart->write(m_txFrameBuffer, len);

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -45,6 +45,7 @@
 #include "Config.hpp"
 #include "RxBase.hpp"
 #include "CrsfCodec.hpp"
+#include "ITelemetry.hpp"
 
 
 /**
@@ -54,7 +55,7 @@
 * Protocol knowledge (frame format, CRC, channel packing) is delegated entirely
 * to CrsfCodec; this class owns only transport and application state.
 */
-class Crsf : public RxBase
+class Crsf : public RxBase, public ITelemetry
 {
   public:
 
@@ -157,6 +158,16 @@ class Crsf : public RxBase
     */
     CrsfLinkStats getLinkStats() const;
 
+    /**
+    * @brief   Send battery voltage telemetry to the RC transmitter.
+    * @details Delegates frame assembly entirely to CrsfCodec::buildBatteryFrame(),
+    *          which handles the unit conversion from volts to the CRSF wire format
+    *          and packs all other fields.  The resulting bytes are written directly
+    *          to the CRSF UART.  Rate limiting is the caller's responsibility.
+    * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
+    */
+    void sendBatteryTelemetry(float voltageVolts) override;
+
 
   private:
 
@@ -210,6 +221,13 @@ class Crsf : public RxBase
 
     /** Most recently received link statistics; initialised to worst-case values. */
     CrsfLinkStats   m_crsfLinkStats                          = {0U, -128, 0U, -128};
+
+    /**
+    * Reusable output buffer for outgoing telemetry frames.
+    * Sized to the maximum CRSF frame length so that any frame type can be built 
+    * without a separate buffer.
+    */
+    uint8_t m_txFrameBuffer[CrsfCodec::MAX_FRAME_SIZE] = {};
 
     // Objects
     /** Timer used to detect loss of communications. */

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -166,7 +166,7 @@ class Crsf : public RxBase, public ITelemetry
     *          to the CRSF UART.  Rate limiting is the caller's responsibility.
     * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
     */
-    void sendBatteryTelemetry(float voltageVolts) override;
+    void sendBatteryTelemetry(const float& voltageVolts) override;
 
 
   private:

--- a/PlainFlightController/CrsfCodec.cpp
+++ b/PlainFlightController/CrsfCodec.cpp
@@ -204,3 +204,85 @@ CrsfCodec::unpackChannels(const uint8_t* const payload, uint32_t (&rawChannels)[
                    |  (static_cast<uint32_t>(payload[21]) << 3U))
                    & CHANNEL_VALUE_MASK;
 }
+
+/**
+* @brief   Build a complete CRSF Battery Sensor frame (type 0x08) into buf.
+* @details The CRSF battery frame carries four fields in big-endian byte order:
+*
+*            Field           Wire bytes   Wire unit          Source
+*            --------------- ------------ ------------------ -----------------------
+*            Voltage         2            100 mV per LSB     voltageVolts × 10
+*            Current         2            10 mA per LSB      zero (sensor absent)
+*            Capacity used   3            mAh                zero (sensor absent)
+*            Remaining       1            percent (0–100)    zero (sensor absent)
+*
+*          The unit conversion from volts to centivolts (× 100) is done here.
+*          When a current sensor is added, its raw value in amps would
+*          be converted to centiamps (× 100) at the corresponding field.
+*
+*          Frame layout:
+*            [0]     Sync byte  (ADDR_FLIGHT_CONTROLLER = 0xC8)
+*            [1]     Frame length = BATTERY_FRAME_SIZE - 2 = 10
+*            [2]     Frame type  (FRAMETYPE_BATTERY = 0x08)  <-- CRC region start
+*            [3–4]   Voltage, big-endian uint16_t, centivolts
+*            [5–6]   Current, big-endian uint16_t, zero
+*            [7–9]   Capacity used, big-endian 24-bit, zero
+*            [10]    Remaining percent, zero
+*            [11]    CRC8 DVB-S2 over bytes [2..10]          <- CRC region end
+*
+*          Battery voltage is always positive; the cast from float to uint16_t is
+*          safe for any realistic pack voltage (a 65V pack would be the limit,
+*          far beyond practical use).
+*
+* @param   buf           Output buffer; must be at least MAX_FRAME_SIZE bytes.
+* @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
+* @return  Number of bytes written into buf (always BATTERY_FRAME_SIZE = 12).
+*/
+uint8_t
+CrsfCodec::buildBatteryFrame(uint8_t* buf, const float voltageVolts)
+{
+  uint8_t index = 0U;
+ 
+  // Sync byte: identifies this frame as originating from the flight controller.
+  buf[index++] = ADDR_FLIGHT_CONTROLLER;
+ 
+  // Frame length field: counts type(1) + payload(8) + CRC(1) = 10.
+  // Excludes the sync byte and the length byte itself.
+  buf[index++] = static_cast<uint8_t>(BATTERY_FRAME_SIZE - 2U);
+ 
+  // Mark where the CRC region begins: the CRC covers from the type byte
+  // through to the last payload byte.
+  const uint8_t crcStart = index;
+ 
+  // Frame type.
+  buf[index++] = FRAMETYPE_BATTERY;
+ 
+  // Voltage: convert from volts to decivolts (100 mV per LSB) Note: this is not correct
+  // according to the TBS CRSF Spec.  However the Spec suggests LSB = 10 uV which makes
+  // no sense for a signed 16 bit value.  The value here results in the correct reading
+  // at the transmitter.
+  // Data type is int16_t per spec; static_cast to uint32_t handles the bit packing safely.
+  const int16_t voltageDv = static_cast<int16_t>(voltageVolts * 10.0f);
+  buf[index++] = static_cast<uint8_t>((static_cast<uint32_t>(voltageDv) >> 8U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>( static_cast<uint32_t>(voltageDv)        & 0xFFU);
+ 
+  // Current: sensor not yet fitted; transmitted as zero.
+  buf[index++] = 0U;
+  buf[index++] = 0U;
+ 
+  // Capacity used (24-bit field): not yet derived; transmitted as zero.
+  buf[index++] = 0U;
+  buf[index++] = 0U;
+  buf[index++] = 0U;
+ 
+  // Remaining percentage: not yet derived; transmitted as zero.
+  buf[index++] = 0U;
+ 
+  // CRC8 DVB-S2: calculated over type + payload bytes.
+  buf[index] = calculateCrc(&buf[crcStart], static_cast<uint8_t>(index - crcStart));
+  index++;
+ 
+  // index is now BATTERY_FRAME_SIZE (12).
+  return index;
+}
+ 

--- a/PlainFlightController/CrsfCodec.hpp
+++ b/PlainFlightController/CrsfCodec.hpp
@@ -41,7 +41,6 @@
 
 #include <inttypes.h>
 
-
 /**
 * @class  CrsfCodec
 * @brief  Static utility class for CRSF frame decoding and CRC calculation.
@@ -71,6 +70,15 @@ class CrsfCodec
 
     /** Byte offset of the first payload byte within a frame buffer. */
     static constexpr uint32_t PAYLOAD_OFFSET          = 3U;
+
+    /**
+     * Total byte count of a complete CRSF battery sensor frame.
+     *   sync(1) + length(1) + type(1) + payload(8) + CRC(1) = 12 bytes.
+     *
+     * Payload breakdown (8 bytes):
+     *   voltage(2) + current(2) + capacity_used(3) + remaining(1)
+     */
+    static constexpr uint32_t BATTERY_FRAME_SIZE  = 12U;
 
 
     // -------------------------------------------------------------------------
@@ -166,6 +174,23 @@ class CrsfCodec
     */
     static uint8_t calculateCrc(const uint8_t* const data, const uint8_t length);
 
+    /**
+    * @brief   Build a complete CRSF Battery Sensor frame (type 0x08) into buf.
+    * @details Encodes voltage, current, capacity used, and remaining percentage
+    *          from the supplied BatteryData struct into a ready-to-transmit CRSF
+    *          frame.  All multi-byte fields are big-endian, matching the CRSF wire
+    *          format.  The CRC covers the type byte and all payload bytes, computed
+    *          by the existing calculateCrc() helper.
+    *
+    *          The caller is responsible for supplying a buffer of at least
+    *          MAX_FRAME_SIZE bytes.  The returned length will always equal
+    *          BATTERY_FRAME_SIZE (12) for a well-formed call.
+    *
+    * @param   buf   Output buffer; must be at least MAX_FRAME_SIZE bytes.
+    * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
+    * @return  Number of bytes written into buf (always BATTERY_FRAME_SIZE).
+    */
+    static uint8_t buildBatteryFrame(uint8_t* buf, const float voltageVolts);
 
   private:
 

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -37,7 +37,10 @@ DemandProcessor::DemandProcessor()
   } 
   else if constexpr (Config::RECEIVER_TYPE == ReceiverType::CRSF)
   {
-    radioCtrl = new Crsf(InternalConfig::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
+    // Intermediate pointer required to enable implicit upcast to two object types
+    Crsf* crsfObj = new Crsf(InternalConfig::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
+    radioCtrl = crsfObj;
+    telemetryCtrl = crsfObj;  // Having an assigned pointer here deactivates the guard on telemetry methods.
   }
   else
   {

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -26,6 +26,7 @@
 #include <Arduino.h>
 #include "Utilities.hpp"
 #include "RxBase.hpp"
+#include "ITelemetry.hpp"
 #include "SBus.hpp"
 #include "Crsf.hpp"
 #include "Config.hpp"
@@ -99,6 +100,7 @@ public:
   bool headingHoldActive();
   bool propHangActive();
   Demands const * const getDemands() const {return &m_demand;};
+  ITelemetry* getTelemetry() const { return telemetryCtrl; }
 
 private:
   void decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState);
@@ -112,4 +114,5 @@ private:
 
   //Objects
   RxBase* radioCtrl = nullptr;
+  ITelemetry* telemetryCtrl = nullptr;
 };

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -76,6 +76,11 @@ FlightControl::begin()
   }
 
   batteryMonitor.begin(config.getBatteryScaler());
+
+  if constexpr (Config::HAS_TELEMETRY)
+  {
+    telemetryManager.begin(rc.getTelemetry(), InternalConfig::TELEMETRY_BATTERY_PERIOD_MS);
+  }
 }
 
 
@@ -151,6 +156,11 @@ FlightControl::operate()
   rc.process(&m_flightState, &m_lastFlightState, config.getRates(), config.getMaxAngles());
   checkStateChange();
   batteryMonitor.operate();
+
+  if constexpr (Config::HAS_TELEMETRY)
+  {
+    telemetryManager.update(batteryMonitor.getVoltage());
+  }
 
   if constexpr(Config::ESP32S3.HAS_NEOPIXEL)
   {

--- a/PlainFlightController/FlightControl.hpp
+++ b/PlainFlightController/FlightControl.hpp
@@ -32,6 +32,7 @@
 #include "IMU.hpp"
 #include "Config.hpp"
 #include "RxBase.hpp"
+#include "TelemetryManager.hpp"
 #include "Configurator.hpp"
 #include "FileSystem.hpp"
 #include "ModelTypes.hpp"
@@ -86,4 +87,5 @@ class FlightControl : public Utilities
     PIDF rollPIDF = PIDF();
     IMU imu = IMU();  
     Configurator config;  
+    TelemetryManager telemetryManager;
 };

--- a/PlainFlightController/ITelemetry.hpp
+++ b/PlainFlightController/ITelemetry.hpp
@@ -56,7 +56,7 @@ class ITelemetry
     *          implementation; the caller passes only the raw float it already has.
     * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
     */
-    virtual void sendBatteryTelemetry(float voltageVolts) = 0;
+    virtual void sendBatteryTelemetry(const float& voltageVolts) = 0;
 
 
   protected:

--- a/PlainFlightController/ITelemetry.hpp
+++ b/PlainFlightController/ITelemetry.hpp
@@ -1,0 +1,69 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   ITelemetry.hpp
+* @brief  Pure abstract interface for telemetry transmission to an RC transmitter.
+*
+* Adding a new telemetry type
+* ---------------------------
+* Add a virtual method here, implement it in Crsf (and any other implementor),
+* add the corresponding codec frame builder, and add a timer in TelemetryManager.
+* No other files require changes.
+*/
+
+#pragma once
+
+
+/**
+* @class  ITelemetry
+* @brief  Abstract interface for sending telemetry data to an RC transmitter.
+*
+* Implementing classes (e.g. Crsf) inherit from both RxBase and ITelemetry.
+* The flight controller calls these methods without knowing which protocol or
+* transport is in use.
+*/
+class ITelemetry
+{
+  public:
+
+    /**
+    * @brief  Virtual destructor.
+    *         Ensures correct cleanup when destroying through a base-class pointer,
+    *         even though ITelemetry holds no data members of its own.
+    */
+    virtual ~ITelemetry() = default;
+
+    /**
+    * @brief   Send battery voltage telemetry to the RC transmitter.
+    * @details The implementing class converts the supplied voltage into its own
+    *          wire format and transmits it.  All scaling happens inside the 
+    *          implementation; the caller passes only the raw float it already has.
+    * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
+    */
+    virtual void sendBatteryTelemetry(float voltageVolts) = 0;
+
+
+  protected:
+
+    /**
+    * @brief  Protected default constructor.
+    *         Prevents direct instantiation; only derived classes may be constructed.
+    */
+    ITelemetry() = default;
+};

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -59,6 +59,9 @@ namespace InternalConfig
   static_assert(NUMBER_SERVOS + NUMBER_MOTORS <= 8U, 
     "Configuration Error: Combined total of servos and motors cannot exceed 8.");
 
+  // Battery telemetry transmit periods (milliseconds)
+  static constexpr uint32_t TELEMETRY_BATTERY_PERIOD_MS      = 500U;
+
   //==========================================================================
   // DEBUG SETTINGS
   //==========================================================================

--- a/PlainFlightController/TelemetryManager.cpp
+++ b/PlainFlightController/TelemetryManager.cpp
@@ -77,7 +77,7 @@ TelemetryManager::begin(ITelemetry* telemetry, uint32_t batteryPeriodMs)
 * @param   voltageVolts  Current battery pack voltage in volts.
 */
 void
-TelemetryManager::update(const float voltageVolts)
+TelemetryManager::update(const float& voltageVolts)
 {
   // Early exit: no telemetry path available (e.g. SBus receiver).
   if (nullptr == m_telemetry)

--- a/PlainFlightController/TelemetryManager.cpp
+++ b/PlainFlightController/TelemetryManager.cpp
@@ -1,0 +1,93 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   TelemetryManager.cpp
+* @brief  Rate-gating orchestrator for outgoing telemetry transmissions.
+*/
+
+#include "TelemetryManager.hpp"
+
+
+/**
+* @brief   Construct a TelemetryManager.
+* @details The battery timer is initialised via the member default
+*          (CTimer(0U)) so it reports EXPIRED on the first update() call,
+*          transmitting immediately rather than waiting a full period.
+*          This matches the pattern used by the loss-of-comms timers in
+*          Crsf and SBus.
+* @param   telemetry        Telemetry implementation pointer (may be nullptr).
+* @param   batteryPeriodMs  Battery transmit period in milliseconds.
+*/
+TelemetryManager::TelemetryManager(ITelemetry* const telemetry,
+                                   const uint32_t    batteryPeriodMs)
+  : m_telemetry(telemetry),
+    m_batteryPeriodMs(batteryPeriodMs)
+{
+}
+
+/**
+* @brief   Default constructor.
+*/
+TelemetryManager::TelemetryManager()
+  : m_telemetry(nullptr),
+    m_batteryPeriodMs(0U)
+{
+}
+
+/**
+* @brief   Initialisation.
+*/
+void
+TelemetryManager::begin(ITelemetry* telemetry, uint32_t batteryPeriodMs)
+{
+  m_telemetry = telemetry;
+  m_batteryPeriodMs = batteryPeriodMs;
+  m_batteryTimer.set(0U); // Force immediate expire on first update() call.
+}
+
+
+/**
+* @brief   Check the battery timer and transmit if it has elapsed.
+* @details The null-pointer guard is the sole mechanism for handling receivers
+*          with no telemetry capability.  When telemetryCtrl is nullptr the
+*          function returns without touching the timer or calling any virtual
+*          method.
+*
+*          When telemetryCtrl is valid: if the battery timer has expired, the
+*          voltage value is forwarded to sendBatteryTelemetry() and the timer
+*          is restarted.  The called method does the serialisation and UART
+*          write; this method owns only the timing decision.
+*
+* @param   voltageVolts  Current battery pack voltage in volts.
+*/
+void
+TelemetryManager::update(const float voltageVolts)
+{
+  // Early exit: no telemetry path available (e.g. SBus receiver).
+  if (nullptr == m_telemetry)
+  {
+    return;
+  }
+
+  if (CTimer::State::EXPIRED == m_batteryTimer.getState())
+  {
+    m_telemetry->sendBatteryTelemetry(voltageVolts);
+    m_batteryTimer.set(static_cast<uint64_t>(m_batteryPeriodMs));
+  }
+}

--- a/PlainFlightController/TelemetryManager.hpp
+++ b/PlainFlightController/TelemetryManager.hpp
@@ -1,0 +1,114 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   TelemetryManager.hpp
+* @brief  Rate-gating orchestrator for outgoing telemetry transmissions.
+*
+* Role in the telemetry path
+* --------------------------
+* The flight controller holds a TelemetryManager instance and calls update()
+* on each iteration of operate().  The manager decides whether each telemetry
+* type is due for transmission based on per-type timers, then delegates the
+* actual serialisation and UART write to the ITelemetry implementation it was
+* given at construction time.
+*
+* The manager has no knowledge of the underlying protocol.  It knows only the
+* ITelemetry interface and the raw values passed to update().  Adding a new
+* telemetry type requires adding a timer here and a corresponding send call in
+* update(); no other structural change is needed.
+*
+* Null-pointer capability guard
+* ------------------------------
+* When constructed with a nullptr telemetry pointer (the case for a receiver
+* with no downlink path, e.g. SBus), update() returns immediately after a
+* single null check.  No virtual dispatch, no timer evaluation, no work.
+*
+* Timer initialisation
+* --------------------
+* The battery timer is initialised with period 0, which causes CTimer to
+* report EXPIRED immediately.  The first call to update() after power-on
+* therefore transmits without waiting a full period, getting data to the
+* transmitter as early as possible.
+*/
+
+#pragma once
+
+#include <inttypes.h>
+#include "Timer.hpp"
+#include "ITelemetry.hpp"
+
+
+/**
+* @class  TelemetryManager
+* @brief  Orchestrates rate-limited transmission of telemetry data.
+*
+* Constructed once at flight-controller start-up.  Thereafter update() is
+* called every main-loop iteration when telemetry is enabled.
+*/
+class TelemetryManager
+{
+  public:
+
+    /**
+    * @brief   Construct a TelemetryManager.
+    * @details The battery timer is initialised to the expired state so that
+    *          the very first update() call transmits immediately.
+    * @param   telemetry        Pointer to the telemetry implementation.  May be
+    *                           nullptr when the active receiver has no telemetry
+    *                           downlink; update() becomes a no-op in that case.
+    * @param   batteryPeriodMs  Minimum interval between battery telemetry frames, ms.
+    */
+    TelemetryManager(ITelemetry* telemetry, uint32_t batteryPeriodMs);
+
+        /**
+    * @brief   Default constructor.
+    * @details Required for instantiation as a member of FlightControl.
+    *          Initialises pointers to nullptr and periods to 0.
+    */
+    TelemetryManager();
+
+    /**
+    * @brief   Initialise the manager with a telemetry implementation.
+    * @param   telemetry        Pointer to the telemetry implementation (e.g. Crsf).
+    * @param   batteryPeriodMs  Minimum interval between battery telemetry frames, ms.
+    */
+    void begin(ITelemetry* telemetry, uint32_t    batteryPeriodMs);
+               
+    /**
+    * @brief   Push the current battery voltage and transmit if the timer has elapsed.
+    * @details Returns immediately if the telemetry pointer is nullptr.  Otherwise
+    *          checks whether the battery timer has expired; if so, calls
+    *          sendBatteryTelemetry() and restarts the timer.  No serialisation
+    *          work occurs on iterations where the timer has not expired.
+    * @param   voltageVolts  Current battery pack voltage in volts.
+    */
+    void update(float voltageVolts);
+
+
+  private:
+
+    /** Telemetry implementation. nullptr → receiver has no downlink; update() is a no-op. */
+    ITelemetry* m_telemetry       = nullptr;
+
+    /** Minimum transmit interval for battery frames, in milliseconds. */
+    uint32_t    m_batteryPeriodMs = 0U;
+
+    /** Timer that gates battery telemetry transmissions. */
+    CTimer      m_batteryTimer    = CTimer(0U);
+};

--- a/PlainFlightController/TelemetryManager.hpp
+++ b/PlainFlightController/TelemetryManager.hpp
@@ -98,7 +98,7 @@ class TelemetryManager
     *          work occurs on iterations where the timer has not expired.
     * @param   voltageVolts  Current battery pack voltage in volts.
     */
-    void update(float voltageVolts);
+    void update(const float& voltageVolts);
 
 
   private:

--- a/PlainFlightController/Timer.hpp
+++ b/PlainFlightController/Timer.hpp
@@ -40,6 +40,7 @@ class CTimer
       RUNNING,
     };
 
+    CTimer() = default;
     CTimer(const uint32_t delayTime);
     void set(const uint32_t delayTime);
     State getState();


### PR DESCRIPTION
This PR implements the necessary infrastructure to provide plainFlight with a telemetry capability and a single example (Battery Voltage) implemented.  At this stage only the CRSF receiver is capable of supporting telemetry but the interface is generic and the pattern established here should support other telemetry capable receivers.

Many files have been touched but most only lightly.

ITelemetry.hpp provided the virtual base class for telemetry capable receivers
Crsf.hpp/.cpp now inherits from RxBase and ITelemetry. A send method for battery voltage is also implemented
CrsfCodec.hpp/.cpp implements a 0x08 CRSF Battery packet builder used by Crsf
DemandProcessor.hpp/.cpp owns the receiver and the telemetry classes.  They are the same class but allocated to separate pointers when the underlying class supports it.  A null pointer for the telemetry class is used as a guard to signify no telemetry capability.
FlightControl.hpp/.cpp implements and configures the TelemetryManager.  It also gains a new operate activity to update the TelemetryManager.
TelemetryManager.hpp/.cpp is responsible for the timing of telemetry output.  The update routing is called each look but telemetry is only sent on expiration of a packet timer.  Each packet type has its own timer.
Timer.hpp got a default constructor
Config.hpp got a new option  HAS_TELEMETRY
InternalConfig.hpp got a new option for the battery telemetry send interval.

Telemetry frequency is important as CRSF has limited bandwidth on the back channel.

The code has been tested with live values (although I don't have a battery connected) and with fixed value (You can just inject a fixed value to the update call in FlightControl.cpp).
