### PR TITLE
Pr/18 tx channel pass through

### DIFF
--- a/PlainFlightController/BoardConfig.hpp
+++ b/PlainFlightController/BoardConfig.hpp
@@ -142,4 +142,37 @@ static constexpr Board TINY =
   .SWAP_NEOPIXEL_RGB_TO_GRB = true,   //If your neopixel ordering is green-red-blue then set this to true.
 };
 
+/**
+* @brief Structure representing the standard IO map for the Waveshare module carrier board by Cyberslug.
+*        Rev 0.0 is currently under test
+*/
+static constexpr Board WSMC = 
+{
+  //LEDC channel pins used for servos/motors.
+  .OUTPUT_1           = 1U,   //GPIO1 
+  .OUTPUT_2           = 2U,   //GPIO2
+  .OUTPUT_3           = 3U,   //GPIO3
+  .OUTPUT_4           = 4U,   //GPIO4
+  .OUTPUT_5           = 5U,   //GPIO5
+  .OUTPUT_6           = 6U,   //GPIO6
+  .OUTPUT_7           = 7U,   //GPIO07
+  .OUTPUT_8           = 14U,   //GPIO08
+  //Other IO pins
+  .LED_ON_BOARD       = 21U,  //GPIO21
+  .I2C_SDA            = 9U,   //GPIO09
+  .I2C_SCL            = 10U,  //GPIO10
+  .RADIO_RECEIVER_RX  = 44U,  //GPIO44
+  .RADIO_RECEIVER_TX  = 43U,  //GPIO43
+  //.GNSS_RX            = 11U,  //GPIO11
+  //.GNSS_TX            = 12U,  //GPIO12
+  .LED_EXTERNAL       = 8U,  //GPIO16  not used
+  .BATTERY_ADC        = 13U,  //GPIO13
+  //GPIO 8, 9, 10, 11, 17, 18, 38, 39, 40, 41, 42, 45 spare
+  //Options
+  .SINK_ONBOARD_LED         = false,  //Set true to sink onboard LED, false to source onboard LED. 
+  .HAS_NEOPIXEL             = true,   //When using a board with a Neopixel i.e. WS2812 or equivalent.
+  .SWAP_NEOPIXEL_RGB_TO_GRB = true,  //If your neopixel ordering is green-red-blue then set this to true.
+};
+
+
 }//Namespace BoardConfig end.

