### PR TITLE
Gps telemetry

### DIFF
--- a/PlainFlightController/BoardConfig.hpp
+++ b/PlainFlightController/BoardConfig.hpp
@@ -145,9 +145,10 @@ struct Board
   };
 
 /**
-* @brief Structure representing the standard IO map for DKG carrier board with ESP32S3-ZERO.
+* @brief Structure representing the standard IO map for the Waveshare module carrier board by Cyberslug.
+*        Rev 0.0 is currently under test
 */
-static constexpr Board DKG = 
+static constexpr Board WSMC = 
 {
   //LEDC channel pins used for servos/motors.
   .OUTPUT_1           = 1U,   //GPIO1 

--- a/PlainFlightController/BoardConfig.hpp
+++ b/PlainFlightController/BoardConfig.hpp
@@ -26,34 +26,36 @@
 namespace BoardConfig
 {
 
-  /**
-  * @brief  Structure representing all IO used by Plain Flight Controller.
-  * @note   Some boards may have additional spare IO.
-  */
-  struct Board
-  {
-    //LEDC channel pins used for servos/motors.
-    const uint8_t OUTPUT_1;
-    const uint8_t OUTPUT_2;
-    const uint8_t OUTPUT_3;
-    const uint8_t OUTPUT_4;
-    const uint8_t OUTPUT_5;
-    const uint8_t OUTPUT_6;
-    const uint8_t OUTPUT_7;
-    const uint8_t OUTPUT_8;
-    //Other IO pins
-    const uint8_t LED_ON_BOARD;
-    const uint8_t I2C_SDA;
-    const uint8_t I2C_SCL;
-    const uint8_t RADIO_RECEIVER_RX;
-    const uint8_t RADIO_RECEIVER_TX;
-    const uint8_t LED_EXTERNAL;
-    const uint8_t BATTERY_ADC;
-    //Options
-    const bool SINK_ONBOARD_LED;          //Set true to sink onboard LED, false to source onboard LED. 
-    const bool HAS_NEOPIXEL;              //When using a board with a Neopixel i.e. WS2812 or equivalent.
-    const bool SWAP_NEOPIXEL_RGB_TO_GRB;  //If your neopixel ordering is green-red-blue then set this to true.
-  };
+/**
+* @brief  Structure representing all IO used by Plain Flight Controller.
+* @note   Some boards may have additional spare IO.
+*/
+struct Board
+{
+  //LEDC channel pins used for servos/motors.
+  const uint8_t OUTPUT_1;
+  const uint8_t OUTPUT_2;
+  const uint8_t OUTPUT_3;
+  const uint8_t OUTPUT_4;
+  const uint8_t OUTPUT_5;
+  const uint8_t OUTPUT_6;
+  const uint8_t OUTPUT_7;
+  const uint8_t OUTPUT_8;
+  //Other IO pins
+  const uint8_t LED_ON_BOARD;
+  const uint8_t I2C_SDA;
+  const uint8_t I2C_SCL;
+  const uint8_t RADIO_RECEIVER_RX;
+  const uint8_t RADIO_RECEIVER_TX;
+  const uint8_t GNSS_RX;
+  const uint8_t GNSS_TX;
+  const uint8_t LED_EXTERNAL;
+  const uint8_t BATTERY_ADC;
+  //Options
+  const bool SINK_ONBOARD_LED;          //Set true to sink onboard LED, false to source onboard LED. 
+  const bool HAS_NEOPIXEL;              //When using a board with a Neopixel i.e. WS2812 or equivalent.
+  const bool SWAP_NEOPIXEL_RGB_TO_GRB;  //If your neopixel ordering is green-red-blue then set this to true.
+};
 
 
   /**
@@ -141,5 +143,36 @@ namespace BoardConfig
     .HAS_NEOPIXEL             = true,   //When using a board with a Neopixel i.e. WS2812 or equivalent.
     .SWAP_NEOPIXEL_RGB_TO_GRB = true,   //If your neopixel ordering is green-red-blue then set this to true.
   };
+
+/**
+* @brief Structure representing the standard IO map for DKG carrier board with ESP32S3-ZERO.
+*/
+static constexpr Board DKG = 
+{
+  //LEDC channel pins used for servos/motors.
+  .OUTPUT_1           = 1U,   //GPIO1 
+  .OUTPUT_2           = 2U,   //GPIO2
+  .OUTPUT_3           = 3U,   //GPIO3
+  .OUTPUT_4           = 4U,   //GPIO4
+  .OUTPUT_5           = 5U,   //GPIO5
+  .OUTPUT_6           = 6U,   //GPIO6
+  .OUTPUT_7           = 7U,   //GPIO07
+  .OUTPUT_8           = 8U,   //GPIO08
+  //Other IO pins
+  .LED_ON_BOARD       = 21U,  //GPIO21
+  .I2C_SDA            = 9U,   //GPIO09
+  .I2C_SCL            = 10U,  //GPIO10
+  .RADIO_RECEIVER_RX  = 44U,  //GPIO44
+  .RADIO_RECEIVER_TX  = 43U,  //GPIO43
+  .GNSS_RX            = 11U,  //GPIO11
+  .GNSS_TX            = 12U,  //GPIO12
+  .LED_EXTERNAL       = 16U,  //GPIO16  not used
+  .BATTERY_ADC        = 13U,  //GPIO13
+  //GPIO 8, 9, 10, 11, 17, 18, 38, 39, 40, 41, 42, 45 spare
+  //Options
+  .SINK_ONBOARD_LED         = false,  //Set true to sink onboard LED, false to source onboard LED. 
+  .HAS_NEOPIXEL             = true,   //When using a board with a Neopixel i.e. WS2812 or equivalent.
+  .SWAP_NEOPIXEL_RGB_TO_GRB = true,  //If your neopixel ordering is green-red-blue then set this to true.
+};
 
 }//Namespace BoardConfig end.

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -23,7 +23,7 @@
 * SECTION GUIDE
 * -------------
 * 1. BOARD & HARDWARE       - Define the physical ESP32S3 board.
-* 2. RECEIVER               - Define the radio protocol.
+* 2. RECEIVER & GPS         - Define the external communication protocols.
 * 3. MODEL TYPE             - Define the aircraft type.
 * 4. OUTPUT ASSIGNMENT      - Define the output connection to servos/motors.
 * 5. OUTPUT CONFIGURATION   - Change during physical installation (reversal, travel).
@@ -41,6 +41,7 @@
 #include "LedcServo.hpp"
 #include "CommonTypes.hpp"
 #include "BoardConfig.hpp"
+#include "GnssTypes.hpp"
 
 /**
  * @class Config
@@ -59,12 +60,17 @@ class Config
 
 
   //==========================================================================
-  // SECTION 2: RECEIVER
-  // Select the receiver protocol matching your radio system.
-  // Available options (defined in CommonTypes.hpp): CRSF, SBUS
+  // SECTION 2: RECEIVER & GPS
+  // Select the protocols matching your radio system and GPS hardware.
+  // Receiver options (CommonTypes.hpp): CRSF, SBUS
+  // GNSS Type (CommonTypes.hpp):        NONE, CASIC, UBX
+  // UBX Models (GnssTypes.hpp):         UBXM6M, UBXM78, UBX9P
   //==========================================================================
 
   static constexpr ReceiverType RECEIVER_TYPE                = ReceiverType::CRSF;
+  static constexpr GnssType     GNSS_TYPE                    = GnssType::CASIC;
+  static constexpr UbxSeries    GENERATION                   = UbxSeries::UBX_M9_PLUS; // Only relevant for GNSS_TYPE UBX
+
 
 
   //==========================================================================

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -193,7 +193,7 @@ class Config
   // SECTION 7:  OPTIONAL GPS
   // Select the protocols matching your GPS hardware.
   // GNSS Type (CommonTypes.hpp):        NONE, CASIC, UBX
-  // UBX Models (GnssTypes.hpp):         UBXM6M, UBXM78, UBX9P
+  // UBX Models (GnssTypes.hpp):         UBX_M6_MINUS, UBX_M7_M8, UBX_M9_PLUS
   //==========================================================================
 
   static constexpr GnssType     GNSS_TYPE                    = GnssType::CASIC;

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -60,18 +60,12 @@ class Config
 
 
   //==========================================================================
-  // SECTION 2: RECEIVER & GPS
-  // Select the protocols matching your radio system and GPS hardware.
+  // SECTION 2: RECEIVER
+  // Select the protocols matching your radio system.
   // Receiver options (CommonTypes.hpp): CRSF, SBUS
-  // GNSS Type (CommonTypes.hpp):        NONE, CASIC, UBX
-  // UBX Models (GnssTypes.hpp):         UBXM6M, UBXM78, UBX9P
   //==========================================================================
 
   static constexpr ReceiverType RECEIVER_TYPE                = ReceiverType::CRSF;
-  static constexpr GnssType     GNSS_TYPE                    = GnssType::CASIC;
-  static constexpr UbxSeries    GENERATION                   = UbxSeries::UBX_M9_PLUS; // Only relevant for GNSS_TYPE UBX
-
-
 
   //==========================================================================
   // SECTION 3: MODEL TYPE
@@ -196,7 +190,18 @@ class Config
 
 
   //==========================================================================
-  // SECTION 7: FLIGHT CHARACTERISTICS
+  // SECTION 7:  OPTIONAL GPS
+  // Select the protocols matching your GPS hardware.
+  // GNSS Type (CommonTypes.hpp):        NONE, CASIC, UBX
+  // UBX Models (GnssTypes.hpp):         UBXM6M, UBXM78, UBX9P
+  //==========================================================================
+
+  static constexpr GnssType     GNSS_TYPE                    = GnssType::CASIC;
+  static constexpr UbxSeries    GENERATION                   = UbxSeries::UBX_M9_PLUS; // Only relevant for GNSS_TYPE UBX
+
+
+  //==========================================================================
+  // SECTION 8: FLIGHT CHARACTERISTICS
   // Adjust these during maiden flight and subsequent tuning.
   // Available options (defined in CommonTypes.hpp) IS_250_DEG_SECOND, IS_500_DEG_SECOND
   //==========================================================================
@@ -232,9 +237,9 @@ class Config
   // Transmitter stick deadband (normalised units, approximately 0.5% of normalised span).
   static constexpr uint32_t TX_DEADBAND_NORM                 = 10U;
 
-
+  
   //==========================================================================
-  // SECTION 8: MULTICOPTER MOTOR SETTINGS
+  // SECTION 9: MULTICOPTER MOTOR SETTINGS
   // Relevant for multicopter builds only.
   //==========================================================================
 

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -197,8 +197,8 @@ class Config
   // UBX Models (GnssTypes.hpp):         UBX_M6_MINUS, UBX_M7_M8, UBX_M9_PLUS
   //==========================================================================
 
-  static constexpr GnssType     GNSS_TYPE                    = GnssType::CASIC;
-  static constexpr UbxSeries    GENERATION                   = UbxSeries::UBX_M9_PLUS; // Only relevant for GNSS_TYPE UBX
+  static constexpr GnssType     GNSS_TYPE                    = GnssType::UBX;
+  static constexpr UbxSeries    GENERATION                   = UbxSeries::UBX_M6_MINUS; // Only relevant for GNSS_TYPE UBX
 
 
   //==========================================================================

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -23,13 +23,14 @@
 * SECTION GUIDE
 * -------------
 * 1. BOARD & HARDWARE       - Define the physical ESP32S3 board.
-* 2. RECEIVER & GPS         - Define the external communication protocols.
+* 2. RECEIVER               - Define the external communication protocols.
 * 3. MODEL TYPE             - Define the aircraft type.
 * 4. OUTPUT ASSIGNMENT      - Define the output connection to servos/motors.
 * 5. OUTPUT CONFIGURATION   - Change during physical installation (reversal, travel).
 * 6. FEATURE FLAGS          - Enable/disable optional features for this build.
-* 7. FLIGHT CHARACTERISTICS - Adjust during maiden flight and tuning.
-* 8. MULTICOPTER SETTINGS   - Motor idle and minimum throttle, multicopter builds only.
+* 7. OPTIONAL GPS           - Configure a CASIC or UBX GPS to be used for telemetry.
+* 8. FLIGHT CHARACTERISTICS - Adjust during maiden flight and tuning.
+* 9. MULTICOPTER SETTINGS   - Motor idle and minimum throttle, multicopter builds only.
 *
 */
 

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -144,7 +144,7 @@ Crsf::getDemands()
             parseRcChannels(payload, static_cast<uint8_t>(frameLength));
 
             // Valid RC frame received — reset the loss-of-comms timer
-            lossOfCommsTimer.set(COMMS_TIME_OUT_PERIOD);
+            m_lossOfCommsTimer.set(COMMS_TIME_OUT_PERIOD);
             m_rxData.lostComms = false;
 
             if constexpr(InternalConfig::DEBUG_RX)
@@ -178,7 +178,7 @@ Crsf::getDemands()
     }
   }
 
