### PR TITLE
Remove redundant gyro reversals

### DIFF
--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -234,12 +234,6 @@ class Config
   // Gyro rate range. Set exactly one to true.
   static constexpr GyroRate GYRO_RATE                        = GyroRate::IS_250_DEGS_SECOND;
 
-  // Gyro correction direction. Set to true to reverse the correction sense on
-  // the corresponding axis.
-  static constexpr bool REVERSE_PITCH_CORRECTIONS            = false;
-  static constexpr bool REVERSE_ROLL_CORRECTIONS             = false;
-  static constexpr bool REVERSE_YAW_CORRECTIONS              = false;
-
   // Acro trainer recovery rate (degrees/second).
   // Caution: do not exceed the gyro rate set above.
   // Do not set too high on multicopters to avoid overshoot instability.

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -555,31 +555,9 @@ FlightControl::checkStateChange()
 void
 FlightControl::processPIDF(DemandProcessor::Demands * const demands)
 {
-  if constexpr(Config::REVERSE_PITCH_CORRECTIONS)
-  {
-    demands->pitch = pitchPIDF.pidfController(demands->pitch, static_cast<int32_t>(-imuData->mpu6050.gyro_Y * 100.0f), config.getPitchGains());
-  }
-  else
-  {
-    demands->pitch = pitchPIDF.pidfController(demands->pitch, static_cast<int32_t>(imuData->mpu6050.gyro_Y * 100.0f), config.getPitchGains());
-  }
-
-  if constexpr(Config::REVERSE_ROLL_CORRECTIONS)
-  {
-    demands->roll = rollPIDF.pidfController(demands->roll, static_cast<int32_t>(-imuData->mpu6050.gyro_X * 100.0f), config.getRollGains());
-  }
-  else
-  {
-    demands->roll = rollPIDF.pidfController(demands->roll, static_cast<int32_t>(imuData->mpu6050.gyro_X * 100.0f), config.getRollGains());
-  }
-
+  demands->pitch = pitchPIDF.pidfController(demands->pitch, static_cast<int32_t>(imuData->mpu6050.gyro_Y * 100.0f), config.getPitchGains());
+  demands->roll = rollPIDF.pidfController(demands->roll, static_cast<int32_t>(imuData->mpu6050.gyro_X * 100.0f), config.getRollGains());
   float gyro_Z = imuData->mpu6050.gyro_Z;
-
-  if constexpr(Config::REVERSE_YAW_CORRECTIONS)
-  {
-    //Purposely change sign of Z axis here to avoid screwing up madgwick filter.
-    gyro_Z = -gyro_Z;
-  }
 
   if constexpr(InternalConfig::MODEL_IS_MULTICOPTER)
   {

--- a/PlainFlightController/IMU.cpp
+++ b/PlainFlightController/IMU.cpp
@@ -190,21 +190,6 @@ IMU::Madgwick6DOF(const DemandProcessor::FlightState * const flightState)
     }
   }
 
-  if constexpr(Config::REVERSE_ROLL_CORRECTIONS)
-  {
-    m_imu.roll = -m_imu.roll;
-  }
-
-  if constexpr(Config::REVERSE_PITCH_CORRECTIONS)
-  {
-    m_imu.pitch = -m_imu.pitch;
-  }
-
-  if constexpr(Config::REVERSE_YAW_CORRECTIONS && Config::USE_PROP_HANG_MODE)
-  {
-    m_imu.yaw = -m_imu.yaw;
-  }
-
   if constexpr(InternalConfig::DEBUG_MADGWICK)
   {
     const uint64_t nowTime = millis();  


### PR DESCRIPTION
Background: In earlier versions of the code there were 3 possible orientations of the IMU, these were `Default`, `IMU_ROLLED_RIGHT_90` and `IMU_ROLLED_180`. However in practice there are some 24 possible orientations.  In order to be able to configure further orientations the ability to reverse each axis was added.  This brought the config options `REVERSE_PITCH_CORRECTIONS`, `REVERSE_ROLL_CORRECTIONS`, `REVERSE_YAW_CORRECTIONS`.  However the current revision of the code allows direct selection of all 24 possible orientations through orienting of the X and Y axis relative to the aircraft.

There is no longer a need for these parameters to correct IMU orientation issues as all possible mounting orientations are directly supported.

These reversal options can't correctly fix an issue with a servo operation direction as this is take care of further downstream through the `REVERSE_OUTPUT_X` options.

Conclusion: These configuration options no longer serve a useful function and can be removed simplifying both the configuration and IMU/flight control logic.

This PR simply removes all references to REVERSE_XXXXX_CORRECTIONS in the code base.