--- a/PlainFlightController/BoardConfig.hpp
+++ b/PlainFlightController/BoardConfig.hpp
@@ -26,153 +26,120 @@
 namespace BoardConfig
 {
 
-/**
-* @brief  Structure representing all IO used by Plain Flight Controller.
-* @note   Some boards may have additional spare IO.
-*/
-struct Board
-{
-  //LEDC channel pins used for servos/motors.
-  const uint8_t OUTPUT_1;
-  const uint8_t OUTPUT_2;
-  const uint8_t OUTPUT_3;
-  const uint8_t OUTPUT_4;
-  const uint8_t OUTPUT_5;
-  const uint8_t OUTPUT_6;
-  const uint8_t OUTPUT_7;
-  const uint8_t OUTPUT_8;
-  //Other IO pins
-  const uint8_t LED_ON_BOARD;
-  const uint8_t I2C_SDA;
-  const uint8_t I2C_SCL;
-  const uint8_t RADIO_RECEIVER_RX;
-  const uint8_t RADIO_RECEIVER_TX;
-  const uint8_t LED_EXTERNAL;
-  const uint8_t BATTERY_ADC;
-  //Options
-  const bool SINK_ONBOARD_LED;          //Set true to sink onboard LED, false to source onboard LED. 
-  const bool HAS_NEOPIXEL;              //When using a board with a Neopixel i.e. WS2812 or equivalent.
-  const bool SWAP_NEOPIXEL_RGB_TO_GRB;  //If your neopixel ordering is green-red-blue then set this to true.
-};
+  /**
+  * @brief  Structure representing all IO used by Plain Flight Controller.
+  * @note   Some boards may have additional spare IO.
+  */
+  struct Board
+  {
+    //LEDC channel pins used for servos/motors.
+    const uint8_t OUTPUT_1;
+    const uint8_t OUTPUT_2;
+    const uint8_t OUTPUT_3;
+    const uint8_t OUTPUT_4;
+    const uint8_t OUTPUT_5;
+    const uint8_t OUTPUT_6;
+    const uint8_t OUTPUT_7;
+    const uint8_t OUTPUT_8;
+    //Other IO pins
+    const uint8_t LED_ON_BOARD;
+    const uint8_t I2C_SDA;
+    const uint8_t I2C_SCL;
+    const uint8_t RADIO_RECEIVER_RX;
+    const uint8_t RADIO_RECEIVER_TX;
+    const uint8_t LED_EXTERNAL;
+    const uint8_t BATTERY_ADC;
+    //Options
+    const bool SINK_ONBOARD_LED;          //Set true to sink onboard LED, false to source onboard LED. 
+    const bool HAS_NEOPIXEL;              //When using a board with a Neopixel i.e. WS2812 or equivalent.
+    const bool SWAP_NEOPIXEL_RGB_TO_GRB;  //If your neopixel ordering is green-red-blue then set this to true.
+  };
 
 
-/**
-* @brief Structure representing the standard IO map for ESP32S3-XIAO by Seed Studio.
-*/
-static constexpr Board XIAO = 
-{
-  //LEDC channel pins used for servos/motors.
-  .OUTPUT_1           = 1U, //GPIO1 = D0
-  .OUTPUT_2           = 2U, //GPIO2 = D1
-  .OUTPUT_3           = 3U, //GPIO3 = D2
-  .OUTPUT_4           = 4U, //GPIO4 = D3
-  .OUTPUT_5           = 7U, //GPIO7 = D8
-  .OUTPUT_6           = 8U, //GPIO8 = D9
-  //Other IO pins
-  .LED_ON_BOARD       = 21U,//GPIO21
-  .I2C_SDA            = 5U, //GPIO5 = D4
-  .I2C_SCL            = 6U, //GPIO6 = D5
-  .RADIO_RECEIVER_RX  = 44U,//GPIO44 = D7
-  .RADIO_RECEIVER_TX  = 45U,//GPIO45 = Unmapped pin on the XIAO
-  .LED_EXTERNAL       = 43U,//GPIO1 = D6
-  .BATTERY_ADC        = 9U, //GPIO9 = D10
-  //Options
-  .SINK_ONBOARD_LED         = true,   //Set true to sink onboard LED, false to source onboard LED. 
-  .HAS_NEOPIXEL             = false,  //When using a board with a Neopixel i.e. WS2812 or equivalent.
-  .SWAP_NEOPIXEL_RGB_TO_GRB = false,  //If your neopixel ordering is green-red-blue then set this to true.
-};
+  /**
+  * @brief Structure representing the standard IO map for ESP32S3-XIAO by Seed Studio.
+  */
+  static constexpr Board XIAO = 
+  {
+    //LEDC channel pins used for servos/motors.
+    .OUTPUT_1           = 1U, //GPIO1 = D0
+    .OUTPUT_2           = 2U, //GPIO2 = D1
+    .OUTPUT_3           = 3U, //GPIO3 = D2
+    .OUTPUT_4           = 4U, //GPIO4 = D3
+    .OUTPUT_5           = 7U, //GPIO7 = D8
+    .OUTPUT_6           = 8U, //GPIO8 = D9
+    //Other IO pins
+    .LED_ON_BOARD       = 21U,//GPIO21
+    .I2C_SDA            = 5U, //GPIO5 = D4
+    .I2C_SCL            = 6U, //GPIO6 = D5
+    .RADIO_RECEIVER_RX  = 44U,//GPIO44 = D7
+    .RADIO_RECEIVER_TX  = 45U,//GPIO45 = Unmapped pin on the XIAO
+    .LED_EXTERNAL       = 43U,//GPIO1 = D6
+    .BATTERY_ADC        = 9U, //GPIO9 = D10
+    //Options
+    .SINK_ONBOARD_LED         = true,   //Set true to sink onboard LED, false to source onboard LED. 
+    .HAS_NEOPIXEL             = false,  //When using a board with a Neopixel i.e. WS2812 or equivalent.
+    .SWAP_NEOPIXEL_RGB_TO_GRB = false,  //If your neopixel ordering is green-red-blue then set this to true.
+  };
 
 
-/**
-* @brief Structure representing the standard IO map for ESP32S3-ZERO by Waveshare.
-*/
-static constexpr Board ZERO = 
-{
-  //LEDC channel pins used for servos/motors.
-  .OUTPUT_1           = 1U,   //GPIO1 
-  .OUTPUT_2           = 2U,   //GPIO2
-  .OUTPUT_3           = 3U,   //GPIO3
-  .OUTPUT_4           = 4U,   //GPIO4
-  .OUTPUT_5           = 5U,   //GPIO5
-  .OUTPUT_6           = 6U,   //GPIO6
-  .OUTPUT_7           = 14U,  //GPIO14
-  .OUTPUT_8           = 15U,  //GPIO15
-  //Other IO pins
-  .LED_ON_BOARD       = 21U,  //GPIO21
-  .I2C_SDA            = 12U,  //GPIO12
-  .I2C_SCL            = 13U,  //GPIO13
-  .RADIO_RECEIVER_RX  = 44U,  //GPIO44
-  .RADIO_RECEIVER_TX  = 43U,  //GPIO43
-  .LED_EXTERNAL       = 16U,  //GPIO16
-  .BATTERY_ADC        = 7U,   //GPIO7
-  //GPIO 8, 9, 10, 11, 17, 18, 38, 39, 40, 41, 42, 45 spare
-  //Options
-  .SINK_ONBOARD_LED         = false,  //Set true to sink onboard LED, false to source onboard LED. 
-  .HAS_NEOPIXEL             = true,   //When using a board with a Neopixel i.e. WS2812 or equivalent.
-  .SWAP_NEOPIXEL_RGB_TO_GRB = true,   //If your neopixel ordering is green-red-blue then set this to true.
-};
+  /**
+  * @brief Structure representing the standard IO map for ESP32S3-ZERO by Waveshare.
+  */
+  static constexpr Board ZERO = 
+  {
+    //LEDC channel pins used for servos/motors.
+    .OUTPUT_1           = 1U,   //GPIO1 
+    .OUTPUT_2           = 2U,   //GPIO2
+    .OUTPUT_3           = 3U,   //GPIO3
+    .OUTPUT_4           = 4U,   //GPIO4
+    .OUTPUT_5           = 5U,   //GPIO5
+    .OUTPUT_6           = 6U,   //GPIO6
+    .OUTPUT_7           = 14U,  //GPIO14
+    .OUTPUT_8           = 15U,  //GPIO15
+    //Other IO pins
+    .LED_ON_BOARD       = 21U,  //GPIO21
+    .I2C_SDA            = 12U,  //GPIO12
+    .I2C_SCL            = 13U,  //GPIO13
+    .RADIO_RECEIVER_RX  = 44U,  //GPIO44
+    .RADIO_RECEIVER_TX  = 43U,  //GPIO43
+    .LED_EXTERNAL       = 16U,  //GPIO16
+    .BATTERY_ADC        = 7U,   //GPIO7
+    //GPIO 8, 9, 10, 11, 17, 18, 38, 39, 40, 41, 42, 45 spare
+    //Options
+    .SINK_ONBOARD_LED         = false,  //Set true to sink onboard LED, false to source onboard LED. 
+    .HAS_NEOPIXEL             = true,   //When using a board with a Neopixel i.e. WS2812 or equivalent.
+    .SWAP_NEOPIXEL_RGB_TO_GRB = true,   //If your neopixel ordering is green-red-blue then set this to true.
+  };
 
 
-/**
-* @brief Structure representing the standard IO map for ESP32S3-TINY by Waveshare.
-*/
-static constexpr Board TINY = 
-{
-  //LEDC channel pins used for servos/motors.
-  .OUTPUT_1           = 1U,   //GPIO1 
-  .OUTPUT_2           = 2U,   //GPIO2
-  .OUTPUT_3           = 3U,   //GPIO3
-  .OUTPUT_4           = 4U,   //GPIO4
-  .OUTPUT_5           = 5U,   //GPIO5
-  .OUTPUT_6           = 6U,   //GPIO6
-  .OUTPUT_7           = 7U,   //GPIO7
-  .OUTPUT_8           = 8U,   //GPIO8
-  //Other IO pins
-  .LED_ON_BOARD       = 38U,   //GPIO38
-  .I2C_SDA            = 18U,   //GPIO18
-  .I2C_SCL            = 17U,   //GPIO17
-  .RADIO_RECEIVER_RX  = 44U,   //GPIO44
-  .RADIO_RECEIVER_TX  = 43U,   //GPIO43
-  .LED_EXTERNAL       = 12U,   //GPIO12
-  .BATTERY_ADC        = 13U,   //GPIO13
-  //GPIO 9, 10, 11, 14, 15, 16, 21, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 45, 47, 48 spare
-  //Options
-  .SINK_ONBOARD_LED         = false,  //Set true to sink onboard LED, false to source onboard LED. 
-  .HAS_NEOPIXEL             = true,   //When using a board with a Neopixel i.e. WS2812 or equivalent.
-  .SWAP_NEOPIXEL_RGB_TO_GRB = true,   //If your neopixel ordering is green-red-blue then set this to true.
-};
-
-/**
-* @brief Structure representing the standard IO map for the Waveshare module carrier board by Cyberslug.
-*        Rev 0.0 is currently under test
-*/
-static constexpr Board WSMC = 
-{
-  //LEDC channel pins used for servos/motors.
-  .OUTPUT_1           = 1U,   //GPIO1 
-  .OUTPUT_2           = 2U,   //GPIO2
-  .OUTPUT_3           = 3U,   //GPIO3
-  .OUTPUT_4           = 4U,   //GPIO4
-  .OUTPUT_5           = 5U,   //GPIO5
-  .OUTPUT_6           = 6U,   //GPIO6
-  .OUTPUT_7           = 7U,   //GPIO07
-  .OUTPUT_8           = 14U,   //GPIO08
-  //Other IO pins
-  .LED_ON_BOARD       = 21U,  //GPIO21
-  .I2C_SDA            = 9U,   //GPIO09
-  .I2C_SCL            = 10U,  //GPIO10
-  .RADIO_RECEIVER_RX  = 44U,  //GPIO44
-  .RADIO_RECEIVER_TX  = 43U,  //GPIO43
-  //.GNSS_RX            = 11U,  //GPIO11
-  //.GNSS_TX            = 12U,  //GPIO12
-  .LED_EXTERNAL       = 8U,  //GPIO16  not used
-  .BATTERY_ADC        = 13U,  //GPIO13
-  //GPIO 8, 9, 10, 11, 17, 18, 38, 39, 40, 41, 42, 45 spare
-  //Options
-  .SINK_ONBOARD_LED         = false,  //Set true to sink onboard LED, false to source onboard LED. 
-  .HAS_NEOPIXEL             = true,   //When using a board with a Neopixel i.e. WS2812 or equivalent.
-  .SWAP_NEOPIXEL_RGB_TO_GRB = true,  //If your neopixel ordering is green-red-blue then set this to true.
-};
-
+  /**
+  * @brief Structure representing the standard IO map for ESP32S3-TINY by Waveshare.
+  */
+  static constexpr Board TINY = 
+  {
+    //LEDC channel pins used for servos/motors.
+    .OUTPUT_1           = 1U,   //GPIO1 
+    .OUTPUT_2           = 2U,   //GPIO2
+    .OUTPUT_3           = 3U,   //GPIO3
+    .OUTPUT_4           = 4U,   //GPIO4
+    .OUTPUT_5           = 5U,   //GPIO5
+    .OUTPUT_6           = 6U,   //GPIO6
+    .OUTPUT_7           = 7U,   //GPIO7
+    .OUTPUT_8           = 8U,   //GPIO8
+    //Other IO pins
+    .LED_ON_BOARD       = 38U,   //GPIO38
+    .I2C_SDA            = 18U,   //GPIO18
+    .I2C_SCL            = 17U,   //GPIO17
+    .RADIO_RECEIVER_RX  = 44U,   //GPIO44
+    .RADIO_RECEIVER_TX  = 43U,   //GPIO43
+    .LED_EXTERNAL       = 12U,   //GPIO12
+    .BATTERY_ADC        = 13U,   //GPIO13
+    //GPIO 9, 10, 11, 14, 15, 16, 21, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 45, 47, 48 spare
+    //Options
+    .SINK_ONBOARD_LED         = false,  //Set true to sink onboard LED, false to source onboard LED. 
+    .HAS_NEOPIXEL             = true,   //When using a board with a Neopixel i.e. WS2812 or equivalent.
+    .SWAP_NEOPIXEL_RGB_TO_GRB = true,   //If your neopixel ordering is green-red-blue then set this to true.
+  };
 
 }//Namespace BoardConfig end.

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -1,11 +1,34 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   CommonTypes.hpp
+* @brief  This file contains enums and structures that are used throughout the program.
+*/
+
 #pragma once
 
 #include <cstdint>
 
 /**
- * @enum ModelType
- * @brief Defines all aircraft configurations supported by the flight controller.
- */
+* @enum ModelType
+* @brief Defines all aircraft configurations supported by the flight controller.
+*/
 enum class ModelType : uint8_t
 {
   PLANE_FULL_HOUSE,
@@ -24,9 +47,9 @@ enum class ModelType : uint8_t
 };
 
 /**
- * @enum ReceiverType
- * @brief Supported radio protocols.
- */
+* @enum ReceiverType
+* @brief Supported radio protocols.
+*/
 enum class ReceiverType : uint8_t
 {
   SBUS,
@@ -34,9 +57,9 @@ enum class ReceiverType : uint8_t
 };
 
 /**
- * @enum GyroRate
- * @brief Supported gyro rate range.
- */
+* @enum GyroRate
+* @brief Supported gyro rate range.
+*/
 enum class GyroRate : uint8_t
 {
   IS_250_DEGS_SECOND,
@@ -44,14 +67,45 @@ enum class GyroRate : uint8_t
 };
 
 /**
- * @enum AircraftDir
- * @brief Used for orientation of the gyro relative to the aircraft.
- *        Note: The ordering is important here, it is used to ensure that 
- *        a valid orientation is selected.
- */
+* @enum AircraftDir
+* @brief Used for orientation of the gyro relative to the aircraft.
+*        Note: The ordering is important here, it is used to ensure that 
+*        a valid orientation is selected.
+*/
 enum class AircraftDir: uint8_t 
 { 
   FRONT, BACK, 
   LEFT, RIGHT, 
   UP, DOWN 
+};
+
+/**
+* @enum RcChannelName
+* @brief Standard channel names for RC control mapping.
+* Other channels must be referred to by number
+*/
+enum class RcChannelName : uint32_t
+{
+    THROTTLE = 0U,
+    ROLL,
+    PITCH,
+    YAW,
+    ARM,
+    MODE,
+    AUX1,
+    AUX2,
+    AUX3,
+    AUX4,
+    AUX5,
+    AUX6
+};
+
+/**
+* @struct PassThroughStruct
+* @brief Used for channel pass through structure in Config.hpp.
+*/
+struct PassThroughStruct
+{
+  uint8_t outputPin;
+  RcChannelName channel;
 };

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -97,7 +97,13 @@ enum class RcChannelName : uint32_t
   AUX3,
   AUX4,
   AUX5,