-  if (CTimer::State::EXPIRED == lossOfCommsTimer.getState())
+  if (CTimer::State::EXPIRED == m_lossOfCommsTimer.getState())
   {
     m_rxData.lostComms = true;
   }
@@ -270,7 +270,7 @@ Crsf::parseLinkStatistics(const uint8_t* payload, uint8_t frameLength)
   //   [4] active_antenna   — unused here
   //   [5] rf_profile       — unused here
   //   [6] up_rf_power      — transmitter power index
-  m_crsfLinkStats.rssiDbm     = static_cast<int8_t>(payload[0]);
+  m_crsfLinkStats.rssiDbm     = -static_cast<int8_t>(payload[0]);
   m_crsfLinkStats.linkQuality = static_cast<uint8_t>(payload[2]);
   m_crsfLinkStats.snrDb       = static_cast<int8_t>(payload[3]);
   m_crsfLinkStats.txPower     = static_cast<uint8_t>(payload[6]);
@@ -283,7 +283,7 @@ Crsf::parseLinkStatistics(const uint8_t* payload, uint8_t frameLength)
 *           channel data in range [MIN_NORMALISED .. MAX_NORMALISED].
 */
 const RxBase::RxPacket
-Crsf::getData() const
+Crsf::getData()
 {
   return m_rxData;
 }
