### PR TITLE
Channel naming and allocation

### DIFF
--- a/PlainFlightController/ChannelValidation.hpp
+++ b/PlainFlightController/ChannelValidation.hpp
@@ -1,7 +1,7 @@
 /* 
 * Original file by D. Gamble (Github: Cyberslug)
 *
-* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
 *
 * This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
 * 
@@ -25,6 +25,7 @@
 
 #include "CommonTypes.hpp"
 #include "Config.hpp"
+#include "RxBase.hpp"
 
 /**
  * @namespace ChannelValidation
@@ -48,7 +49,9 @@ namespace ChannelValidation
   */
   static constexpr bool channelIsDuplicated()
   {
-    uint32_t used[8] = {};
+    // MAX_RX_CHANNELS is the absolute maximum that can be assigned under any circumstances
+    // Practical maximum is actually less than  5 candidates + 8 possible PWM channels
+    uint32_t used[RxBase::MAX_RX_CHANNELS] = {};
     uint32_t count = 0U;
 
     const RcChannelName candidates[] =
@@ -60,6 +63,7 @@ namespace ChannelValidation
       Config::PROP_HANG_CHANNEL,
     };
 
+    // Record those channel functions that are not NONE
     for (const RcChannelName candidate : candidates)
     {
       if (candidate != RcChannelName::NONE)
@@ -67,14 +71,18 @@ namespace ChannelValidation
         used[count++] = toIndex(candidate);
       }
     }
-    for (uint32_t i = 0U; i < PASS_THROUGH_COUNT; ++i)
+
+    // Record those pass-through pins that are assigned a channel
+    for (uint32_t i = 0U; i < PASS_THROUGH_COUNT; i++)
     {
       used[count++] = toIndex(Config::PASS_THROUGH_PINS[i].channel);
     }
 