-  AUX6
+  AUX6,
+  AUX7,
+  AUX8,
+  AUX9,
+  AUX10,
+  AUX11,
+  AUX12
 };
 
 /**

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -86,18 +86,18 @@ enum class AircraftDir: uint8_t
 */
 enum class RcChannelName : uint32_t
 {
-    THROTTLE = 0U,
-    ROLL,
-    PITCH,
-    YAW,
-    ARM,
-    MODE,
-    AUX1,
-    AUX2,
-    AUX3,
-    AUX4,
-    AUX5,
-    AUX6
+  THROTTLE = 0U,
+  ROLL,
+  PITCH,
+  YAW,
+  ARM,
+  MODE,
+  AUX1,
+  AUX2,
+  AUX3,
+  AUX4,
+  AUX5,
+  AUX6
 };
 
 /**

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -56,7 +56,7 @@ class Config
   // Available options (defined in BoardConfig.hpp): XIAO, ZERO, TINY
   //==========================================================================
 
-  static constexpr BoardConfig::Board ESP32S3                = BoardConfig::XIAO;
+  static constexpr BoardConfig::Board ESP32S3                = BoardConfig::ZERO;
 
 
   //==========================================================================
@@ -76,7 +76,7 @@ class Config
   // QUAD_X_COPTER, QUAD_P_COPTER, BI_COPTER, CHINOOK_COPTER, TRI_COPTER, DUAL_COPTER, SINGLE_COPTER
   //==========================================================================
   
-  static constexpr ModelType MODEL_TYPE                      = ModelType::PLANE_RUDDER_ELEVATOR;
+  static constexpr ModelType MODEL_TYPE                      = ModelType::PLANE_FULL_HOUSE;
 
   //==========================================================================
   // SECTION 4: OUTPUT ASSIGNMENT
@@ -109,19 +109,19 @@ class Config
   {
       ESP32S3.OUTPUT_1,   // Servo 1 - e.g. left aileron  (PlaneFullHouse)
       ESP32S3.OUTPUT_2,   // Servo 2 - e.g. right aileron (PlaneFullHouse)
-      //ESP32S3.OUTPUT_3,   // Servo 3 - e.g. elevator      (PlaneFullHouse)
-      //ESP32S3.OUTPUT_4,   // Servo 4 - e.g. rudder        (PlaneFullHouse)
+      ESP32S3.OUTPUT_3,   // Servo 3 - e.g. elevator      (PlaneFullHouse)
+      ESP32S3.OUTPUT_4,   // Servo 4 - e.g. rudder        (PlaneFullHouse)
   };
 
   static constexpr uint8_t MOTOR_PINS[] =
   {
       // PlaneFullHouse expects two motors here even when not physically fitted 
       // as the code support differential thrust.
-      ESP32S3.OUTPUT_3,   // Motor 1 - e.g. left/single motor  (PlaneFullHouse)
-      ESP32S3.OUTPUT_4,   // Motor 2 - e.g. right motor (PlaneFullHouse)
+      ESP32S3.OUTPUT_5,   // Motor 1 - e.g. left/single motor  (PlaneFullHouse)
+      ESP32S3.OUTPUT_6,   // Motor 2 - e.g. right motor (PlaneFullHouse)
   };
 
-  // Refresh rates for servos, motors and pass through channels.
+  // Refresh rates for servos, motors and any pass through channels.
   // Available options (defined in LedcServo.hpp):
   //   IS_50Hz, IS_100Hz, IS_150Hz, IS_200Hz, IS_250Hz, IS_300Hz, IS_350Hz, IS_ONESHOT125
   // Use IS_50Hz for analogue servos.
@@ -134,11 +134,12 @@ class Config
 
   // Any spare PWM channels not used by the model type can be used as channel pass through from Tx.
   // This can be useful to pass through functions such as under carriage and lights etc.
-  static constexpr uint8_t PASS_THROUGH_PINS[][2] =
+  // IMPORTANT NOTE: When using SBus if your model configuration uses more than 8 RC channels, then in Sbus.hpp set USE_ALL_18_CHANNELS = true 
+  static constexpr PassThroughStruct PASS_THROUGH_PINS[] =
   {      
-      //Output Pin to use,  Rx channel to assign
-      {ESP32S3.OUTPUT_5,    static_cast<uint8_t>(RxBase::ChannelName::ARM)},  // E.g. Gear
-      {ESP32S3.OUTPUT_6,    static_cast<uint8_t>(RxBase::ChannelName::MODE)}   // E.g. Lights
+    //Output Pin to use,  Rx channel to assign
+    {ESP32S3.OUTPUT_7,    RcChannelName::AUX4},  // E.g. Gear
+    {ESP32S3.OUTPUT_8,    RcChannelName::AUX5}   // E.g. Lights
   };
 
   //==========================================================================
@@ -175,11 +176,11 @@ class Config
   // Enable or disable optional features for this aircraft build.
   //==========================================================================
 
-  static constexpr bool USE_FLAPS                            = true;  // Flaps on Tx channel 7; use 2, 3 position switch or rotary pot.
+  static constexpr bool USE_FLAPS                            = false;  // Flaps on Tx channel 7; use 2, 3 position switch or rotary pot.
   static constexpr bool USE_DIFFERENTIAL_THRUST              = false;  // Fixed-wing twin engine differential thrust.
   static constexpr bool USE_HEADING_HOLD                     = false;  // Gyro-based heading hold on Tx channel 8.
   static constexpr bool USE_LOW_VOLTS_CUT_OFF                = false;  // Limit throttle upon low battery voltage.
-  static constexpr bool USE_EXTERNAL_LED                     = true;  // Enable external LED output.
+  static constexpr bool USE_EXTERNAL_LED                     = false;  // Enable external LED output.
   static constexpr bool USE_ACRO_TRAINER                     = false;  // Level mode when pitch & roll sticks centred, rate mode otherwise.
   static constexpr bool HAS_TELEMETRY                        = true;   // Enable telemetry downlink to the RC transmitter.
 
@@ -221,7 +222,7 @@ class Config
   // The x and y axis are typically marked on the module board.
   // Available options (defined in CommonTypes.hpp) are FRONT, BACK, LEFT, RIGHT, UP and DOWN
   static constexpr AircraftDir IMU_PLUS_X                    = AircraftDir::FRONT;  // Direction that the gyro plus x axis is facing.
-  static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::RIGHT;   // Direction that the gyro plus y axis is facing.
+  static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::LEFT;   // Direction that the gyro plus y axis is facing.
 
   // Transmitter stick deadband (normalised units, approximately 0.5% of normalised span).
   static constexpr uint32_t TX_DEADBAND_NORM                 = 10U;

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -41,6 +41,7 @@
 #include "LedcServo.hpp"
 #include "CommonTypes.hpp"
 #include "BoardConfig.hpp"
+#include "RxBase.hpp"
 
 /**
  * @class Config
@@ -75,7 +76,7 @@ class Config
   // QUAD_X_COPTER, QUAD_P_COPTER, BI_COPTER, CHINOOK_COPTER, TRI_COPTER, DUAL_COPTER, SINGLE_COPTER
   //==========================================================================
   
-  static constexpr ModelType MODEL_TYPE                      = ModelType::PLANE_FULL_HOUSE;
+  static constexpr ModelType MODEL_TYPE                      = ModelType::PLANE_RUDDER_ELEVATOR;
 
   //==========================================================================
   // SECTION 4: OUTPUT ASSIGNMENT
@@ -108,19 +109,19 @@ class Config
   {
       ESP32S3.OUTPUT_1,   // Servo 1 - e.g. left aileron  (PlaneFullHouse)
       ESP32S3.OUTPUT_2,   // Servo 2 - e.g. right aileron (PlaneFullHouse)
-      ESP32S3.OUTPUT_3,   // Servo 3 - e.g. elevator      (PlaneFullHouse)
-      ESP32S3.OUTPUT_4,   // Servo 4 - e.g. rudder        (PlaneFullHouse)
+      //ESP32S3.OUTPUT_3,   // Servo 3 - e.g. elevator      (PlaneFullHouse)
+      //ESP32S3.OUTPUT_4,   // Servo 4 - e.g. rudder        (PlaneFullHouse)
   };
 
   static constexpr uint8_t MOTOR_PINS[] =
   {
       // PlaneFullHouse expects two motors here even when not physically fitted 
       // as the code support differential thrust.
-      ESP32S3.OUTPUT_5,   // Motor 1 - e.g. left/single motor  (PlaneFullHouse)
-      ESP32S3.OUTPUT_6,   // Motor 2 - e.g. right motor (PlaneFullHouse)
+      ESP32S3.OUTPUT_3,   // Motor 1 - e.g. left/single motor  (PlaneFullHouse)
+      ESP32S3.OUTPUT_4,   // Motor 2 - e.g. right motor (PlaneFullHouse)
   };
 
-  // Refresh rates for servos and motors.
+  // Refresh rates for servos, motors and pass through channels.
   // Available options (defined in LedcServo.hpp):
   //   IS_50Hz, IS_100Hz, IS_150Hz, IS_200Hz, IS_250Hz, IS_300Hz, IS_350Hz, IS_ONESHOT125
   // Use IS_50Hz for analogue servos.
@@ -128,8 +129,17 @@ class Config
   // Note: higher refresh rates give better output resolution and flight controller response.
   // CAUTION: ensure your servos and ESCs are rated for the refresh rate you select.
   static constexpr LedcServo::RefreshRate SERVO_REFRESH_RATE = LedcServo::RefreshRate::IS_150Hz;
-  static constexpr LedcServo::RefreshRate MOTOR_REFRESH_RATE = LedcServo::RefreshRate::IS_150Hz;
+  static constexpr LedcServo::RefreshRate MOTOR_REFRESH_RATE = LedcServo::RefreshRate::IS_ONESHOT125;
+  static constexpr LedcServo::RefreshRate PASS_THROUGH_REFRESH_RATE = LedcServo::RefreshRate::IS_50Hz;
 
+  // Any spare PWM channels not used by the model type can be used as channel pass through from Tx.
+  // This can be useful to pass through functions such as under carriage and lights etc.
+  static constexpr uint8_t PASS_THROUGH_PINS[][2] =
+  {      
+      //Output Pin to use,  Rx channel to assign
+      {ESP32S3.OUTPUT_5,    static_cast<uint8_t>(RxBase::ChannelName::ARM)},  // E.g. Gear
+      {ESP32S3.OUTPUT_6,    static_cast<uint8_t>(RxBase::ChannelName::MODE)}   // E.g. Lights
+  };
 
   //==========================================================================
   // SECTION 5: OUTPUT CONFIGURATION
@@ -152,7 +162,7 @@ class Config
   // Use when WiFi GUI trims have been used to offset servo centre position
   // in order to regain the full range of servo travel.
   // When true, travel is extended to 0.8–2.2 ms.
-  static constexpr bool EXTEND_SERVO_TRAVEL_RANGE            = false;
+  static constexpr bool EXTEND_SERVO_TRAVEL_RANGE            = true;
 
   // Set to true to actively run the ESC calibration routine on next boot.
   // CAUTION: Remove all propellers before calibrating ESCs!
@@ -165,11 +175,11 @@ class Config
   // Enable or disable optional features for this aircraft build.
   //==========================================================================
 
-  static constexpr bool USE_FLAPS                            = false;  // Flaps on Tx channel 7; use 2, 3 position switch or rotary pot.
+  static constexpr bool USE_FLAPS                            = true;  // Flaps on Tx channel 7; use 2, 3 position switch or rotary pot.
   static constexpr bool USE_DIFFERENTIAL_THRUST              = false;  // Fixed-wing twin engine differential thrust.
   static constexpr bool USE_HEADING_HOLD                     = false;  // Gyro-based heading hold on Tx channel 8.
   static constexpr bool USE_LOW_VOLTS_CUT_OFF                = false;  // Limit throttle upon low battery voltage.
-  static constexpr bool USE_EXTERNAL_LED                     = false;  // Enable external LED output.
+  static constexpr bool USE_EXTERNAL_LED                     = true;  // Enable external LED output.
   static constexpr bool USE_ACRO_TRAINER                     = false;  // Level mode when pitch & roll sticks centred, rate mode otherwise.
   static constexpr bool HAS_TELEMETRY                        = true;   // Enable telemetry downlink to the RC transmitter.
 
@@ -211,7 +221,7 @@ class Config
   // The x and y axis are typically marked on the module board.
   // Available options (defined in CommonTypes.hpp) are FRONT, BACK, LEFT, RIGHT, UP and DOWN
   static constexpr AircraftDir IMU_PLUS_X                    = AircraftDir::FRONT;  // Direction that the gyro plus x axis is facing.
-  static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::LEFT;   // Direction that the gyro plus y axis is facing.
+  static constexpr AircraftDir IMU_PLUS_Y                    = AircraftDir::RIGHT;   // Direction that the gyro plus y axis is facing.
 
   // Transmitter stick deadband (normalised units, approximately 0.5% of normalised span).
   static constexpr uint32_t TX_DEADBAND_NORM                 = 10U;

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -129,7 +129,7 @@ class Config
   // Note: higher refresh rates give better output resolution and flight controller response.
   // CAUTION: ensure your servos and ESCs are rated for the refresh rate you select.
   static constexpr LedcServo::RefreshRate SERVO_REFRESH_RATE = LedcServo::RefreshRate::IS_150Hz;
-  static constexpr LedcServo::RefreshRate MOTOR_REFRESH_RATE = LedcServo::RefreshRate::IS_ONESHOT125;
+  static constexpr LedcServo::RefreshRate MOTOR_REFRESH_RATE = LedcServo::RefreshRate::IS_150Hz;
   static constexpr LedcServo::RefreshRate PASS_THROUGH_REFRESH_RATE = LedcServo::RefreshRate::IS_50Hz;
 
   // Any spare PWM channels not used by the model type can be used as channel pass through from Tx.
@@ -138,8 +138,8 @@ class Config
   static constexpr PassThroughStruct PASS_THROUGH_PINS[] =
   {      
     //Output Pin to use,  Rx channel to assign
-    {ESP32S3.OUTPUT_7,    RcChannelName::AUX4},  // E.g. Gear
-    {ESP32S3.OUTPUT_8,    RcChannelName::AUX5}   // E.g. Lights
+    {ESP32S3.OUTPUT_7,    RcChannelName::AUX3},  // E.g. Gear
+    {ESP32S3.OUTPUT_8,    RcChannelName::AUX4}   // E.g. Lights
   };
 
   //==========================================================================

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -41,7 +41,6 @@
 #include "LedcServo.hpp"
 #include "CommonTypes.hpp"
 #include "BoardConfig.hpp"
-#include "RxBase.hpp"
 
 /**
  * @class Config

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -62,11 +62,11 @@ class Crsf : public RxBase, public ITelemetry
     /**
     * @brief Channel mapping for CRSF/ELRS protocol (AETR ordering).
     *
-    * Maps logical ChannelName values to their physical CRSF channel indices.
+    * Maps logical RcChannelName values to their physical CRSF channel indices.
     * CRSF transmits channels in Aileron(0), Elevator(1), Throttle(2), Rudder(3)
     * order; this table re-orders them to the flight controller's convention.
     */
