### PR TITLE
Improve IMU orientation configuration

### DIFF
--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -42,3 +42,15 @@ enum class GyroRate : uint8_t
   IS_250_DEGS_SECOND,
   IS_500_DEGS_SECOND
 };
+
+/**
+ * @enum AircraftDir
+ * @brief Used for orientation of the gyro relative to the aircraft.
+ *        Note: The ordering is important here, it is used to ensure that 
+ *        a valid orientation is selected.
+ */
+enum class AircraftDir { 
+    FRONT, BACK, 
+    LEFT, RIGHT, 
+    UP, DOWN 
+  };

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -49,8 +49,9 @@ enum class GyroRate : uint8_t
  *        Note: The ordering is important here, it is used to ensure that 
  *        a valid orientation is selected.
  */
-enum class AircraftDir { 
-    FRONT, BACK, 
-    LEFT, RIGHT, 
-    UP, DOWN 
-  };
+enum class AircraftDir 
+{ 
+  FRONT, BACK, 
+  LEFT, RIGHT, 
+  UP, DOWN 
+};

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -49,7 +49,7 @@ enum class GyroRate : uint8_t
  *        Note: The ordering is important here, it is used to ensure that 
  *        a valid orientation is selected.
  */
-enum class AircraftDir 
+enum class AircraftDir: uint8_t 
 { 
   FRONT, BACK, 
   LEFT, RIGHT, 

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -209,7 +209,7 @@ class Config
   // IMU mounting is defined in terms of the direction plus_x and plus_y are facing
   // The x and y axis are typically marked on the module board.
   static constexpr AircraftDir IMU_PLUS_X                    = AircraftDir::FRONT;  // Direction that the gyro plus x axis is facing.
-  static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::UP;   // Direction that the gyro plus y axis is facing.
+  static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::LEFT;   // Direction that the gyro plus y axis is facing.
 
   // Transmitter stick deadband (normalised units, approximately 0.5% of normalised span).
   static constexpr uint32_t TX_DEADBAND_NORM                 = 10U;

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -183,6 +183,7 @@ class Config
   // Adjust these during maiden flight and subsequent tuning.
   // Available options (defined in CommonTypes.hpp) IS_250_DEG_SECOND, IS_500_DEG_SECOND
   //==========================================================================
+  // CAUTION: The method of gyro orientation is new and untested. Verify correct operation before flight.
 
   // Gyro rate range. Set exactly one to true.
   static constexpr GyroRate GYRO_RATE                        = GyroRate::IS_250_DEGS_SECOND;
@@ -205,9 +206,9 @@ class Config
   static constexpr bool PROP_HANG_REVERSE_YAW_DEMAND         = false;  // Set true if Tx yaw stick demand is in the wrong sense in prop-hang mode.
 
   // IMU board orientation.
-  // CAUTION: These are new and untested. Verify correct operation before flight.
-  // IMU mounting is defined in terms of the direction plus_x and plus_y are facing
+  // IMU mounting is defined in terms of the direction the accelerometer plus_x and plus_y axes are facing
   // The x and y axis are typically marked on the module board.
+  // Available options (defined in CommonTypes.hpp) are FRONT, BACK, LEFT, RIGHT, UP and DOWN
   static constexpr AircraftDir IMU_PLUS_X                    = AircraftDir::FRONT;  // Direction that the gyro plus x axis is facing.
   static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::LEFT;   // Direction that the gyro plus y axis is facing.
 

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -204,10 +204,12 @@ class Config
   static constexpr bool PROP_HANG_REVERSE_ROLL_DEMAND        = false;  // Set true if Tx roll stick demand is in the wrong sense in prop-hang mode.
   static constexpr bool PROP_HANG_REVERSE_YAW_DEMAND         = false;  // Set true if Tx yaw stick demand is in the wrong sense in prop-hang mode.
 
-  // IMU board orientation corrections.
-  // CAUTION: These are experimental and untested. Verify correct operation before flight.
-  static constexpr bool IMU_ROLLED_RIGHT_90                  = false;  // IMU is rolled 90 degrees to the right of normal orientation.
-  static constexpr bool IMU_ROLLED_180                       = false;  // IMU is flipped 180 degrees on the roll axis (upside down).
+  // IMU board orientation.
+  // CAUTION: These are new and untested. Verify correct operation before flight.
+  // IMU mounting is defined in terms of the direction plus_x and plus_y are facing
+  // The x and y axis are typically marked on the module board.
+  static constexpr AircraftDir IMU_PLUS_X                    = AircraftDir::FRONT;  // Direction that the gyro plus x axis is facing.
+  static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::UP;   // Direction that the gyro plus y axis is facing.
 
   // Transmitter stick deadband (normalised units, approximately 0.5% of normalised span).
   static constexpr uint32_t TX_DEADBAND_NORM                 = 10U;

--- a/PlainFlightController/Mpu6050.cpp
+++ b/PlainFlightController/Mpu6050.cpp
@@ -150,44 +150,34 @@ Mpu6050::readData(MpuData* const data)
 
   if (14U == bytesReceived)
   {
-    if constexpr(Config::IMU_ROLLED_RIGHT_90)
-    {
-      data->rawAccel_X = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawAccel_Z = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawAccel_Y = -(static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->temperature = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_X = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_Z = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_Y = -(static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-    }
-    else if constexpr(Config::IMU_ROLLED_180)
-    {
-      data->rawAccel_X = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawAccel_Y = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawAccel_Z = -(static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->temperature = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_X = -(static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_Y = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_Z = -(static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-    }
-    else
-    {
-      data->rawAccel_X = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawAccel_Y = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawAccel_Z = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->temperature = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_X = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_Y = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-      data->rawGyro_Z = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
-    }
+    const int16_t rawA_X = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
+    const int16_t rawA_Y = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
+    const int16_t rawA_Z = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
+    
+    data->temperature    = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
+    
+    const int16_t rawG_X = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
+    const int16_t rawG_Y = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
+    const int16_t rawG_Z = (static_cast<int16_t>(i2c.read()) << 8) | static_cast<int16_t>(i2c.read());
 
+    // Remap axes using compile-time matrix evaluation
+    data->rawAccel_X = remapAxis<0>(rawA_X, rawA_Y, rawA_Z);
+    data->rawAccel_Y = remapAxis<1>(rawA_X, rawA_Y, rawA_Z);
+    data->rawAccel_Z = remapAxis<2>(rawA_X, rawA_Y, rawA_Z);
+
+    data->rawGyro_X  = remapAxis<0>(rawG_X, rawG_Y, rawG_Z);
+    data->rawGyro_Y  = remapAxis<1>(rawG_X, rawG_Y, rawG_Z);
+    data->rawGyro_Z  = remapAxis<2>(rawG_X, rawG_Y, rawG_Z);
+
+    // Scaling math
     data->gyro_X = static_cast<float>(data->rawGyro_X - data->gyroOffset_X) / m_scaleFactor;
     data->accel_X = static_cast<float>(data->rawAccel_X) / ACCEL_SCALE_FACTOR_16G;
     data->gyro_Y = static_cast<float>(data->rawGyro_Y - data->gyroOffset_Y) / m_scaleFactor;
     data->accel_Y = static_cast<float>(data->rawAccel_Y) / ACCEL_SCALE_FACTOR_16G;
     data->gyro_Z = static_cast<float>(data->rawGyro_Z - data->gyroOffset_Z) / m_scaleFactor;
     data->accel_Z = static_cast<float>(data->rawAccel_Z) / ACCEL_SCALE_FACTOR_16G;
-  
+ 
+    // Debug output
     if constexpr(InternalConfig::DEBUG_MPU6050)
     {
       Serial.print("\t gx:");

--- a/PlainFlightController/Mpu6050.hpp
+++ b/PlainFlightController/Mpu6050.hpp
@@ -23,9 +23,67 @@
 #pragma once
 
 #include <Arduino.h>
+#include <cstdint>
 #include "ESP32_SoftWire.h"
+// #include "CommonTypes.hpp"
 #include "Config.hpp"
 
+// Represent each direction as a {front, left, up} unit vector
+constexpr std::array<int16_t, 3> dirToVec(AircraftDir d) {
+    if (d == AircraftDir::FRONT) return {{  1,  0,  0 }};
+    if (d == AircraftDir::BACK)  return {{ -1,  0,  0 }};
+    if (d == AircraftDir::LEFT)  return {{  0,  1,  0 }};
+    if (d == AircraftDir::RIGHT) return {{  0, -1,  0 }};
+    if (d == AircraftDir::UP)    return {{  0,  0,  1 }};
+    if (d == AircraftDir::DOWN)  return {{  0,  0, -1 }};
+    return {{ 0, 0, 0 }};
+}
+
+// --- Compile-Time Matrix Generator ---
+namespace Orientation {
+  using Matrix3x3 = std::array<std::array<int16_t, 3>, 3>;
+
+  // Build the rotation matrix required to transform the acceleration and rotation
+  // vectors back into the aircraft coordinate space
+  constexpr Matrix3x3 getMatrix() {
+    // x and y are given from the configuration
+    std::array<int16_t, 3> imuX = dirToVec(Config::IMU_PLUS_X);
+    std::array<int16_t, 3> imuY = dirToVec(Config::IMU_PLUS_Y);
+
+    // Z is orthogonal to x and y, we can derive it using the cross product
+    // of IMU X and IMU Y. Note the sign change for the second term.
+    std::array<int16_t, 3> imuZ = {
+        int16_t(imuX[1]*imuY[2] - imuX[2]*imuY[1]),
+        int16_t(imuX[2]*imuY[0] - imuX[0]*imuY[2]),  // negative
+        int16_t(imuX[0]*imuY[1] - imuX[1]*imuY[0])
+    };
+
+    // --- Now fill all 9 elements ---
+    // Row index = aircraft axis {FRONT/BACK=0, LEFT/RIGHT=1, UP/DOWN=2}
+    // Column index = IMU axis {X=0, Y=1, Z=2}
+    return Matrix3x3{{
+        {{imuX[0], imuY[0], imuZ[0]}},  // aircraft X (FRONT/BACK)
+        {{imuX[1], imuY[1], imuZ[1]}},  // aircraft Y (LEFT/RIGHT)
+        {{imuX[2], imuY[2], imuZ[2]}}   // aircraft Z (UP/DOWN)
+    }};
+  }
+  inline constexpr Matrix3x3 final_matrix = getMatrix();
+
+  // This relies on the AircraftDir enum having sequential opposites to check for sharing opposited direction
+  static_assert(
+    Config::IMU_PLUS_X != Config::IMU_PLUS_Y &&
+    Config::IMU_PLUS_X != (static_cast<AircraftDir>(static_cast<int>(Config::IMU_PLUS_Y) ^ 1)),
+    "Invalid IMU Configuration: IMU_PLUS_X and IMU_PLUS_Y cannot share the same physical dimension!"
+  );
+};
+
+// Single row Matrix multiplication helper function
+template<size_t Row>
+inline int16_t remapAxis(int16_t x, int16_t y, int16_t z) {
+  if constexpr (Orientation::final_matrix[Row][0] != 0) return x * Orientation::final_matrix[Row][0];
+  else if constexpr (Orientation::final_matrix[Row][1] != 0) return y * Orientation::final_matrix[Row][1];
+  else return z * Orientation::final_matrix[Row][2];
+}
 
 class Mpu6050
 {

--- a/PlainFlightController/Mpu6050.hpp
+++ b/PlainFlightController/Mpu6050.hpp
@@ -64,7 +64,8 @@ namespace Orientation
 
     // Z is orthogonal to x and y, we can derive it using the cross product
     // of IMU X and IMU Y. Note the sign change for the second term.
-    std::array<int16_t, 3> imuZ = {
+    std::array<int16_t, 3> imuZ = 
+    {
         int16_t(imuX[1]*imuY[2] - imuX[2]*imuY[1]),
         int16_t(imuX[2]*imuY[0] - imuX[0]*imuY[2]),  // negative
         int16_t(imuX[0]*imuY[1] - imuX[1]*imuY[0])
@@ -73,7 +74,8 @@ namespace Orientation
     // --- Now fill all 9 elements ---
     // Row index = aircraft axis {FRONT/BACK=0, LEFT/RIGHT=1, UP/DOWN=2}
     // Column index = IMU axis {X=0, Y=1, Z=2}
-    return Matrix3x3{{
+    return Matrix3x3
+    {{
         {{imuX[0], imuY[0], imuZ[0]}},  // aircraft X (FRONT/BACK)
         {{imuX[1], imuY[1], imuZ[1]}},  // aircraft Y (LEFT/RIGHT)
         {{imuX[2], imuY[2], imuZ[2]}}   // aircraft Z (UP/DOWN)

--- a/PlainFlightController/Mpu6050.hpp
+++ b/PlainFlightController/Mpu6050.hpp
@@ -25,7 +25,6 @@
 #include <Arduino.h>
 #include <cstdint>
 #include "ESP32_SoftWire.h"
-// #include "CommonTypes.hpp"
 #include "Config.hpp"
 
 /**

--- a/PlainFlightController/Mpu6050.hpp
+++ b/PlainFlightController/Mpu6050.hpp
@@ -28,8 +28,13 @@
 // #include "CommonTypes.hpp"
 #include "Config.hpp"
 
-// Represent each direction as a {front, left, up} unit vector
-constexpr std::array<int16_t, 3> dirToVec(AircraftDir d) {
+/**
+* @brief    Converts an AircraftDir enum value to a unit vector in {front, left, up} coordinate space.
+* @param    d  The aircraft direction to convert.
+* @return   A 3-element array representing the unit vector for the given direction.
+*/
+constexpr std::array<int16_t, 3> dirToVec(AircraftDir d) 
+{
     if (d == AircraftDir::FRONT) return {{  1,  0,  0 }};
     if (d == AircraftDir::BACK)  return {{ -1,  0,  0 }};
     if (d == AircraftDir::LEFT)  return {{  0,  1,  0 }};
@@ -39,13 +44,20 @@ constexpr std::array<int16_t, 3> dirToVec(AircraftDir d) {
     return {{ 0, 0, 0 }};
 }
 
-// --- Compile-Time Matrix Generator ---
-namespace Orientation {
+/**
+* @brief    Builds a 3x3 rotation matrix at compile time to transform IMU-space
+*           acceleration and rotation vectors into aircraft coordinate space.
+*           The Z axis is derived as the cross product of the configured IMU X and Y axes.
+* @return   A 3x3 matrix where each row maps an aircraft axis to the corresponding IMU axis.
+*/
+namespace Orientation 
+{
   using Matrix3x3 = std::array<std::array<int16_t, 3>, 3>;
 
   // Build the rotation matrix required to transform the acceleration and rotation
   // vectors back into the aircraft coordinate space
-  constexpr Matrix3x3 getMatrix() {
+  constexpr Matrix3x3 getMatrix() 
+  {
     // x and y are given from the configuration
     std::array<int16_t, 3> imuX = dirToVec(Config::IMU_PLUS_X);
     std::array<int16_t, 3> imuY = dirToVec(Config::IMU_PLUS_Y);
@@ -67,6 +79,11 @@ namespace Orientation {
         {{imuX[2], imuY[2], imuZ[2]}}   // aircraft Z (UP/DOWN)
     }};
   }
+
+  /**
+  * @brief    Precomputed rotation matrix derived from Config::IMU_PLUS_X and Config::IMU_PLUS_Y.
+  *           Used at runtime to remap raw IMU data into aircraft coordinate space.
+  */
   inline constexpr Matrix3x3 final_matrix = getMatrix();
 
   // This relies on the AircraftDir enum having sequential opposites to check for sharing opposited direction
@@ -77,9 +94,19 @@ namespace Orientation {
   );
 };
 
-// Single row Matrix multiplication helper function
+/**
+* @brief    Multiplies a single row of the orientation matrix against the raw IMU axis values,
+*           remapping one aircraft axis from IMU space. Since the matrix contains only unit vectors
+*           (0, 1, or -1), only one column per row will be non-zero.
+* @tparam   Row  The aircraft axis row index (0=front/back, 1=left/right, 2=up/down).
+* @param    x    Raw IMU X axis value.
+* @param    y    Raw IMU Y axis value.
+* @param    z    Raw IMU Z axis value.
+* @return   The remapped axis value in aircraft coordinate space.
+*/
 template<size_t Row>
-inline int16_t remapAxis(int16_t x, int16_t y, int16_t z) {
+inline int16_t remapAxis(int16_t x, int16_t y, int16_t z) 
+{
   if constexpr (Orientation::final_matrix[Row][0] != 0) return x * Orientation::final_matrix[Row][0];
   else if constexpr (Orientation::final_matrix[Row][1] != 0) return y * Orientation::final_matrix[Row][1];
   else return z * Orientation::final_matrix[Row][2];


### PR DESCRIPTION
This PR offers an improvement in the way that the orientation of the IMU board is configured.

The direction of the X and Y axes are commonly marked on IMU modules.  This PR uses that readily obtained information to unambiguously orient the board relative to the aircraft.

Previously three options for orientation were offered these were
1. A default
2. IMU rolled right 90 degrees
3. IMU rolled 180 degrees.

However there are a total of 24 potential orientations for the IMU, albeit half are a mirror orientation and may are perhaps not feasible.

In this PR we remove the two options and the default from the config.hpp file and replace them with an explicit orientation in terms of the marking on the module.  The new config items are 

static constexpr AircraftDir IMU_PLUS_X                    = AircraftDir::FRONT;  // Direction that the gyro plus x axis is facing.
static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::LEFT;   // Direction that the gyro plus y axis is facing.

AircraftDir is a new enum enumerating the 6 directions FRONT, BACK, LEFT, RIGHT, UP, DOWN.

To implement this changes have been made to Mpu6050.hpp/.cpp.  Specifically machinery has been added to MPU6050.hpp to build a rotation matrix to achieve the reorientation of the gyro outputs. A helper function "remapAxis" has also been provided to do the actual matrix multiplication.

Note however that the rotation matrix has entries of 0, -1 and 1.  The matrix is constructed at compile time and the matrix multiplication is essentially reassignment and negation of values.  All achieved at compile time and completed with no additional processing time.  

The calculations (reassignment and negation) has been tested in all 24 possible orientations by observing that when the installed as configured the DEBUG_MPU6050 output continues to have +1G acceleration on the z axis and aileron roll gives values with the correct sense (negative left, positive right) around the X axis.