-    for (uint32_t i = 0U; i < count; ++i)
+    // Count is the sum of channels assigned
+    // Test no element in used[] is equal to any other element
+    for (uint32_t i = 0U; i < count; i++)
     {
-      for (uint32_t j = (i + 1U); j < count; ++j)
+      for (uint32_t j = (i + 1U); j < count; j++)
       {
         if (used[i] == used[j])
         {

--- a/PlainFlightController/ChannelValidation.hpp
+++ b/PlainFlightController/ChannelValidation.hpp
@@ -1,0 +1,87 @@
+/* 
+* Original file by D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2025 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+* @file   ChannelValidation.hpp
+* @brief  Compile-time checks confirming no two RC functions share a channel.
+*/
+#pragma once
+
+#include "CommonTypes.hpp"
+#include "Config.hpp"
+
+/**
+ * @namespace ChannelValidation
+ */
+namespace ChannelValidation
+{
+  static constexpr uint32_t toIndex(RcChannelName name)
+  {
+    return static_cast<uint32_t>(name);
+  }
+
+  // Derived directly from Config.hpp, matching the same technique used for
+  // InternalConfig::NUMBER_PASS_THROUGH,  kept local to this file so it does
+  // not need to include InternalConfig.hpp.
+  static constexpr uint32_t PASS_THROUGH_COUNT =
+    static_cast<uint32_t>(sizeof(Config::PASS_THROUGH_PINS) / sizeof(Config::PASS_THROUGH_PINS[0]));
+
+  /**
+  * @brief  Confirms no two assigned RC functions share the same channel.
+  * @return true if any two assigned channels collide, false otherwise.
+  */
+  static constexpr bool channelIsDuplicated()
+  {
+    uint32_t used[8] = {};
+    uint32_t count = 0U;
+
+    const RcChannelName candidates[] =
+    {
+      Config::ARM_CHANNEL,
+      Config::MODE_CHANNEL,
+      Config::FLAPS_CHANNEL,
+      Config::HEADING_HOLD_CHANNEL,
+      Config::PROP_HANG_CHANNEL,
+    };
+
+    for (const RcChannelName candidate : candidates)
+    {
+      if (candidate != RcChannelName::NONE)
+      {
+        used[count++] = toIndex(candidate);
+      }
+    }
+    for (uint32_t i = 0U; i < PASS_THROUGH_COUNT; ++i)
+    {
+      used[count++] = toIndex(Config::PASS_THROUGH_PINS[i].channel);
+    }
+
+    for (uint32_t i = 0U; i < count; ++i)
+    {
+      for (uint32_t j = (i + 1U); j < count; ++j)
+      {
+        if (used[i] == used[j])
+        {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -90,8 +90,6 @@ enum class RcChannelName : uint32_t
   ROLL,
   PITCH,
   YAW,
-  ARM,
-  MODE,
   AUX1,
   AUX2,
   AUX3,
@@ -103,7 +101,11 @@ enum class RcChannelName : uint32_t
   AUX9,
   AUX10,
   AUX11,
-  AUX12
+  AUX12,
+  AUX13,
+  AUX14,
+  COUNT,              // Sentinel: total number of channels.  Never use to index channels
+  NONE = 0xFFFFFFFFU  // Sentinel: no channel assigned.  Never use to index channels
 };
 
 /**

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -193,11 +193,13 @@ class Config
   //==========================================================================
   // SECTION 7: FEATURE FLAGS
   // Enable or disable optional features for this aircraft build.
+  // Note: The USE_FLAPS, USE_HEADING_HOLD and USE_PROP_HANG_MODE require
+  // the allocation of channels to select these.  See 5. RC FUNCTION ASSIGNMENT
   //==========================================================================
 
-  static constexpr bool USE_FLAPS                            = false;  // Flaps on Tx channel 7; use 2, 3 position switch or rotary pot.
+  static constexpr bool USE_FLAPS                            = false;  // Assign channel required; use 2, 3 position switch or rotary pot.
   static constexpr bool USE_DIFFERENTIAL_THRUST              = false;  // Fixed-wing twin engine differential thrust.
-  static constexpr bool USE_HEADING_HOLD                     = false;  // Gyro-based heading hold on Tx channel 8.
+  static constexpr bool USE_HEADING_HOLD                     = false;  // Assign channel required; Gyro-based heading hold.
   static constexpr bool USE_LOW_VOLTS_CUT_OFF                = false;  // Limit throttle upon low battery voltage.
   static constexpr bool USE_EXTERNAL_LED                     = false;  // Enable external LED output.
   static constexpr bool USE_ACRO_TRAINER                     = false;  // Level mode when pitch & roll sticks centred, rate mode otherwise.
@@ -205,7 +207,7 @@ class Config
 
   // Prop hang / tail-sitter mode (experimental).
   // You need to understand flight controllers well to configure this.
-  static constexpr bool USE_PROP_HANG_MODE                   = false;  // Self-levelling pitch/yaw for prop hanging via Tx channel 9.
+  static constexpr bool USE_PROP_HANG_MODE                   = false;  // Assign channel required; Self-levelling pitch/yaw for prop hanging.
   static constexpr bool PROP_HANG_TAIL_SITTER_MODE           = false;  // Roll stick commands yaw, yaw stick commands roll when prop hanging.
 
 

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -22,15 +22,16 @@
 *
 * SECTION GUIDE
 * -------------
-* 1. BOARD & HARDWARE       - Define the physical ESP32S3 board.
-* 2. RECEIVER               - Define the external communication protocols.
-* 3. MODEL TYPE             - Define the aircraft type.
-* 4. OUTPUT ASSIGNMENT      - Define the output connection to servos/motors.
-* 5. OUTPUT CONFIGURATION   - Change during physical installation (reversal, travel).
-* 6. FEATURE FLAGS          - Enable/disable optional features for this build.
-* 7. OPTIONAL GPS           - Configure a CASIC or UBX GPS to be used for telemetry.
-* 8. FLIGHT CHARACTERISTICS - Adjust during maiden flight and tuning.
-* 9. MULTICOPTER SETTINGS   - Motor idle and minimum throttle, multicopter builds only.
+* 1.  BOARD & HARDWARE       - Define the physical ESP32S3 board.
+* 2.  RECEIVER               - Define the external communication protocols.
+* 3.  MODEL TYPE             - Define the aircraft type.
+* 4.  OUTPUT ASSIGNMENT      - Define the output connection to servos/motors.
+* 5.  RC FUNCTION ASSIGNMENT - Assign control function to channel.
+* 6.  OUTPUT CONFIGURATION   - Change during physical installation (reversal, travel).
+* 7.  FEATURE FLAGS          - Enable/disable optional features for this build.
+* 8.  OPTIONAL GPS           - Configure a CASIC or UBX GPS to be used for telemetry.
+* 9.  FLIGHT CHARACTERISTICS - Adjust during maiden flight and tuning.
+* 10. MULTICOPTER SETTINGS   - Motor idle and minimum throttle, multicopter builds only.
 *
 */
 
@@ -138,12 +139,30 @@ class Config
   static constexpr PassThroughStruct PASS_THROUGH_PINS[] =
   {      
     //Output Pin to use,  Rx channel to assign
-    {ESP32S3.OUTPUT_7,    RcChannelName::AUX3},  // E.g. Gear
-    {ESP32S3.OUTPUT_8,    RcChannelName::AUX4}   // E.g. Lights
+    {ESP32S3.OUTPUT_7,    RcChannelName::AUX5},  // E.g. Gear
+    {ESP32S3.OUTPUT_8,    RcChannelName::AUX6}   // E.g. Lights
   };
 
   //==========================================================================
-  // SECTION 5: OUTPUT CONFIGURATION
+  // SECTION 5: RC FUNCTION ASSIGNMENT
+  // Assigns each switch/control function to a receiver channel position.
+  // THROTTLE, ROLL, PITCH and YAW are fixed and are not assigned here.
+  // ARM_CHANNEL and MODE_CHANNEL are mandatory and must be set to a distinct
+  // AUXn value.
+  // FLAPS_CHANNEL, HEADING_HOLD_CHANNEL and PROP_HANG_CHANNEL must be set to
+  // RcChannelName::NONE while their corresponding feature flag (in SECTION 7,
+  // FEATURE FLAGS) is false. When the feature is enabled, set the matching
+  // constant below to a distinct, unused AUXn value.
+  //==========================================================================
+
+  static constexpr RcChannelName ARM_CHANNEL          = RcChannelName::AUX1;
+  static constexpr RcChannelName MODE_CHANNEL         = RcChannelName::AUX2;
+  static constexpr RcChannelName FLAPS_CHANNEL        = RcChannelName::NONE;
+  static constexpr RcChannelName HEADING_HOLD_CHANNEL = RcChannelName::NONE;
+  static constexpr RcChannelName PROP_HANG_CHANNEL    = RcChannelName::NONE;
+
+  //==========================================================================
+  // SECTION 6: OUTPUT CONFIGURATION
   // Set during physical installation to match your wiring and servo orientation.
   //==========================================================================
 
@@ -172,7 +191,7 @@ class Config
 
 
   //==========================================================================
-  // SECTION 6: FEATURE FLAGS
+  // SECTION 7: FEATURE FLAGS
   // Enable or disable optional features for this aircraft build.
   //==========================================================================
 
@@ -191,7 +210,7 @@ class Config
 
 
   //==========================================================================
-  // SECTION 7:  OPTIONAL GPS
+  // SECTION 8:  OPTIONAL GPS
   // Select the protocols matching your GPS hardware.
   // GNSS Type (CommonTypes.hpp):        NONE, CASIC, UBX
   // UBX Models (GnssTypes.hpp):         UBX_M6_MINUS, UBX_M7_M8, UBX_M9_PLUS
@@ -202,7 +221,7 @@ class Config
 
 
   //==========================================================================
-  // SECTION 8: FLIGHT CHARACTERISTICS
+  // SECTION 9: FLIGHT CHARACTERISTICS
   // Adjust these during maiden flight and subsequent tuning.
   // Available options (defined in CommonTypes.hpp) IS_250_DEG_SECOND, IS_500_DEG_SECOND
   //==========================================================================
@@ -240,7 +259,7 @@ class Config
 
   
   //==========================================================================
-  // SECTION 9: MULTICOPTER MOTOR SETTINGS
+  // SECTION 10: MULTICOPTER MOTOR SETTINGS
   // Relevant for multicopter builds only.
   //==========================================================================
 

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -68,25 +68,31 @@ class Crsf : public RxBase, public ITelemetry
     * CRSF transmits channels in Aileron(0), Elevator(1), Throttle(2), Rudder(3)
     * order; this table re-orders them to the flight controller's convention.
     */
-    static constexpr uint32_t CHANNEL_MAP[16] =
+    static constexpr uint32_t CHANNEL_MAP[18] =
     {
       2U,   // THROTTLE → CRSF channel 2
       0U,   // ROLL     → CRSF channel 0 (Aileron)
       1U,   // PITCH    → CRSF channel 1 (Elevator)
       3U,   // YAW      → CRSF channel 3 (Rudder)
-      4U,   // ARM      → CRSF channel 4
-      5U,   // MODE     → CRSF channel 5
-      6U,   // AUX1     → CRSF channel 6
-      7U,   // AUX2     → CRSF channel 7
-      8U,   // AUX3     → CRSF channel 8
-      9U,   // AUX4     → CRSF channel 9
-      10U,  // AUX5     → CRSF channel 10
-      11U,  // AUX6     → CRSF channel 11
-      12U,  // AUX7     → CRSF channel 12
-      13U,  // AUX8     → CRSF channel 13
-      14U,  // AUX8     → CRSF channel 14
-      15U,  // AUX10    → CRSF channel 15
+      4U,   // AUX1     → CRSF channel 4
+      5U,   // AUX2     → CRSF channel 5
+      6U,   // AUX3     → CRSF channel 6
+      7U,   // AUX4     → CRSF channel 7
+      8U,   // AUX5     → CRSF channel 8
+      9U,   // AUX6     → CRSF channel 9
+      10U,  // AUX7     → CRSF channel 10
+      11U,  // AUX8     → CRSF channel 11
+      12U,  // AUX9     → CRSF channel 12
+      13U,  // AUX10    → CRSF channel 13
+      14U,  // AUX11    → CRSF channel 14
+      15U,  // AUX12    → CRSF channel 15
+      16U,  // AUX13    → not present in the CRSF channel frame; always reads as 0
+      17U,  // AUX14    → not present in the CRSF channel frame; always reads as 0
     };
+
+    static_assert((sizeof(CHANNEL_MAP) / sizeof(CHANNEL_MAP[0])) ==
+      static_cast<uint32_t>(RcChannelName::COUNT),
+      "Configuration Error: CHANNEL_MAP size must match RcChannelName::COUNT.");
 
     /**
     * @struct CrsfLinkStats

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -116,7 +116,11 @@ DemandProcessor::decodeStickPositions(FlightState const* const flightState, File
   }
 
   m_demand.throttle = radioCtrl->getChannel(m_normalisedData, RcChannelName::THROTTLE);
-  m_demand.flaps = radioCtrl->getChannel(m_normalisedData, RcChannelName::AUX1);
+  
+  if constexpr (Config::USE_FLAPS)
+  {
+    m_demand.flaps = radioCtrl->getChannel(m_normalisedData, RcChannelName::AUX1);
+  }
 
   switch (*flightState)
   {

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -183,6 +183,9 @@ DemandProcessor::decodeOperatingMode(FlightState* const flightState, FlightState
   FlightState demandedFlightState = *flightState;
   m_demand.armed = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, Config::ARM_CHANNEL));
   m_throttleHigh = (RxBase::LOW_THROTTLE_NORM < radioCtrl->getChannel(m_normalisedData, RcChannelName::THROTTLE));
+  // Check headinHold and propHang each pass to ensure state is correctly reflected when disarmed
+  m_demand.headingHold = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, Config::HEADING_HOLD_CHANNEL));
+  m_demand.propHang = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, Config::PROP_HANG_CHANNEL));
 
   if (FlightState::CALIBRATE == demandedFlightState)
   {
@@ -283,8 +286,6 @@ DemandProcessor::getDemandedFlightModeFixedWing()
 {
   if constexpr(Config::USE_PROP_HANG_MODE)
   {
-    m_demand.propHang = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, Config::PROP_HANG_CHANNEL));
-
     if (m_demand.propHang)
     {
       return FlightState::PROP_HANG;
@@ -354,7 +355,6 @@ DemandProcessor::getDemandedFlightModeMultiCopter()
 bool
 DemandProcessor::headingHoldActive()
 {
-  m_demand.headingHold = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, Config::HEADING_HOLD_CHANNEL));
   return m_demand.headingHold;
 }
 
@@ -389,30 +389,20 @@ DemandProcessor::printData()
 {
   if constexpr (InternalConfig::DEBUG_RC_DATA)
   {
-    Serial.print("pitch: ");
-    Serial.print(m_demand.pitch);
-    Serial.print("\t roll: ");
-    Serial.print(m_demand.roll);
-    Serial.print("\t yaw: ");
-    Serial.print(m_demand.yaw);
-    Serial.print("\t throttle: ");
-    Serial.print(m_demand.throttle);
-    Serial.print("\t flaps: ");
-    Serial.print(m_demand.flaps);
-    Serial.print("\t armed: ");
-    Serial.print(m_demand.armed);
-    Serial.print("\t mode: ");
-    Serial.print(static_cast<uint32_t>(getDemandedFlightModeFixedWing()));
+    Serial.printf("pitch: %5d roll: %5d yaw: %5d throttle: %5d flaps: %5d %8s mode: %1d ", 
+      m_demand.pitch, m_demand.roll, m_demand.yaw, m_demand.throttle, m_demand.flaps, 
+      m_demand.armed ? "ARMED": "DISARMED", static_cast<uint8_t>(getDemandedFlightModeFixedWing()));
     if constexpr(Config::USE_HEADING_HOLD)
     {
-      Serial.print("\t Heading: ");
-      Serial.print(m_demand.headingHold);
+      Serial.printf(" HeadingHold: %3s", m_demand.headingHold ? "On" : "Off");
     }
     if constexpr(Config::USE_PROP_HANG_MODE)
     {
-      Serial.print("\t PropHang: ");
-      Serial.println(m_demand.propHang);
-    }
+      Serial.printf(" PropHang: %3s\n", m_demand.propHang ? "On" : "Off");
+    } 
+    else 
+    {
     Serial.println();
+    }
   }
 }

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -119,7 +119,7 @@ DemandProcessor::decodeStickPositions(FlightState const* const flightState, File
   
   if constexpr (Config::USE_FLAPS)
   {
-    m_demand.flaps = radioCtrl->getChannel(m_normalisedData, RcChannelName::AUX1);
+    m_demand.flaps = radioCtrl->getChannel(m_normalisedData, Config::FLAPS_CHANNEL);
   }
 
   switch (*flightState)
@@ -181,7 +181,7 @@ void
 DemandProcessor::decodeOperatingMode(FlightState* const flightState, FlightState* const lastFlightState)
 {
   FlightState demandedFlightState = *flightState;
-  m_demand.armed = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RcChannelName::ARM));
+  m_demand.armed = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, Config::ARM_CHANNEL));
   m_throttleHigh = (RxBase::LOW_THROTTLE_NORM < radioCtrl->getChannel(m_normalisedData, RcChannelName::THROTTLE));
 
   if (FlightState::CALIBRATE == demandedFlightState)
@@ -283,7 +283,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
 {
   if constexpr(Config::USE_PROP_HANG_MODE)
   {
-    m_demand.propHang = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RcChannelName::AUX3));
+    m_demand.propHang = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, Config::PROP_HANG_CHANNEL));
 
     if (m_demand.propHang)
     {
@@ -291,7 +291,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
     }
   }
 
-  const RxBase::SwitchPosition modeSwitchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, RcChannelName::MODE));
+  const RxBase::SwitchPosition modeSwitchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, Config::MODE_CHANNEL));
 
   switch (modeSwitchPosition)
   {
@@ -327,7 +327,7 @@ DemandProcessor::getDemandedFlightModeFixedWing()
 DemandProcessor::FlightState
 DemandProcessor::getDemandedFlightModeMultiCopter()
 {
-  RxBase::SwitchPosition switchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, RcChannelName::MODE));
+  RxBase::SwitchPosition switchPosition = RxBase::getSwitch3Position(radioCtrl->getChannel(m_normalisedData, Config::MODE_CHANNEL));
 
   switch (switchPosition)
   {
@@ -354,7 +354,7 @@ DemandProcessor::getDemandedFlightModeMultiCopter()
 bool
 DemandProcessor::headingHoldActive()
 {
-  m_demand.headingHold = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, RcChannelName::AUX2));
+  m_demand.headingHold = RxBase::isSwitchHigh(radioCtrl->getChannel(m_normalisedData, Config::HEADING_HOLD_CHANNEL));
   return m_demand.headingHold;
 }
 

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -105,9 +105,17 @@ namespace InternalConfig
   static_assert(!Config::USE_PROP_HANG_MODE || (Config::PROP_HANG_CHANNEL != RcChannelName::NONE),
     "Configuration Error: USE_PROP_HANG_MODE is enabled but PROP_HANG_CHANNEL is not assigned.");
 
+  // Check feature enabled when channel is assigned
+  static_assert(Config::USE_FLAPS || (Config::FLAPS_CHANNEL == RcChannelName::NONE),
+    "Configuration Error: FLAPS_CHANNEL is assigned but USE_FLAPS is not enabled.");
+  static_assert(Config::USE_HEADING_HOLD || (Config::HEADING_HOLD_CHANNEL == RcChannelName::NONE),
+    "Configuration Error: HEADING_HOLD_CHANNEL is assigned but USE_HEADING_HOLD is not enabled.");
+  static_assert(Config::USE_PROP_HANG_MODE || (Config::PROP_HANG_CHANNEL == RcChannelName::NONE),
+    "Configuration Error: PROP_HANG_CHANNEL is assigned but USE_PROP_HANG_MODE is not enabled.");
+
   // Duplicate channel assignment check 
   static_assert(!ChannelValidation::channelIsDuplicated(),
-    "Configuration Error: Two or more RC functions are assigned to the same channel.");
+    "Configuration Error: Two or more RC functions and/or PassThrough are assigned to the same channel.");
 
   //==========================================================================
   // DEBUG SETTINGS

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -25,6 +25,7 @@
 
 #include "Config.hpp"
 #include "CommonTypes.hpp"
+#include "ChannelValidation.hpp"
 
 /**
  * @namespace InternalConfig
@@ -89,6 +90,24 @@ namespace InternalConfig
 
   // Battery telemetry transmit periods (milliseconds)
   static constexpr uint32_t TELEMETRY_GNSS_PERIOD_MS      = 200U;  // 5Hz
+
+  // ARM and MODE assignment checks
+  static_assert(Config::ARM_CHANNEL != RcChannelName::NONE,
+    "Configuration Error: ARM_CHANNEL must be assigned to a channel.");
+  static_assert(Config::MODE_CHANNEL != RcChannelName::NONE,
+    "Configuration Error: MODE_CHANNEL must be assigned to a channel.");
+
+  // Check channel assigned when feature is enabled
+  static_assert(!Config::USE_FLAPS || (Config::FLAPS_CHANNEL != RcChannelName::NONE),
+    "Configuration Error: USE_FLAPS is enabled but FLAPS_CHANNEL is not assigned.");
+  static_assert(!Config::USE_HEADING_HOLD || (Config::HEADING_HOLD_CHANNEL != RcChannelName::NONE),
+    "Configuration Error: USE_HEADING_HOLD is enabled but HEADING_HOLD_CHANNEL is not assigned.");
+  static_assert(!Config::USE_PROP_HANG_MODE || (Config::PROP_HANG_CHANNEL != RcChannelName::NONE),
+    "Configuration Error: USE_PROP_HANG_MODE is enabled but PROP_HANG_CHANNEL is not assigned.");
+
+  // Duplicate channel assignment check 
+  static_assert(!ChannelValidation::channelIsDuplicated(),
+    "Configuration Error: Two or more RC functions are assigned to the same channel.");
 
   //==========================================================================
   // DEBUG SETTINGS

--- a/PlainFlightController/RxBase.hpp
+++ b/PlainFlightController/RxBase.hpp
@@ -35,7 +35,7 @@
 class RxBase
 {
    public:
-      static constexpr uint32_t MAX_RX_CHANNELS    = 16U;
+      static constexpr uint32_t MAX_RX_CHANNELS    = 18U;
       static constexpr int32_t MIN_NORMALISED      = -1024;
       static constexpr int32_t MID_NORMALISED      = 0;
       static constexpr int32_t MAX_NORMALISED      = 1024;

--- a/PlainFlightController/SBus.cpp
+++ b/PlainFlightController/SBus.cpp
@@ -112,8 +112,8 @@ SBus::getDemands()
             rawChannels[13] = (uint32_t)((m_buff[18] >> 7U) | (m_buff[19] << 1U) | ((m_buff[20] << 9U) & 0x07FFU));
             rawChannels[14] = (uint32_t)((m_buff[20] >> 2U) | ((m_buff[21] << 6U) & 0x07FFU));
             rawChannels[15] = (uint32_t)((m_buff[21] >> 5U) | ((m_buff[22] << 3U) & 0x07FFU));
-            rawChannels[17] = (m_buff[23] & CH17_MASK) ? MAX_SBUS_US : MIN_SBUS_US;  // No special boolean channels
-            rawChannels[18] = (m_buff[23] & CH18_MASK) ? MAX_SBUS_US : MIN_SBUS_US;  // No special boolean channels
+            rawChannels[16] = (m_buff[23] & CH17_MASK) ? MAX_SBUS_US : MIN_SBUS_US;  // No special boolean channels
+            rawChannels[17] = (m_buff[23] & CH18_MASK) ? MAX_SBUS_US : MIN_SBUS_US;  // No special boolean channels
           }  
         } 
 

--- a/PlainFlightController/SBus.hpp
+++ b/PlainFlightController/SBus.hpp
@@ -123,7 +123,7 @@ private:
    static constexpr uint32_t PAYLOAD_LEN     = 23U;
    static constexpr uint32_t HEADER_LEN      = 1U;
    static constexpr uint32_t FOOTER_LEN      = 1U;
-   static constexpr uint32_t NUM_SBUS_CH     = 16U;
+   static constexpr uint32_t NUM_SBUS_CH     = 18U;
    static constexpr uint32_t HEADER          = 0x0FU;
    static constexpr uint32_t FOOTER          = 0x00U;
    static constexpr uint32_t FOOTER2         = 0x04U;

--- a/PlainFlightController/SBus.hpp
+++ b/PlainFlightController/SBus.hpp
@@ -61,21 +61,25 @@ public:
       1U,  // ROLL
       2U,  // PITCH
       3U,  // YAW
-      4U,  // ARM
-      5U,  // MODE
-      6U,  // AUX1
-      7U,  // AUX2
-      8U,  // AUX3
-      9U,  // AUX4
-      10U, // AUX5
-      11U, // AUX6
-      12U, // AUX7
-      13U, // AUX8
-      14U, // AUX9
-      15U, // AUX10
-      16U, // AUX11
-      17U, // AUX12
+      4U,  // AUX1
+      5U,  // AUX2
+      6U,  // AUX3
+      7U,  // AUX4
+      8U,  // AUX5
+      9U,  // AUX6
+      10U, // AUX7
+      11U, // AUX8
+      12U, // AUX9
+      13U, // AUX10
+      14U, // AUX11
+      15U, // AUX12
+      16U, // AUX13
+      17U, // AUX14
    };
+
+   static_assert((sizeof(CHANNEL_MAP) / sizeof(CHANNEL_MAP[0])) ==
+     static_cast<uint32_t>(RcChannelName::COUNT),
+     "Configuration Error: CHANNEL_MAP size must match RcChannelName::COUNT.");
 
    /**
    * @brief Constructor for SBus receiver.


### PR DESCRIPTION
This PR addresses issue #45 and changes the channel naming convention used in plainFlight to match that used by Spektrum receivers.  The first four channels are  `Throttle, Aileron, Elevator and Rudder`.  Subsequent channels are named `AUX1 ... AUX14` for a total of 18 channels (SBus) with CRSF receivers having 12 AUX channels.  The hard coding of  various functions has also been removed allowing arbitrary allocation of mandatory and optional functions in the `Config.hpp file`.

Allocation of the mandatory `ARM` and `MODE` functions is ensured with assert statements as is the requirement to have a function channel allocated when certain functions are enabled.  Protection against multiple allocation of channels, including as passthrough channels,  is also provided by assert statements. To do this one file `ChannelValidation.hpp` was added to the repository this file contains the machinery to check no two channels are assigned the same function.  It is only used in `InternalConfig.hpp`  but was thought too large to place there as it was a distraction from the basic function.

Secondly a few small bugs, performance hits and annoyances are fixed here.  These include
1. Ensuring flap status is only evaluated when enabled.
2. Fixing an indexing error when more that 18 channels were selected in SBus.
3. Ensuring the channel arrays will support 18 channels when selected.
4. Fixed `USE_ALL_18_CHANNELS` which would fail as max channels was 16.
5. Removing the side effect of setting `headingHold` by the getter `headingHoldActive()`. 
6. Updating `headingHold` and `propHang` status each loop (previously this was only set when armed leaving incorrect status when not armed. This was an inconsistency not a bug as the functions have no effect when not armed.)
7. Improving the format of data printed with `DEBUG_RC_DATA` to remove jitter when values changed length.

The code has been bench tested.  Assertions function as expected and functions work as expected.