-    static constexpr uint32_t CHANNEL_MAP[9] =
+    static constexpr uint32_t CHANNEL_MAP[16] =
     {
       2U,   // THROTTLE → CRSF channel 2
       0U,   // ROLL     → CRSF channel 0 (Aileron)
@@ -76,7 +76,14 @@ class Crsf : public RxBase, public ITelemetry
       5U,   // MODE     → CRSF channel 5
       6U,   // AUX1     → CRSF channel 6
       7U,   // AUX2     → CRSF channel 7
-      8U    // AUX3     → CRSF channel 8
+      8U,   // AUX3     → CRSF channel 8
+      9U,   // AUX4     → CRSF channel 9
+      10U,  // AUX5     → CRSF channel 10
+      11U,  // AUX6     → CRSF channel 11
+      12U,  // AUX7     → CRSF channel 12
+      13U,  // AUX8     → CRSF channel 13
+      14U,  // AUX8     → CRSF channel 14
+      15U,  // AUX10    → CRSF channel 15
     };
 
     /**
@@ -142,11 +149,11 @@ class Crsf : public RxBase, public ITelemetry
     const bool hasLostCommunications() const override;
 
     /**
-    * @brief   Resolve a logical ChannelName to its physical CRSF channel index.
+    * @brief   Resolve a logical RcChannelName to its physical CRSF channel index.
     * @param   name  Logical channel name enum value.
     * @return  Physical channel index (0-based) for use with RxPacket::ch[].
     */
-    uint32_t getChannelIndex(ChannelName name) const override
+    uint32_t getChannelIndex(RcChannelName name) const override
     {
       return CHANNEL_MAP[static_cast<uint32_t>(name)];
     }

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -94,29 +94,29 @@ void
 DemandProcessor::decodeStickPositions(FlightState const* const flightState, FileSystem::Rates const* const rates, FileSystem::MaxAngle const* const maxAngle)
 {
   //Normalise stick commands to signed values that we can work with
-  m_demand.pitch = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::PITCH);
+  m_demand.pitch = radioCtrl->getChannel(m_normalisedData, RcChannelName::PITCH);
 
   if (Config::TX_DEADBAND_NORM > abs(m_demand.pitch))
   {
     m_demand.pitch = 0;
   }
 
-  m_demand.roll = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::ROLL);
+  m_demand.roll = radioCtrl->getChannel(m_normalisedData, RcChannelName::ROLL);
 
   if (Config::TX_DEADBAND_NORM > abs(m_demand.roll))
   {
     m_demand.roll = 0;
   }
 
-  m_demand.yaw = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::YAW);
+  m_demand.yaw = radioCtrl->getChannel(m_normalisedData, RcChannelName::YAW);
 
   if (Config::TX_DEADBAND_NORM > abs(m_demand.yaw))
   {
     m_demand.yaw = 0;
   }
 