@@ -295,7 +295,7 @@ Crsf::getData() const
 *           COMMS_TIME_OUT_PERIOD milliseconds.
 */
 const bool
-Crsf::hasLostCommunications() const
+Crsf::hasLostCommunications()
 {
   return m_rxData.lostComms;
 }
@@ -362,5 +362,20 @@ void
 Crsf::sendBatteryTelemetry(const float& voltageVolts)
 {
   const uint8_t len = CrsfCodec::buildBatteryFrame(m_txFrameBuffer, voltageVolts);
+  m_uart->write(m_txFrameBuffer, len);
+}
+
+/**
+* @brief   Send gps data packet telemetry to the RC transmitter.
+* @details Delegates frame assembly entirely to CrsfCodec::buildGPSFrame(),
+*          which handles the unit conversion and packs all other fields.  
+*          The resulting bytes are written directly to the CRSF UART.  
+*          Rate limiting is the caller's responsibility.
+* @param   data  A GnssData structure.
+*/
+void 
+Crsf::sendGnssTelemetry(const GnssData& data)
+{
+  const uint8_t len = CrsfCodec::buildGpsFrame(m_txFrameBuffer, data);
   m_uart->write(m_txFrameBuffer, len);
 }

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -1,5 +1,7 @@
 /* 
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -139,14 +139,14 @@ class Crsf : public RxBase, public ITelemetry
     * @return  RxPacket with failsafe flag, lostComms flag, and 16 normalised
     *          channel values in the range [MIN_NORMALISED .. MAX_NORMALISED].
     */
-    const RxPacket getData() const override;
+    const RxPacket getData() override;
 
     /**
     * @brief   Report whether CRSF communications have been lost.
     * @return  true if no valid RC channels frame has been received within
     *          COMMS_TIME_OUT_PERIOD milliseconds.
     */
-    const bool hasLostCommunications() const override;
+    const bool hasLostCommunications() override;
 
     /**
     * @brief   Resolve a logical RcChannelName to its physical CRSF channel index.
@@ -173,8 +173,17 @@ class Crsf : public RxBase, public ITelemetry
     *          to the CRSF UART.  Rate limiting is the caller's responsibility.
     * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
     */
-    void sendBatteryTelemetry(const float& voltageVolts) override;
+    void sendBatteryTelemetry(const float voltageVolts) override;
 
+    /**
+    * @brief   Send gps data packet telemetry to the RC transmitter.
+    * @details Delegates frame assembly entirely to CrsfCodec::buildGPSFrame(),
+    *          which handles the unit conversion and packs all other fields.  
+    *          The resulting bytes are written directly to the CRSF UART.  
+    *          Rate limiting is the caller's responsibility.
+    * @param   data  A GnssData structure.
+    */
+    void sendGnssTelemetry(const GnssData& data) override;
 
   private:
 
@@ -238,7 +247,7 @@ class Crsf : public RxBase, public ITelemetry
 
     // Objects
     /** Timer used to detect loss of communications. */
-    CTimer          lossOfCommsTimer                         = CTimer(0);
+    CTimer          m_lossOfCommsTimer                         = CTimer(0);
 
 
     // -------------------------------------------------------------------------

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -173,7 +173,7 @@ class Crsf : public RxBase, public ITelemetry
     *          to the CRSF UART.  Rate limiting is the caller's responsibility.
     * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
     */