-  m_demand.throttle = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::THROTTLE);
-  m_demand.flaps = radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::AUX1);
+  m_demand.throttle = radioCtrl->getChannel(m_normalisedData, RcChannelName::THROTTLE);
+  m_demand.flaps = radioCtrl->getChannel(m_normalisedData, RcChannelName::AUX1);
 
   switch (*flightState)
   {
@@ -177,8 +177,8 @@ void
 DemandProcessor::decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState)
 {
   FlightState demandedFlightState = *flightState;
-  m_demand.armed = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::ARM));
-  m_throttleHigh = (RxBase::LOW_THROTTLE_NORM < radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::THROTTLE));
+  m_demand.armed = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RcChannelName::ARM));
+  m_throttleHigh = (RxBase::LOW_THROTTLE_NORM < radioCtrl->getChannel(m_normalisedData, RcChannelName::THROTTLE));
 
   if (FlightState::CALIBRATE == demandedFlightState)
   {
@@ -255,7 +255,7 @@ DemandProcessor::throttleIsHigh()
 bool
 DemandProcessor::wifiApDemanded()
 {
-  return ((!m_demand.armed) && RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::THROTTLE)));
+  return ((!m_demand.armed) && RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RcChannelName::THROTTLE)));
 }
 
 
@@ -279,7 +279,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
 {
   if constexpr(Config::USE_PROP_HANG_MODE)
   {
-    m_demand.propHang = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::AUX3));
+    m_demand.propHang = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RcChannelName::AUX3));
 
     if (m_demand.propHang)
     {
@@ -287,7 +287,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
     }
   }
 
-  const RxBase::SwitchPosition modeSwitchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::MODE));
+  const RxBase::SwitchPosition modeSwitchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, RcChannelName::MODE));
 
   switch (modeSwitchPosition)
   {
@@ -323,7 +323,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
 DemandProcessor::FlightState
 DemandProcessor::getDemandedFlightModeMultiCopter()
 {
-  RxBase::SwitchPosition switchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::MODE));
+  RxBase::SwitchPosition switchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, RcChannelName::MODE));
 
   switch (switchPosition)
   {
@@ -350,7 +350,7 @@ DemandProcessor::getDemandedFlightModeMultiCopter()
 bool
 DemandProcessor::headingHoldActive()
 {
-  m_demand.headingHold = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RxBase::ChannelName::AUX2));
+  m_demand.headingHold = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RcChannelName::AUX2));
   return m_demand.headingHold;
 }
 

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -101,7 +101,7 @@ public:
   bool propHangActive();
   Demands const * const getDemands() const {return &m_demand;};
   ITelemetry* getTelemetry() const {return telemetryCtrl;};
-  RxBase::RxPacket const * const getNormailsedRcData() const {return &m_normalisedData;};
+  RxBase::RxPacket const * const getNormalisedRcData() const {return &m_normalisedData;};
 
 private:
   void decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState);

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -100,7 +100,8 @@ public:
   bool headingHoldActive();
   bool propHangActive();
   Demands const * const getDemands() const {return &m_demand;};
-  ITelemetry* getTelemetry() const { return telemetryCtrl; }
+  ITelemetry* getTelemetry() const { return telemetryCtrl;};
+  RxBase::RxPacket const * const getNormailsedRcData() const {return &m_normalisedData;};
 
 private:
   void decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState);

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -100,7 +100,7 @@ public:
   bool headingHoldActive();
   bool propHangActive();
   Demands const * const getDemands() const {return &m_demand;};
-  ITelemetry* getTelemetry() const { return telemetryCtrl;};
+  ITelemetry* getTelemetry() const {return telemetryCtrl;};
   RxBase::RxPacket const * const getNormailsedRcData() const {return &m_normalisedData;};
 
 private:

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -262,6 +262,7 @@ FlightControl::doCalibrateState()
 
   myModel->servoMixer(rc.getDemands(), config.getServoTrims());
   myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);  //Ensure motors do not operate
+  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
 }
 
 
@@ -273,6 +274,7 @@ FlightControl::doDisarmedState()
 {
   myModel->servoMixer(rc.getDemands(), config.getServoTrims());
   myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);  //Ensure motors do not operate
+  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
 }
 
 
@@ -291,6 +293,7 @@ FlightControl::doPassThroughState()
   }
 
   myModel->motorMixer(&demands);
+  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
 }
 
 
@@ -310,6 +313,7 @@ FlightControl::doRateState()
   }
 
   myModel->motorRateMixer(&demands);
+  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
 }
 
 
@@ -326,6 +330,7 @@ FlightControl::doFailSafeState()
     //Multicopters will fall out of the sky upon failsafe.
     myModel->servoMixer(&DemandProcessor::DEFAULT_DEMANDS, config.getServoTrims());
     myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);
+    myModel->handlePassThroughChannels(rc.getNormailsedRcData());
   }
   else
   {
@@ -360,7 +365,8 @@ FlightControl::doLevelledState()
     demands.throttle = batteryMonitor.limitThrottle(demands.throttle, rc.throttleIsHigh(), RxBase::MIN_NORMALISED);
   }
 
-  myModel->motorRateMixer(&demands);
+  myModel->motorRateMixer(&demands);  
+  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
 }
 
 
@@ -401,7 +407,8 @@ FlightControl::doAcroTrainerState()
       demands.throttle = batteryMonitor.limitThrottle(demands.throttle, rc.throttleIsHigh(), RxBase::MIN_NORMALISED);
     }
 
-    myModel->motorRateMixer(&demands);
+    myModel->motorRateMixer(&demands);    
+    myModel->handlePassThroughChannels(rc.getNormailsedRcData());
   }
   else
   {
@@ -468,7 +475,8 @@ FlightControl::doPropHangState()
     demands.throttle = batteryMonitor.limitThrottle(demands.throttle, rc.throttleIsHigh(), RxBase::MIN_NORMALISED);
   }
 
-  myModel->motorRateMixer(&demands);
+  myModel->motorRateMixer(&demands);  
+  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
 }
 
 
@@ -479,7 +487,8 @@ void
 FlightControl::doWifiApState()
 {
   myModel->servoMixer(&DemandProcessor::DEFAULT_DEMANDS, config.getServoTrims());
-  myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);
+  myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);  
+  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
 
   batteryMonitor.setVoltageScaler(config.getBatteryScaler());
   config.updateBatteryVoltage(batteryMonitor.getVoltage());
@@ -499,7 +508,8 @@ FlightControl::doFaultedState()
   //bad things happened
   const DemandProcessor::Demands demands = *rc.getDemands();
   myModel->servoMixer(&demands, config.getServoTrims());
-  myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);
+  myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);  
+  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
 }
 
 

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -262,7 +262,7 @@ FlightControl::doCalibrateState()
 
   myModel->servoMixer(rc.getDemands(), config.getServoTrims());
   myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);  //Ensure motors do not operate
-  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+  myModel->handlePassThroughChannels(rc.getNormalisedRcData());
 }
 
 
@@ -274,7 +274,7 @@ FlightControl::doDisarmedState()
 {
   myModel->servoMixer(rc.getDemands(), config.getServoTrims());
   myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);  //Ensure motors do not operate
-  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+  myModel->handlePassThroughChannels(rc.getNormalisedRcData());
 }
 
 
@@ -293,7 +293,7 @@ FlightControl::doPassThroughState()
   }
 
   myModel->motorMixer(&demands);
-  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+  myModel->handlePassThroughChannels(rc.getNormalisedRcData());
 }
 
 
@@ -313,7 +313,7 @@ FlightControl::doRateState()
   }
 
   myModel->motorRateMixer(&demands);
-  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+  myModel->handlePassThroughChannels(rc.getNormalisedRcData());
 }
 
 
@@ -330,7 +330,7 @@ FlightControl::doFailSafeState()
     //Multicopters will fall out of the sky upon failsafe.
     myModel->servoMixer(&DemandProcessor::DEFAULT_DEMANDS, config.getServoTrims());
     myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);
-    myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+    myModel->handlePassThroughChannels(rc.getNormalisedRcData());
   }
   else
   {
@@ -366,7 +366,7 @@ FlightControl::doLevelledState()
   }
 
   myModel->motorRateMixer(&demands);  
-  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+  myModel->handlePassThroughChannels(rc.getNormalisedRcData());
 }
 
 
@@ -408,7 +408,7 @@ FlightControl::doAcroTrainerState()
     }
 
     myModel->motorRateMixer(&demands);    
-    myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+    myModel->handlePassThroughChannels(rc.getNormalisedRcData());
   }
   else
   {
@@ -476,7 +476,7 @@ FlightControl::doPropHangState()
   }
 
   myModel->motorRateMixer(&demands);  
-  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+  myModel->handlePassThroughChannels(rc.getNormalisedRcData());
 }
 
 
@@ -488,7 +488,7 @@ FlightControl::doWifiApState()
 {
   myModel->servoMixer(&DemandProcessor::DEFAULT_DEMANDS, config.getServoTrims());
   myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);  
-  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+  myModel->handlePassThroughChannels(rc.getNormalisedRcData());
 
   batteryMonitor.setVoltageScaler(config.getBatteryScaler());
   config.updateBatteryVoltage(batteryMonitor.getVoltage());