-    void sendBatteryTelemetry(const float voltageVolts) override;
+    void sendBatteryTelemetry(const float& voltageVolts) override;
 
     /**
     * @brief   Send gps data packet telemetry to the RC transmitter.

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -1,5 +1,7 @@
 /* 
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/CrsfCodec.cpp
+++ b/PlainFlightController/CrsfCodec.cpp
@@ -347,7 +347,7 @@ CrsfCodec::buildGpsFrame(uint8_t* buf, const GnssData& data)
   buf[index++] = static_cast<uint8_t>((longBits >> 16U) & 0xFFU);
   buf[index++] = static_cast<uint8_t>((longBits >> 8U) & 0xFFU);
   buf[index++] = static_cast<uint8_t>(longBits & 0xFFU);
-  const uint16_t gSpeedDV = static_cast<uint16_t>(data.gSpeed * 0.36f); // mm/s to kph * 100
+  const uint16_t gSpeedDV = static_cast<uint16_t>(data.gSpeed * 0.036f); // mm/s to kph * 10, beware the TBS spec has an error
   buf[index++] = static_cast<uint8_t>((gSpeedDV >> 8U) & 0xFFU);
   buf[index++] = static_cast<uint8_t>(gSpeedDV & 0xFFU);
   const uint16_t headMotDv = static_cast<uint16_t>(data.headMot / 1000L);  // degrees * 1E5 to degrees * 100

--- a/PlainFlightController/CrsfCodec.cpp
+++ b/PlainFlightController/CrsfCodec.cpp
@@ -1,5 +1,7 @@
 /* 
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/CrsfCodec.cpp
+++ b/PlainFlightController/CrsfCodec.cpp
@@ -286,3 +286,83 @@ CrsfCodec::buildBatteryFrame(uint8_t* buf, const float voltageVolts)
   return index;
 }
  
+/**
+* @brief   Build a complete CRSF GPS Sensor frame (type 0x02) into buf.
+* @details The CRSF GPS frame carries six fields in big-endian byte order:
+*
+*            Field           Wire bytes   Wire unit          Source
+*            --------------- ------------ ------------------ -----------------------
+*            latitude        4            degree * 10`000`000
+*            longitude       4            degree * 10`000`000
+*            groundspeed     2            km/h * 100
+*            heading         2            degree * 100
+*            altitude        2            meter + 1000m offset
+*            satellites      1            # of sats in view
+*
+*          Frame layout:
+*            [0]     Sync byte  (ADDR_FLIGHT_CONTROLLER = 0xC8)
+*            [1]     Frame length = BATTERY_FRAME_SIZE - 2 = 10
+*            [2]     Frame type  (FRAMETYPE_BATTERY = 0x08)  <-- CRC region start
+*            [3–6]   Latitude, big-endian uint32_t, degrees * 10E7
+*            [7–10]  Longitude, big-endian uint32_t, degrees * 10E7
+*            [11–12] Ground Speed, big-endian 16-bit, km/h * 100
+*            [13-14] Heading, big-endian 16-bit, degrees * 100
+*            [15-16] Altitude, big-endian 16-bit, metres + 1000
+*            [17]    #Satellites, big-endian 8-bit, N
+*            [18]    CRC8 DVB-S2 over bytes [2..17]          <- CRC region end
+*
+*
+* @param   buf   Output buffer; must be at least MAX_FRAME_SIZE bytes.
+* @param   data  GnssData structure
+* @return  Number of bytes written into buf (always GPS_FRAME_SIZE = 19).
+*/
+
+uint8_t
+CrsfCodec::buildGpsFrame(uint8_t* buf, const GnssData& data)
+{
+  uint8_t index = 0U;
+ 
+  // Sync byte: identifies this frame as originating from the flight controller.
+  buf[index++] = ADDR_FLIGHT_CONTROLLER;
+ 
+  // Frame length field: counts type(1) + payload(8) + CRC(1) = 10.
+  // Excludes the sync byte and the length byte itself.
+  buf[index++] = static_cast<uint8_t>(GPS_FRAME_SIZE - 2U);
+ 
+  // Mark where the CRC region begins: the CRC covers from the type byte
+  // through to the last payload byte.
+  const uint8_t crcStart = index;
+ 
+  // Frame type.
+  buf[index++] = FRAMETYPE_GPS;
+  const uint32_t latBits = static_cast<uint32_t>(data.latitude);  // cast to avoid right shift signed int
+  buf[index++] = static_cast<uint8_t>((latBits >> 24U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>((latBits >> 16U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>((latBits >> 8U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>(latBits & 0xFFU);
+  const uint32_t longBits = static_cast<uint32_t>(data.longitude);  // cast to avoid right shift signed int
+  buf[index++] = static_cast<uint8_t>((longBits >> 24U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>((longBits >> 16U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>((longBits >> 8U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>(longBits & 0xFFU);
+  const uint16_t gSpeedDV = static_cast<uint16_t>(data.gSpeed * 0.36f); // mm/s to kph * 100
+  buf[index++] = static_cast<uint8_t>((gSpeedDV >> 8U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>(gSpeedDV & 0xFFU);
+  const uint16_t headMotDv = static_cast<uint16_t>(data.headMot / 1000L);  // degrees * 1E5 to degrees * 100
+  buf[index++] = static_cast<uint8_t>((headMotDv >> 8U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>(headMotDv & 0xFFU);
+  const int32_t altMetres = data.altMSL / 1000L;  // mm to m
+  const int32_t altWithOffset = altMetres + 1000;
+  const uint16_t altMSLDv = (altWithOffset > 0) ?
+                              static_cast<uint16_t>(altWithOffset): 0U;  // Guard against (unlikely) - ve to unsigned
+  buf[index++] = static_cast<uint8_t>((altMSLDv >> 8U) & 0xFFU);
+  buf[index++] = static_cast<uint8_t>(altMSLDv & 0xFFU);
+  buf[index++] = data.satellites;
+ 
+   // CRC8 DVB-S2: calculated over type + payload bytes.
+  buf[index] = calculateCrc(&buf[crcStart], static_cast<uint8_t>(index - crcStart));
+  index++;
+ 
+  // index is now GPS_FRAME_SIZE (19).
+  return index;
+}

--- a/PlainFlightController/CrsfCodec.hpp
+++ b/PlainFlightController/CrsfCodec.hpp
@@ -84,7 +84,7 @@ class CrsfCodec
     static constexpr uint32_t BATTERY_FRAME_SIZE  = 12U;
 
     /**
-     * Total byte count of a complete CRSF battery sensor frame.
+     * Total byte count of a complete CRSF GPS sensor frame.
      *   sync(1) + length(1) + type(1) + payload(15) + CRC(1) = 19 bytes.
      *
      * Payload breakdown (8 bytes):

--- a/PlainFlightController/CrsfCodec.hpp
+++ b/PlainFlightController/CrsfCodec.hpp
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <inttypes.h>
+#include "GnssDriver.hpp"
 
 /**
 * @class  CrsfCodec
@@ -80,6 +81,14 @@ class CrsfCodec
      */
     static constexpr uint32_t BATTERY_FRAME_SIZE  = 12U;
 
+    /**
+     * Total byte count of a complete CRSF battery sensor frame.
+     *   sync(1) + length(1) + type(1) + payload(15) + CRC(1) = 19 bytes.
+     *
+     * Payload breakdown (8 bytes):
+     *   latitude(4) + longitude(4) + groundspeed(2) + heading(2) + altitude(2) + #satellites(1)
+     */
+    static constexpr uint32_t GPS_FRAME_SIZE  = 19U;
 
     // -------------------------------------------------------------------------
     // Device address constants  (CRSF spec: Device Addresses)
@@ -191,6 +200,23 @@ class CrsfCodec
     * @return  Number of bytes written into buf (always BATTERY_FRAME_SIZE).
     */
     static uint8_t buildBatteryFrame(uint8_t* buf, const float voltageVolts);
+
+    /**
+    * @brief   Build a complete CRSF GPS Sensor frame (type 0x02) into buf.
+    * @details Encodes lattitude, longitude etc into a ready-to-transmit CRSF
+    *          frame.  All multi-byte fields are big-endian, matching the CRSF wire
+    *          format.  The CRC covers the type byte and all payload bytes, computed
+    *          by the existing calculateCrc() helper.
+    *
+    *          The caller is responsible for supplying a buffer of at least
+    *          MAX_FRAME_SIZE bytes.  The returned length will always equal
+    *          BATTERY_FRAME_SIZE (12) for a well-formed call.
+    *
+    * @param   buf   Output buffer; must be at least MAX_FRAME_SIZE bytes.
+    * @param   data  A GnssData structure.
+    * @return  Number of bytes written into buf (always GPS_FRAME_SIZE = 19).
+    */
+    static uint8_t buildGpsFrame(uint8_t* buf, const GnssData& data);
 
   private:
 

--- a/PlainFlightController/CrsfCodec.hpp
+++ b/PlainFlightController/CrsfCodec.hpp
@@ -1,5 +1,7 @@
 /* 
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -40,7 +40,7 @@ DemandProcessor::DemandProcessor()
     // Intermediate pointer required to enable implicit upcast to two object types
     Crsf* crsfObj = new Crsf(InternalConfig::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
     radioCtrl = crsfObj;
-    telemetryCtrl = crsfObj;  // Having an assigned pointer here deactivates the guard on telemetry methods.
+    m_telemetry = crsfObj;
   }
   else
   {

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -26,7 +26,7 @@
 #include <Arduino.h>
 #include "Utilities.hpp"
 #include "RxBase.hpp"
-#include "ITelemetry.hpp"
+#include "TelemetryManager.hpp"
 #include "SBus.hpp"
 #include "Crsf.hpp"
 #include "Config.hpp"
@@ -99,6 +99,13 @@ public:
   bool throttleIsHigh();
   bool headingHoldActive();
   bool propHangActive();
+
+  /**
+  * @brief  Returns the telemetry interface if the active receiver supports it.
+  * @return Pointer to ITelemetry implementation, or nullptr.
+  */
+  ITelemetry* getTelemetry() const { return m_telemetry; };
+
   Demands const * const getDemands() const {return &m_demand;};
   ITelemetry* getTelemetry() const {return telemetryCtrl;};
   RxBase::RxPacket const * const getNormalisedRcData() const {return &m_normalisedData;};
@@ -115,5 +122,5 @@ private:
 
   //Objects
   RxBase* radioCtrl = nullptr;
-  ITelemetry* telemetryCtrl = nullptr;
+  ITelemetry* m_telemetry = nullptr;
 };

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -107,7 +107,6 @@ public:
   ITelemetry* getTelemetry() const { return m_telemetry; };
 
   Demands const * const getDemands() const {return &m_demand;};
-  ITelemetry* getTelemetry() const {return telemetryCtrl;};
   RxBase::RxPacket const * const getNormalisedRcData() const {return &m_normalisedData;};
 
 private:

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -49,7 +49,7 @@ FlightControl::begin()
   if (imu.isFaulted())
   {
     Serial.println("Faulted");
-    m_flightState = DemandProcessor::FlightState::FAULTED;
+    DemandProcessor::FlightState::FAULTED;
   }
 
   if (!config.begin())

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -79,7 +79,13 @@ FlightControl::begin()
 
   if constexpr (Config::HAS_TELEMETRY)
   {
-    telemetryManager.begin(rc.getTelemetry(), InternalConfig::TELEMETRY_BATTERY_PERIOD_MS);
+    if constexpr (Config::GNSS_TYPE != GnssType::NONE)  // The only function of GNSS is for telemetry
+    {
+      gnss.beginSafe(*InternalConfig::GNSS_UART, Config::ESP32S3.GNSS_RX, Config::ESP32S3.GNSS_TX);
+    }
+    telemetryManager.begin(rc.getTelemetry(), 
+        InternalConfig::TELEMETRY_BATTERY_PERIOD_MS, 
+        InternalConfig::TELEMETRY_GNSS_PERIOD_MS);
   }
 }
 
@@ -159,7 +165,18 @@ FlightControl::operate()
 
   if constexpr (Config::HAS_TELEMETRY)
   {
-    telemetryManager.update(batteryMonitor.getVoltage());
+    // GPS is only gathered and sent when hardware is actually fitted.
+    // When GNSS_TYPE == NONE the compiler eliminates this entire block.
+    if constexpr (Config::GNSS_TYPE != GnssType::NONE)
+    {
+      gnss.update();
+      if (gnss.hasNewData()){
+        GnssData d;
+        gnss.getData(d);
+        telemetryManager.updateGnss(d);
+      }
+    }
+    telemetryManager.updateBattery(batteryMonitor.getVoltage());
   }
 
   if constexpr(Config::ESP32S3.HAS_NEOPIXEL)
@@ -178,7 +195,7 @@ FlightControl::operate()
 
   if (!imu.isOk())
   {
-    DemandProcessor::FlightState::FAULTED;
+    m_flightState = DemandProcessor::FlightState::FAULTED;
   }
 
   switch (m_flightState)

--- a/PlainFlightController/FlightControl.hpp
+++ b/PlainFlightController/FlightControl.hpp
@@ -32,6 +32,7 @@
 #include "IMU.hpp"
 #include "Config.hpp"
 #include "RxBase.hpp"
+#include "GnssDriver.hpp"
 #include "TelemetryManager.hpp"
 #include "Configurator.hpp"
 #include "FileSystem.hpp"
@@ -88,4 +89,5 @@ class FlightControl : public Utilities
     IMU imu = IMU();  
     Configurator config;  
     TelemetryManager telemetryManager;
+    GnssDriver gnss;
 };

--- a/PlainFlightController/GnssDriver.hpp
+++ b/PlainFlightController/GnssDriver.hpp
@@ -1,0 +1,73 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   GnssDriver.hpp
+* @brief  An interface to dualGNSS with instatiation mechanism
+*/
+
+#pragma once
+
+#include <type_traits>
+#include "Config.hpp"
+#include "dualGNSS.hpp"
+// #include "UbxGNSS.hpp"
+// #include "CasicGNSS.hpp"
+// #include "GnssTypes.hpp"
+#include "CommonTypes.hpp"
+
+// static constexpr GnssType TYPE = GnssType::CASIC;
+// static constexpr UbxSeries GENERATION = UbxSeries::UBX_M9_PLUS;
+
+class GnssDriver
+{
+  public:
+    bool  begin(HardwareSerial& serial, int8_t rxPin, int8_t txPin)
+                { return m_gnss.begin(serial, rxPin, txPin);       }
+    void  beginPassive(HardwareSerial& serial, int8_t rxPin, int8_t txPin,
+                    uint32_t baud = UbxConfigurator::TARGET_BAUD_RATE)
+                    {m_gnss.beginPassive(serial, rxPin, txPin, baud);}
+    bool  beginSafe(HardwareSerial& serial, int8_t rxPin, int8_t txPin)
+      {
+        // Fast-track: attempt passive start at 115 200 baud (the library's target rate).
+        // If the module is already configured and outputting valid frames, this
+        // succeeds immediately and the full configuration sequence is unnecessary.
+        m_gnss.beginPassive(serial, rxPin, txPin);
+
+        const uint32_t deadline = millis() + 200UL;
+        while (millis() < deadline) {
+          m_gnss.update();
+          if (m_gnss.hasNewData()) {
+            // Fast track succeeded
+            return true;  // receiving valid frames — no configuration needed
+          }
+        }
+        // Full configuration: sweep baud rates, identify module, apply settings.
+        return m_gnss.begin(serial, rxPin, txPin);
+      }    
+    void  update()       { m_gnss.update();      }
+    bool  hasNewData()   { return m_gnss.hasNewData();  }
+    bool  isFixValid()   { return m_gnss.isFixValid();  }
+    void  getData(GnssData& dest)   { m_gnss.getData(dest);  }
+    GnssConfigResult getConfigResult() { return m_gnss.getConfigResult(); }
+
+  private:
+    // One line. Config drives both the module type and the protocol version.
+    // If GNSS_TYPE is CASIC the second argument is accepted but unused.
+    Gnss<Config::GNSS_TYPE, Config::GENERATION> m_gnss;  // Configured external to the class
+};

--- a/PlainFlightController/GnssDriver.hpp
+++ b/PlainFlightController/GnssDriver.hpp
@@ -28,13 +28,7 @@
 #include <type_traits>
 #include "Config.hpp"
 #include "dualGNSS.hpp"
-// #include "UbxGNSS.hpp"
-// #include "CasicGNSS.hpp"
-// #include "GnssTypes.hpp"
 #include "CommonTypes.hpp"
-
-// static constexpr GnssType TYPE = GnssType::CASIC;
-// static constexpr UbxSeries GENERATION = UbxSeries::UBX_M9_PLUS;
 
 class GnssDriver
 {

--- a/PlainFlightController/GnssDriver.hpp
+++ b/PlainFlightController/GnssDriver.hpp
@@ -29,6 +29,7 @@
 #include "Config.hpp"
 #include "dualGNSS.hpp"
 #include "CommonTypes.hpp"
+#include "InternalConfig.hpp"
 
 class GnssDriver
 {
@@ -59,7 +60,13 @@ class GnssDriver
     void  update()       { m_gnss.update();      }
     bool  hasNewData()   { return m_gnss.hasNewData();  }
     bool  isFixValid()   { return m_gnss.isFixValid();  }
-    void  getData(GnssData& dest)   { m_gnss.getData(dest);  }
+    void  getData(GnssData& dest)   { 
+      m_gnss.getData(dest);  
+      if constexpr(InternalConfig::DEBUG_GPS)
+      {
+        Serial.printf("%02d:%02d:%02d %02d Lat %07d, Long %07d\n", dest.hour, dest.minute, dest.second, dest.satellites, dest.latitude, dest.longitude);
+      }
+    }
     GnssConfigResult getConfigResult() { return m_gnss.getConfigResult(); }
 
   private:

--- a/PlainFlightController/GnssDriver.hpp
+++ b/PlainFlightController/GnssDriver.hpp
@@ -1,5 +1,7 @@
 /* 
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/ITelemetry.hpp
+++ b/PlainFlightController/ITelemetry.hpp
@@ -29,7 +29,7 @@
 
 #pragma once
 
-
+#include "GnssTypes.hpp"
 /**
 * @class  ITelemetry
 * @brief  Abstract interface for sending telemetry data to an RC transmitter.
@@ -56,7 +56,16 @@ class ITelemetry
     *          implementation; the caller passes only the raw float it already has.
     * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
     */
-    virtual void sendBatteryTelemetry(const float& voltageVolts) = 0;
+    virtual void sendBatteryTelemetry(const float voltageVolts) = 0;
+
+    /**
+    * @brief   Send gnss packet telemetry to the RC transmitter.
+    * @details The implementing class converts the supplied data into its own
+    *          wire format and transmits it.  All scaling happens inside the 
+    *          implementation; the caller passes only the raw data it already has.
+    * @param   data  A GnssData structure.
+    */
+    virtual void sendGnssTelemetry(const GnssData& data) = 0;
 
 
   protected:

--- a/PlainFlightController/ITelemetry.hpp
+++ b/PlainFlightController/ITelemetry.hpp
@@ -1,7 +1,7 @@
 /* 
 * Original File Author: D. Gamble (Github: Cyberslug)
 *
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/ITelemetry.hpp
+++ b/PlainFlightController/ITelemetry.hpp
@@ -1,4 +1,6 @@
 /* 
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
 * Copyright (c) 2025 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).

--- a/PlainFlightController/ITelemetry.hpp
+++ b/PlainFlightController/ITelemetry.hpp
@@ -56,7 +56,7 @@ class ITelemetry
     *          implementation; the caller passes only the raw float it already has.
     * @param   voltageVolts  Battery pack voltage in volts (e.g. 12.6f).
     */
-    virtual void sendBatteryTelemetry(const float voltageVolts) = 0;
+    virtual void sendBatteryTelemetry(const float& voltageVolts) = 0;
 
     /**
     * @brief   Send gnss packet telemetry to the RC transmitter.

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -1,9 +1,5 @@
 /* 
-<<<<<<< HEAD
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
-=======
 * Copyright (c) 2026 P.Cook (alias 'plainFlight')
->>>>>>> bf362b5 (add stragglers)
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 
@@ -109,7 +105,7 @@ namespace InternalConfig
   static constexpr bool DEBUG_CONFIGURATOR                   = false;
   static constexpr bool DEBUG_MPU6050                        = false;
   static constexpr bool DEBUG_OUTPUT                         = false;
-  static constexpr bool DEBUG_GPS                            = true;
+  static constexpr bool DEBUG_GPS                            = false;
 
   //==========================================================================
   // BUILD SETTINGS

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -109,6 +109,7 @@ namespace InternalConfig
   static constexpr bool DEBUG_CONFIGURATOR                   = false;
   static constexpr bool DEBUG_MPU6050                        = false;
   static constexpr bool DEBUG_OUTPUT                         = false;
+  static constexpr bool DEBUG_GPS                            = true;
 
   //==========================================================================
   // BUILD SETTINGS

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -1,5 +1,9 @@
 /* 
+<<<<<<< HEAD
 * Copyright (c) 2025 P.Cook (alias 'plainFlight')
+=======
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
+>>>>>>> bf362b5 (add stragglers)
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -85,7 +85,10 @@ namespace InternalConfig
     "Configuration Error: Combined total of servos, motors and pass through channels cannot exceed 8.");
 
   // Battery telemetry transmit periods (milliseconds)
-  static constexpr uint32_t TELEMETRY_BATTERY_PERIOD_MS      = 500U;
+  static constexpr uint32_t TELEMETRY_BATTERY_PERIOD_MS      = 500U;  // 2Hz
+
+  // Battery telemetry transmit periods (milliseconds)
+  static constexpr uint32_t TELEMETRY_GNSS_PERIOD_MS      = 200U;  // 5Hz
 
   //==========================================================================
   // DEBUG SETTINGS
@@ -113,6 +116,6 @@ namespace InternalConfig
   // USB serial baud rate and receiver UART port.
   static constexpr uint32_t USB_BAUD                         = 500000U;
   static constexpr HardwareSerial* const RECEIVER_UART       = &Serial0;
-
+  static constexpr HardwareSerial* const GNSS_UART           = &Serial1;
 
 }//Namespace InternalConfig end.

--- a/PlainFlightController/RxBase.cpp
+++ b/PlainFlightController/RxBase.cpp
@@ -1,5 +1,7 @@
 /* 
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/RxBase.hpp
+++ b/PlainFlightController/RxBase.hpp
@@ -73,14 +73,14 @@ class RxBase
       * @return RxPacket containing failsafe status, communication status, and normalised channel data.
       */
       virtual const RxPacket
-      getData() const = 0;
+      getData() = 0;
 
       /**
       * @brief Check if communications have been lost.
       * @return true if communications lost, false otherwise.
       */
       virtual const bool
-      hasLostCommunications() const = 0;
+      hasLostCommunications() = 0;
 
       /**
       * @brief Get new data from receiver.

--- a/PlainFlightController/RxBase.hpp
+++ b/PlainFlightController/RxBase.hpp
@@ -1,5 +1,7 @@
 /* 
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 

--- a/PlainFlightController/SBus.cpp
+++ b/PlainFlightController/SBus.cpp
@@ -173,7 +173,7 @@ SBus::getDemands()
 * @return   RxPacket containing failsafe, communication status, and normalised channel data.
 */
 const RxBase::RxPacket
-SBus::getData() const
+SBus::getData()
 {
   return m_rxData;
 }
@@ -184,7 +184,7 @@ SBus::getData() const
 * @return   true when SBus comms has been lost, false otherwise.
 */
 const bool
-SBus::hasLostCommunications() const
+SBus::hasLostCommunications()
 {
   return m_rxData.lostComms;
 }

--- a/PlainFlightController/SBus.hpp
+++ b/PlainFlightController/SBus.hpp
@@ -96,17 +96,17 @@ public:
    */
    void printData();
 
-   /**
-   * @brief Get receiver data packet.
-   * @return RxPacket containing failsafe status, communication status, and normalised channel data.
-   */
-   const RxPacket getData() const override;
+  /**
+     * @brief Get receiver data packet.
+     * @return RxPacket containing failsafe status, communication status, and normalised channel data.
+     */
+  const RxPacket getData() override;
 
-   /**
-   * @brief Check if communications have been lost.
-   * @return true if communications lost, false otherwise.
-   */
-   const bool hasLostCommunications() const override;
+  /**
+     * @brief Check if communications have been lost.
+     * @return true if communications lost, false otherwise.
+     */
+  const bool hasLostCommunications() override;
 
    /**
    * @brief Get channel index from channel name.

--- a/PlainFlightController/TelemetryManager.cpp
+++ b/PlainFlightController/TelemetryManager.cpp
@@ -25,28 +25,12 @@
 
 
 /**
-* @brief   Construct a TelemetryManager.
-* @details The battery timer is initialised via the member default
-*          (CTimer(0U)) so it reports EXPIRED on the first update() call,
-*          transmitting immediately rather than waiting a full period.
-*          This matches the pattern used by the loss-of-comms timers in
-*          Crsf and SBus.
-* @param   telemetry        Telemetry implementation pointer (may be nullptr).
-* @param   batteryPeriodMs  Battery transmit period in milliseconds.
-*/
-TelemetryManager::TelemetryManager(ITelemetry* const telemetry,
-                                   const uint32_t    batteryPeriodMs)
-  : m_telemetry(telemetry),
-    m_batteryPeriodMs(batteryPeriodMs)
-{
-}
-
-/**
 * @brief   Default constructor.
 */
 TelemetryManager::TelemetryManager()
   : m_telemetry(nullptr),
-    m_batteryPeriodMs(0U)
+    m_batteryPeriodMs(0U),
+    m_gnssPeriodMs(0U)
 {
 }
 
@@ -54,11 +38,13 @@ TelemetryManager::TelemetryManager()
 * @brief   Initialisation.
 */
 void
-TelemetryManager::begin(ITelemetry* telemetry, uint32_t batteryPeriodMs)
+TelemetryManager::begin(ITelemetry* telemetry, uint32_t batteryPeriodMs, uint32_t gnssPeriodMs)
 {
   m_telemetry = telemetry;
   m_batteryPeriodMs = batteryPeriodMs;
   m_batteryTimer.set(0U); // Force immediate expire on first update() call.
+  m_gnssPeriodMs = gnssPeriodMs;
+  m_gnssTimer.set(0U); // Force immediate expire on first update() call.
 }
 
 
@@ -77,7 +63,7 @@ TelemetryManager::begin(ITelemetry* telemetry, uint32_t batteryPeriodMs)
 * @param   voltageVolts  Current battery pack voltage in volts.
 */
 void
-TelemetryManager::update(const float& voltageVolts)
+TelemetryManager::updateBattery(const float voltageVolts)
 {
   // Early exit: no telemetry path available (e.g. SBus receiver).
   if (nullptr == m_telemetry)
@@ -89,5 +75,29 @@ TelemetryManager::update(const float& voltageVolts)
   {
     m_telemetry->sendBatteryTelemetry(voltageVolts);
     m_batteryTimer.set(static_cast<uint64_t>(m_batteryPeriodMs));
+  }
+}
+
+/**
+* @brief   Push the current gnss data and transmit if the timer has elapsed.
+* @details Returns immediately if the telemetry pointer is nullptr.  Otherwise
+*          checks whether the gnss timer has expired; if so, calls
+*          sendGnssTelemetry() and restarts the timer.  No serialisation
+*          work occurs on iterations where the timer has not expired.
+* @param   data  Current GnssData packet.
+*/
+void
+TelemetryManager::updateGnss(const GnssData& data)
+{
+  // Early exit: no telemetry path available (e.g. SBus receiver).
+  if (nullptr == m_telemetry)
+  {
+    return;
+  }
+
+  if (CTimer::State::EXPIRED == m_gnssTimer.getState())
+  {
+    m_telemetry->sendGnssTelemetry(data);
+    m_gnssTimer.set(static_cast<uint64_t>(m_gnssPeriodMs));
   }
 }

--- a/PlainFlightController/TelemetryManager.cpp
+++ b/PlainFlightController/TelemetryManager.cpp
@@ -63,7 +63,7 @@ TelemetryManager::begin(ITelemetry* telemetry, uint32_t batteryPeriodMs, uint32_
 * @param   voltageVolts  Current battery pack voltage in volts.
 */
 void
-TelemetryManager::updateBattery(const float voltageVolts)
+TelemetryManager::updateBattery(const float& voltageVolts)
 {
   // Early exit: no telemetry path available (e.g. SBus receiver).
   if (nullptr == m_telemetry)

--- a/PlainFlightController/TelemetryManager.hpp
+++ b/PlainFlightController/TelemetryManager.hpp
@@ -89,7 +89,7 @@ class TelemetryManager
     *          work occurs on iterations where the timer has not expired.
     * @param   voltageVolts  Current battery pack voltage in volts.
     */
-    void updateBattery(const float voltageVolts);
+    void updateBattery(const float& voltageVolts);
 
     /**
     * @brief   Push the current gnss data and transmit if the timer has elapsed.

--- a/PlainFlightController/TelemetryManager.hpp
+++ b/PlainFlightController/TelemetryManager.hpp
@@ -52,6 +52,7 @@
 #include <inttypes.h>
 #include "Timer.hpp"
 #include "ITelemetry.hpp"
+#include "GnssDriver.hpp"
 
 
 /**
@@ -65,17 +66,6 @@ class TelemetryManager
 {
   public:
 
-    /**
-    * @brief   Construct a TelemetryManager.
-    * @details The battery timer is initialised to the expired state so that
-    *          the very first update() call transmits immediately.
-    * @param   telemetry        Pointer to the telemetry implementation.  May be
-    *                           nullptr when the active receiver has no telemetry
-    *                           downlink; update() becomes a no-op in that case.
-    * @param   batteryPeriodMs  Minimum interval between battery telemetry frames, ms.
-    */
-    TelemetryManager(ITelemetry* telemetry, uint32_t batteryPeriodMs);
-
         /**
     * @brief   Default constructor.
     * @details Required for instantiation as a member of FlightControl.
@@ -87,9 +77,10 @@ class TelemetryManager
     * @brief   Initialise the manager with a telemetry implementation.
     * @param   telemetry        Pointer to the telemetry implementation (e.g. Crsf).
     * @param   batteryPeriodMs  Minimum interval between battery telemetry frames, ms.
+    * @param   gnssPeriodMs     Minimum interval between gnss telemetry frames, ms.
     */
-    void begin(ITelemetry* telemetry, uint32_t    batteryPeriodMs);
-               
+    void begin(ITelemetry* telemetry, uint32_t batteryPeriodMs, uint32_t gnssPeriodMs);
+
     /**
     * @brief   Push the current battery voltage and transmit if the timer has elapsed.
     * @details Returns immediately if the telemetry pointer is nullptr.  Otherwise
@@ -98,17 +89,32 @@ class TelemetryManager
     *          work occurs on iterations where the timer has not expired.
     * @param   voltageVolts  Current battery pack voltage in volts.
     */
-    void update(const float& voltageVolts);
+    void updateBattery(const float voltageVolts);
 
+    /**
+    * @brief   Push the current gnss data and transmit if the timer has elapsed.
+    * @details Returns immediately if the telemetry pointer is nullptr.  Otherwise
+    *          checks whether the gnss timer has expired; if so, calls
+    *          sendGnssTelemetry() and restarts the timer.  No serialisation
+    *          work occurs on iterations where the timer has not expired.
+    * @param   data  Current GnssData packet.
+    */
+    void updateGnss(const GnssData& data);
 
   private:
 
     /** Telemetry implementation. nullptr → receiver has no downlink; update() is a no-op. */
-    ITelemetry* m_telemetry       = nullptr;
+    ITelemetry* m_telemetry      = nullptr;
 
     /** Minimum transmit interval for battery frames, in milliseconds. */
     uint32_t    m_batteryPeriodMs = 0U;
 
     /** Timer that gates battery telemetry transmissions. */
     CTimer      m_batteryTimer    = CTimer(0U);
+
+    /** Minimum transmit interval for gnss frames, in milliseconds. */
+    uint32_t    m_gnssPeriodMs     = 0U;
+
+    /** Timer that gates gnss telemetry transmissions. */
+    CTimer      m_gnssTimer        = CTimer(0U);
 };


### PR DESCRIPTION
Adds CRSF GPS telemetry transmission to the existing telemetry infrastructure, alongside a number of minor corrections.

### New functionality

CrsfCodec::buildGpsFrame() encodes latitude, longitude, ground speed, heading, altitude, and satellite count into a CRSF 0x02 GPS frame with correct big-endian byte order and DVB-S2 CRC.
Crsf::sendGnssTelemetry() transmits the built frame over the CRSF UART.
ITelemetry, TelemetryManager, and FlightControl extended to include the GNSS telemetry path, rate-gated via a dedicated timer in TelemetryManager.
GNSS initialisation in FlightControl::begin() uses the safe fast-track start sequence.

### Bug fix

FlightControl::operate(): corrected a missing assignment in the IMU fault check — the expression DemandProcessor::FlightState::FAULTED was evaluated but never assigned to m_flightState, silently swallowing IMU errors detected at runtime.

### Minor corrections

const GnssData& applied correctly throughout the telemetry call chain.
Signed latitude and longitude cast to uint32_t before bit-shifting to avoid implementation-defined behaviour.
Altitude below-sea-level edge case guarded before signed-to-unsigned cast.
RSSI negation corrected in parseLinkStatistics().

### Misc

File author added to several files.