@@ -509,7 +509,7 @@ FlightControl::doFaultedState()
   const DemandProcessor::Demands demands = *rc.getDemands();
   myModel->servoMixer(&demands, config.getServoTrims());
   myModel->motorMixer(&DemandProcessor::DEFAULT_DEMANDS);  
-  myModel->handlePassThroughChannels(rc.getNormailsedRcData());
+  myModel->handlePassThroughChannels(rc.getNormalisedRcData());
 }
 
 

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -1,3 +1,26 @@
+/* 
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   InternalConfig.hpp
+* @brief  Header to hold internal configuration data that is used throughout the program.
+*/
+
 #pragma once
 
 #include "Config.hpp"
@@ -90,4 +113,6 @@ namespace InternalConfig
   // USB serial baud rate and receiver UART port.
   static constexpr uint32_t USB_BAUD                         = 500000U;
   static constexpr HardwareSerial* const RECEIVER_UART       = &Serial0;
-}
+
+
+}//Namespace end.

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -55,9 +55,11 @@ namespace InternalConfig
     static_cast<uint8_t>(sizeof(Config::SERVO_PINS) / sizeof(Config::SERVO_PINS[0]));
   static constexpr uint8_t NUMBER_MOTORS = 
     static_cast<uint8_t>(sizeof(Config::MOTOR_PINS) / sizeof(Config::MOTOR_PINS[0]));
+  static constexpr uint8_t NUMBER_PASS_THROUGH = 
+    static_cast<uint8_t>(sizeof(Config::PASS_THROUGH_PINS) / sizeof(Config::PASS_THROUGH_PINS[0]));
 
-  static_assert(NUMBER_SERVOS + NUMBER_MOTORS <= 8U, 
-    "Configuration Error: Combined total of servos and motors cannot exceed 8.");
+  static_assert((NUMBER_SERVOS + NUMBER_MOTORS + NUMBER_PASS_THROUGH) <= 8U, 
+    "Configuration Error: Combined total of servos, motors and pass through channels cannot exceed 8.");
 
   // Battery telemetry transmit periods (milliseconds)
   static constexpr uint32_t TELEMETRY_BATTERY_PERIOD_MS      = 500U;
@@ -76,7 +78,7 @@ namespace InternalConfig
   static constexpr bool DEBUG_GYRO_CALIBRATION               = false;
   static constexpr bool DEBUG_CONFIGURATOR                   = false;
   static constexpr bool DEBUG_MPU6050                        = false;
-  static constexpr bool DEBUG_OUTPUT                         = false;
+  static constexpr bool DEBUG_OUTPUT                         = true;
 
   //==========================================================================
   // BUILD SETTINGS

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -115,4 +115,4 @@ namespace InternalConfig
   static constexpr HardwareSerial* const RECEIVER_UART       = &Serial0;
 
 
-}//Namespace end.
+}//Namespace InternalConfig end.

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -101,7 +101,7 @@ namespace InternalConfig
   static constexpr bool DEBUG_GYRO_CALIBRATION               = false;
   static constexpr bool DEBUG_CONFIGURATOR                   = false;
   static constexpr bool DEBUG_MPU6050                        = false;
-  static constexpr bool DEBUG_OUTPUT                         = true;
+  static constexpr bool DEBUG_OUTPUT                         = false;
 
   //==========================================================================
   // BUILD SETTINGS

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -47,14 +47,16 @@ public:
     uint8_t outputPins[LedcServo::MAX_LEDC_CHANNELS];  // MAX_LEDC_CHANNELS = 8 for the ESP32-S3
     LedcServo::RefreshRate motorRefresh;
     LedcServo::RefreshRate servoRefresh;
+    LedcServo::RefreshRate passThroughRefresh;
     uint8_t numberMotors;
     uint8_t numberServos;
+    uint8_t numberPassThrough;
   };
 
   ModelBase() 
     : m_idleUp(IDLE_UP),
       m_minThrottle(MIN_THROTTLE),
-      m_totalOutputs(m_modelConfig.numberServos + m_modelConfig.numberMotors)
+      m_totalOutputs(m_modelConfig.numberServos + m_modelConfig.numberMotors + m_modelConfig.numberPassThrough)
   {
     // Ensure not too many outputs are declared
     assert(m_totalOutputs <= LedcServo::MAX_LEDC_CHANNELS);
@@ -68,11 +70,15 @@ public:
 
     for (uint8_t i = 0U; i < m_totalOutputs; i++)
     {
-        bool isServo = i < m_modelConfig.numberServos;
+        const bool isServo = (i < m_modelConfig.numberServos);
+        const bool isPassThrough = (i >= (m_modelConfig.numberServos + m_modelConfig.numberMotors));
+
+        LedcServo::RefreshRate refreshRate = (isServo) ? m_modelConfig.servoRefresh : (isPassThrough) ? m_modelConfig.passThroughRefresh: m_modelConfig.motorRefresh;
+
         outputs[i] = LedcServo(
             m_modelConfig.outputPins[i],
-            isServo ? m_modelConfig.servoRefresh : m_modelConfig.motorRefresh,
-            isServo ? LedcServo::MID_MICRO_SECONDS : LedcServo::MIN_MICRO_SECONDS,
+            refreshRate,
+            (isServo) ? LedcServo::MID_MICRO_SECONDS : LedcServo::MIN_MICRO_SECONDS,  //Pass through assumes MIN_MICRO_SECONDS
             Config::EXTEND_SERVO_TRAVEL_RANGE,
             REVERSE_OUTPUT[i]
         );
@@ -82,6 +88,8 @@ public:
     m_maxServoTimerTicks = static_cast<int32_t>(servoAt(0).getMaxTimerTicks());
     m_minMotorTimerTicks = static_cast<int32_t>(motorAt(0).getMinTimerTicks());//And/or all motors will be the same refresh rate
     m_maxMotorTimerTicks = static_cast<int32_t>(motorAt(0).getMaxTimerTicks());
+    m_minPassThroughTimerTicks = static_cast<int32_t>(passThroughAt(0).getMinTimerTicks());//And/or all pass through channels will be the same refresh rate
+    m_maxPassThroughTimerTicks = static_cast<int32_t>(passThroughAt(0).getMaxTimerTicks());
 
     const int32_t rateMinThrottle = map32(MIN_THROTTLE, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED,
                                       -PIDF::PIDF_MAX_LIMIT, PIDF::PIDF_MAX_LIMIT);
@@ -158,6 +166,34 @@ public:
     */
   int32_t getTrimMultiplier() const {return servoAt(0).getTrimMultiplier();}
 
+  /**/
+  void handlePassThroughChannels(RxBase::RxPacket const * const rxPacket)
+  {
+    uint32_t passThroughData[InternalConfig::NUMBER_PASS_THROUGH];
+
+    //for (uint8_t i : passThroughData)
+    for (uint8_t i=0; i < InternalConfig::NUMBER_PASS_THROUGH; i++)
+    {
+      const int32_t rxChannel = Config::PASS_THROUGH_PINS[i][1];
+      const int32_t rxChannelData = rxPacket->ch[rxChannel];      
+      passThroughData[i] = static_cast<uint32_t>(mapNormalisedPassThroughToTimerTicks(rxChannelData));
+/*
+      Serial.print(i);
+      Serial.print(",");
+      Serial.print(Config::PASS_THROUGH_PINS[i][0]);
+      Serial.print(",");
+      Serial.print(Config::PASS_THROUGH_PINS[i][1]);
+      Serial.print(",");
+      Serial.print(rxChannelData);
+      Serial.print(",");
+      */
+    }
+//Serial.println();
+
+    const uint8_t startIdx = m_modelConfig.numberServos + m_modelConfig.numberMotors;
+    writeToOutputs(startIdx, {passThroughData[0], passThroughData[1]}, "Pass Through");//TODO !!!    
+  }
+
 private:
   //Constants
   static constexpr uint64_t DEBUG_UPDATE_DELAY = 100U;
@@ -168,6 +204,8 @@ private:
   int32_t m_minMotorTimerTicks;
   int32_t m_maxMotorTimerTicks;
   uint32_t m_rateMinThrottleTicks;
+  int32_t m_minPassThroughTimerTicks;
+  int32_t m_maxPassThroughTimerTicks;
 
   //Objects
   LedcServo outputs[LedcServo::MAX_LEDC_CHANNELS];
@@ -175,6 +213,8 @@ private:
   const LedcServo& servoAt(uint8_t i) const { return outputs[i]; }
   LedcServo& motorAt(uint8_t i) { return outputs[m_modelConfig.numberServos + i]; }
   const LedcServo& motorAt(uint8_t i) const { return outputs[m_modelConfig.numberServos + i]; }
+  LedcServo& passThroughAt(uint8_t i) { return outputs[m_modelConfig.numberServos + m_modelConfig.numberMotors + i]; }
+  const LedcServo& passThroughAt(uint8_t i) const { return outputs[m_modelConfig.numberServos + m_modelConfig.numberMotors + i]; }
 
   inline static constexpr ModelConfig m_modelConfig = []() 
   {
@@ -185,10 +225,14 @@ private:
         cfg.outputPins[i] = Config::SERVO_PINS[i];
     for (uint8_t i = 0U; i < InternalConfig::NUMBER_MOTORS; i++)
         cfg.outputPins[InternalConfig::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
+    for (uint8_t i = 0U; i < InternalConfig::NUMBER_PASS_THROUGH; i++)
+        cfg.outputPins[InternalConfig::NUMBER_SERVOS + InternalConfig::NUMBER_MOTORS+ i] = Config::PASS_THROUGH_PINS[i][0];
     cfg.numberServos = InternalConfig::NUMBER_SERVOS;
     cfg.numberMotors = InternalConfig::NUMBER_MOTORS;
+    cfg.numberPassThrough = InternalConfig::NUMBER_PASS_THROUGH;
     cfg.servoRefresh = Config::SERVO_REFRESH_RATE;
     cfg.motorRefresh = Config::MOTOR_REFRESH_RATE;
+    cfg.passThroughRefresh = Config::PASS_THROUGH_REFRESH_RATE;
     return cfg;
   }();
 
@@ -275,6 +319,15 @@ protected:
   uint32_t mapNormalisedMotorToTimerTicks(const int32_t channelValue)
   {
     return static_cast<uint32_t>(map32(channelValue, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, m_minMotorTimerTicks, m_maxMotorTimerTicks));
+  }
+
+  /**
+    * @brief  Converts calculated pass through servo demands to correct timer tick values.
+    * @param  
+    */
+  uint32_t mapNormalisedPassThroughToTimerTicks(const int32_t channelValue)
+  {
+    return static_cast<uint32_t>(map32(channelValue, RxBase::MIN_NORMALISED, RxBase::MAX_NORMALISED, m_minPassThroughTimerTicks, m_maxPassThroughTimerTicks));
   }
 
   /**

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -22,6 +22,7 @@
 */
 #pragma once
 
+#include <span>
 #include "LedcServo.hpp"
 #include "RxBase.hpp"
 #include "Utilities.hpp"
@@ -166,7 +167,10 @@ public:
     */
   int32_t getTrimMultiplier() const {return servoAt(0).getTrimMultiplier();}
 
-  /**/
+  /**
+  * @brief  Allows Tx channels to be passed straight through to PWM outputs. Ideal for undercarriage or lights etc.
+  * @param  rxPacket - The RC raw rc demands.
+  */
   void handlePassThroughChannels(RxBase::RxPacket const * const rxPacket)
   {
     if constexpr(InternalConfig::NUMBER_PASS_THROUGH > 0U)
@@ -181,7 +185,7 @@ public:
       }
 
       const uint8_t startIdx = m_modelConfig.numberServos + m_modelConfig.numberMotors;
-      writeToOutputs(startIdx, {passThroughData[0], passThroughData[1]}, "Pass Through");//TODO !!!  
+      writeToOutputs(startIdx, std::span<const uint32_t>(passThroughData, InternalConfig::NUMBER_PASS_THROUGH), "Pass Through"); 
     }  
   }
 
@@ -254,7 +258,7 @@ protected:
    * @param  values     The list of timer ticks to apply.
    * @param  label      String label for debug output ("Motor" or "Servo").
    */
-  void writeToOutputs(const uint8_t startIndex, const std::initializer_list<uint32_t> values, const char* label)
+  void writeToOutputs(const uint8_t startIndex, std::span<const uint32_t> values, const char* label)
   {
       uint8_t i = 0U;
       for (uint32_t v : values)
@@ -283,7 +287,7 @@ protected:
    */
   void writeMotors(std::initializer_list<uint32_t> values)
   {
-      writeToOutputs(m_modelConfig.numberServos, values, "Motor");
+      writeToOutputs(m_modelConfig.numberServos, std::span<const uint32_t>(values.begin(), values.size()), "Motor");
   }
 
   /**
@@ -291,7 +295,7 @@ protected:
    */
   void writeServos(std::initializer_list<uint32_t> values)
   {
-      writeToOutputs(0U, values, "Servo");
+      writeToOutputs(0U, std::span<const uint32_t>(values.begin(), values.size()), "Servo");
   }
 
   /**

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -169,29 +169,20 @@ public:
   /**/
   void handlePassThroughChannels(RxBase::RxPacket const * const rxPacket)
   {
-    uint32_t passThroughData[InternalConfig::NUMBER_PASS_THROUGH];
-
-    //for (uint8_t i : passThroughData)
-    for (uint8_t i=0; i < InternalConfig::NUMBER_PASS_THROUGH; i++)
+    if constexpr(InternalConfig::NUMBER_PASS_THROUGH > 0U)
     {
-      const int32_t rxChannel = Config::PASS_THROUGH_PINS[i][1];
-      const int32_t rxChannelData = rxPacket->ch[rxChannel];      
-      passThroughData[i] = static_cast<uint32_t>(mapNormalisedPassThroughToTimerTicks(rxChannelData));
-/*
-      Serial.print(i);
-      Serial.print(",");
-      Serial.print(Config::PASS_THROUGH_PINS[i][0]);
-      Serial.print(",");
-      Serial.print(Config::PASS_THROUGH_PINS[i][1]);
-      Serial.print(",");
-      Serial.print(rxChannelData);
-      Serial.print(",");
-      */
-    }
-//Serial.println();
+      uint32_t passThroughData[InternalConfig::NUMBER_PASS_THROUGH];
 
-    const uint8_t startIdx = m_modelConfig.numberServos + m_modelConfig.numberMotors;
-    writeToOutputs(startIdx, {passThroughData[0], passThroughData[1]}, "Pass Through");//TODO !!!    
+      for (uint8_t i=0U; i < InternalConfig::NUMBER_PASS_THROUGH; i++)
+      {
+        const int32_t rxChannel = Config::PASS_THROUGH_PINS[i][1];
+        const int32_t rxChannelData = rxPacket->ch[rxChannel];      
+        passThroughData[i] = static_cast<uint32_t>(mapNormalisedPassThroughToTimerTicks(rxChannelData));
+      }
+
+      const uint8_t startIdx = m_modelConfig.numberServos + m_modelConfig.numberMotors;
+      writeToOutputs(startIdx, {passThroughData[0], passThroughData[1]}, "Pass Through");//TODO !!!  
+    }  
   }
 
 private:

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -179,7 +179,7 @@ public:
 
       for (uint8_t i=0U; i < InternalConfig::NUMBER_PASS_THROUGH; i++)
       {
-        const int32_t rxChannel = Config::PASS_THROUGH_PINS[i][1];
+        const int32_t rxChannel = static_cast<uint32_t>(Config::PASS_THROUGH_PINS[i].channel);
         const int32_t rxChannelData = rxPacket->ch[rxChannel];      
         passThroughData[i] = static_cast<uint32_t>(mapNormalisedPassThroughToTimerTicks(rxChannelData));
       }
@@ -221,7 +221,7 @@ private:
     for (uint8_t i = 0U; i < InternalConfig::NUMBER_MOTORS; i++)
         cfg.outputPins[InternalConfig::NUMBER_SERVOS + i] = Config::MOTOR_PINS[i];
     for (uint8_t i = 0U; i < InternalConfig::NUMBER_PASS_THROUGH; i++)
-        cfg.outputPins[InternalConfig::NUMBER_SERVOS + InternalConfig::NUMBER_MOTORS+ i] = Config::PASS_THROUGH_PINS[i][0];
+        cfg.outputPins[InternalConfig::NUMBER_SERVOS + InternalConfig::NUMBER_MOTORS+ i] = Config::PASS_THROUGH_PINS[i].outputPin;
     cfg.numberServos = InternalConfig::NUMBER_SERVOS;
     cfg.numberMotors = InternalConfig::NUMBER_MOTORS;
     cfg.numberPassThrough = InternalConfig::NUMBER_PASS_THROUGH;

--- a/PlainFlightController/ModelTypes.hpp
+++ b/PlainFlightController/ModelTypes.hpp
@@ -169,7 +169,7 @@ public:
 
   /**
   * @brief  Allows Tx channels to be passed straight through to PWM outputs. Ideal for undercarriage or lights etc.
-  * @param  rxPacket - The RC raw rc demands.
+  * @param  rxPacket - The raw RC demands.
   */
   void handlePassThroughChannels(RxBase::RxPacket const * const rxPacket)
   {

--- a/PlainFlightController/RxBase.hpp
+++ b/PlainFlightController/RxBase.hpp
@@ -42,27 +42,6 @@ class RxBase
       static constexpr int32_t LOW_THROTTLE_NORM   = -922;  // Changed to be 5% of range - post test fix
 
       /**
-      * @enum ChannelName
-      * @brief Standard channel names for RC control mapping.
-      * Other channels must be referred to by number
-      */
-      enum class ChannelName : uint32_t
-      {
-         THROTTLE = 0U,
-         ROLL,
-         PITCH,
-         YAW,
-         ARM,
-         MODE,
-         AUX1,
-         AUX2,
-         AUX3,
-         AUX4,
-         AUX5,
-         AUX6
-      };
-
-      /**
       * @enum SwitchPosition
       * @brief Enumeration for switch states.
       */
@@ -116,14 +95,14 @@ class RxBase
       * @return Channel index (0-based).
       */
       virtual uint32_t
-      getChannelIndex(ChannelName name) const = 0;
+      getChannelIndex(RcChannelName name) const = 0;
 
       /**
       * @brief Helper function to reduce verbosity.
       * @param name The channel name enum (from RxBase).
       * @return Channel index (0-based).
       */
-      int32_t getChannel(const RxPacket& data, ChannelName name) const
+      int32_t getChannel(const RxPacket& data, RcChannelName name) const
       {
          return data.ch[getChannelIndex(name)];
       }

--- a/PlainFlightController/RxBase.hpp
+++ b/PlainFlightController/RxBase.hpp
@@ -56,7 +56,10 @@ class RxBase
          MODE,
          AUX1,
          AUX2,
-         AUX3
+         AUX3,
+         AUX4,
+         AUX5,
+         AUX6
       };
 
       /**

--- a/PlainFlightController/SBus.hpp
+++ b/PlainFlightController/SBus.hpp
@@ -46,91 +46,100 @@
 class SBus : public RxBase
 {
 public:
-  static constexpr uint32_t MIN_SBUS_US           = 172U;
-  static constexpr uint32_t MID_SBUS_US           = 991U;
-  static constexpr uint32_t MAX_SBUS_US           = 1810U;
-  static constexpr bool USE_ALL_18_CHANNELS       = false;
+   static constexpr uint32_t MIN_SBUS_US           = 172U;
+   static constexpr uint32_t MID_SBUS_US           = 991U;
+   static constexpr uint32_t MAX_SBUS_US           = 1810U;
+   static constexpr bool USE_ALL_18_CHANNELS       = false;
 
-  /**
-     * @brief Channel mapping for SBus protocol.
-     * Maps standard channel names to physical SBus channel positions.
-     */
-  static constexpr uint32_t CHANNEL_MAP[9] =
-      {
-          0U,  // THROTTLE
-          1U,  // ROLL
-          2U,  // PITCH
-          3U,  // YAW
-          4U,  // ARM
-          5U,  // MODE
-          6U,  // AUX1
-          7U,  // AUX2
-          8U  // AUX3
-      };
+   /**
+   * @brief Channel mapping for SBus protocol.
+   * Maps standard channel names to physical SBus channel positions.
+   */
+   static constexpr uint32_t CHANNEL_MAP[18] =
+   {
+      0U,  // THROTTLE
+      1U,  // ROLL
+      2U,  // PITCH
+      3U,  // YAW
+      4U,  // ARM
+      5U,  // MODE
+      6U,  // AUX1
+      7U,  // AUX2
+      8U,  // AUX3
+      9U,  // AUX4
+      10U, // AUX5
+      11U, // AUX6
+      12U, // AUX7
+      13U, // AUX8
+      14U, // AUX9
+      15U, // AUX10
+      16U, // AUX11
+      17U, // AUX12
+   };
 
-  /**
-     * @brief Constructor for SBus receiver.
-     * @param uart Pointer to hardware serial port.
-     * @param rxPin RX pin number.
-     * @param txPin TX pin number.
-     */
-  SBus(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin);
+   /**
+   * @brief Constructor for SBus receiver.
+   * @param uart Pointer to hardware serial port.
+   * @param rxPin RX pin number.
+   * @param txPin TX pin number.
+   */
+   SBus(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin);
 
-  /**
-     * @brief Get new data from SBus receiver.
-     * @return true when new data is available, false otherwise.
-     */
-  bool getDemands() override;
+   /**
+   * @brief Get new data from SBus receiver.
+   * @return true when new data is available, false otherwise.
+   */
+   bool getDemands() override;
 
-  /**
-     * @brief Print receiver data to console for debugging.
-     */
-  void printData();
+   /**
+   * @brief Print receiver data to console for debugging.
+   */
+   void printData();
 
-  /**
-     * @brief Get receiver data packet.
-     * @return RxPacket containing failsafe status, communication status, and normalised channel data.
-     */
-  const RxPacket getData() const override;
+   /**
+   * @brief Get receiver data packet.
+   * @return RxPacket containing failsafe status, communication status, and normalised channel data.
+   */
+   const RxPacket getData() const override;
 
-  /**
-     * @brief Check if communications have been lost.
-     * @return true if communications lost, false otherwise.
-     */
-  const bool hasLostCommunications() const override;
+   /**
+   * @brief Check if communications have been lost.
+   * @return true if communications lost, false otherwise.
+   */
+   const bool hasLostCommunications() const override;
 
-  /**
-     * @brief Get channel index from channel name.
-     * @param name The channel name enum.
-     * @return Channel index (0-based).
-     */
-  uint32_t getChannelIndex(RcChannelName name) const
-  {
-    return CHANNEL_MAP[static_cast<uint32_t>(name)];
-  }
+   /**
+   * @brief Get channel index from channel name.
+   * @param name The channel name enum.
+   * @return Channel index (0-based).
+   */
+   uint32_t getChannelIndex(RcChannelName name) const
+   {
+      return CHANNEL_MAP[static_cast<uint32_t>(name)];
+   }
 
 private:
-  static constexpr uint32_t SBUS_BAUD       = 100000U;
-  static constexpr uint32_t PAYLOAD_LEN     = 23U;
-  static constexpr uint32_t HEADER_LEN      = 1U;
-  static constexpr uint32_t FOOTER_LEN      = 1U;
-  static constexpr uint32_t NUM_SBUS_CH     = 16U;
-  static constexpr uint32_t HEADER          = 0x0FU;
-  static constexpr uint32_t FOOTER          = 0x00U;
-  static constexpr uint32_t FOOTER2         = 0x04U;
-  static constexpr uint32_t CH17_MASK       = 0x01U;
-  static constexpr uint32_t CH18_MASK       = 0x02U;
-  static constexpr uint32_t LOST_FRAME_MASK = 0x04U;
-  static constexpr uint32_t FAILSAFE_MASK   = 0x08U;
-  static constexpr uint32_t BUFFER_SIZE     = 25U;
-  static constexpr uint64_t COMMS_TIME_OUT_PERIOD = 100U;
-  static constexpr uint32_t MAX_BYTES_PER_LOOP    = 6U;
+   static constexpr uint32_t SBUS_BAUD       = 100000U;
+   static constexpr uint32_t PAYLOAD_LEN     = 23U;
+   static constexpr uint32_t HEADER_LEN      = 1U;
+   static constexpr uint32_t FOOTER_LEN      = 1U;
+   static constexpr uint32_t NUM_SBUS_CH     = 16U;
+   static constexpr uint32_t HEADER          = 0x0FU;
+   static constexpr uint32_t FOOTER          = 0x00U;
+   static constexpr uint32_t FOOTER2         = 0x04U;
+   static constexpr uint32_t CH17_MASK       = 0x01U;
+   static constexpr uint32_t CH18_MASK       = 0x02U;
+   static constexpr uint32_t LOST_FRAME_MASK = 0x04U;
+   static constexpr uint32_t FAILSAFE_MASK   = 0x08U;
+   static constexpr uint32_t BUFFER_SIZE     = 25U;
+   static constexpr uint64_t COMMS_TIME_OUT_PERIOD = 100U;
+   static constexpr uint32_t MAX_BYTES_PER_LOOP    = 6U;
 
-  HardwareSerial *m_uart;
-  uint32_t m_count = 0U;
-  uint32_t m_prevByte = FOOTER;
-  uint32_t m_buff[BUFFER_SIZE] = {};
-  bool m_lostFrame = false;
-  //Objects
-  CTimer lossOfCommsTimer = CTimer(0);
+   HardwareSerial *m_uart;
+   uint32_t m_count = 0U;
+   uint32_t m_prevByte = FOOTER;
+   uint32_t m_buff[BUFFER_SIZE] = {};
+   bool m_lostFrame = false;
+   //Objects
+   CTimer lossOfCommsTimer = CTimer(0);
 };

--- a/PlainFlightController/SBus.hpp
+++ b/PlainFlightController/SBus.hpp
@@ -104,7 +104,7 @@ public:
      * @param name The channel name enum.
      * @return Channel index (0-based).
      */
-  uint32_t getChannelIndex(ChannelName name) const
+  uint32_t getChannelIndex(RcChannelName name) const
   {
     return CHANNEL_MAP[static_cast<uint32_t>(name)];
   }


### PR DESCRIPTION
### **Summary**
This implementation of Tx channel pass through uses the Config to define the output pin(s) and rc channel(s) that are to be passed through. The name PASS_THROUGH_PINS has been chosen to be in keeping with SERVO_PINS and MOTOR_PINS but is arguably more than just io pins.

Pass through channels are treated differently than servo and motors and have their own refresh rate as retracts/lights may not be able to cope with digital servo rates. Refresh rate for pass through channels has been defaulted to 50Hz.

Method handlePassThroughChannels() has been added to ModelTypes.hpp base class and is called from every flight state within FightControl.cpp. As part of this implementation writeToOutputs() could not maintain the std::initializer_list and has been changed to std::span to allow the passing of an array. This has slightly affected WriteServos() and writeMotors() that required a small update.

Due to a circular reference RxBase::ChanelName moved to CommonTypes.hpp and has been renamed to more a descriptive RcChannelName.

CRSF CHANNEL_MAP[] has been extended to use 16 channels, When using SBus if the mode type configuration already uses 8 or 9 RC channels then it will require setting USE_ALL_18_CHANNELS = true. Comment has been added to Config.hpp to highlight this to a user.

### **Testing**
1, The committed code has been tested with PLANE_FULL_HOUSE with pass through set AUX4 and AUX5 channels on OUTPUT_7 & OUTPUT_8 respectively.
2, The committed code has also been tested with PLANE_RUDDER_ELEVATOR with pass through set AUX2, AUX3, AUX4, AUX5 3, channels on OUTPUT_5, OUTPUT_6, OUTPUT_7 & OUTPUT_8 respectively.
3, The committed code has been tested with DEBUG_OUTPUT which works for servos, motors and pass through outputs.