### PR TITLE
Resolve Issue 44

### DIFF
--- a/PlainFlightController/BearerFactory.hpp
+++ b/PlainFlightController/BearerFactory.hpp
@@ -1,0 +1,64 @@
+/* 
+* Original File Author: D. Gamble (Github: Cyberslug)
+*
+* Copyright (c) 2026 P.Cook (alias 'plainFlight')
+*
+* This file is part of the PlainFlightController distribution (https://github.com/plainFlight/plainFlightController).
+* 
+* This program is free software: you can redistribute it and/or modify  
+* it under the terms of the GNU General Public License as published by  
+* the Free Software Foundation, version 3.
+*
+* This program is distributed in the hope that it will be useful, but 
+* WITHOUT ANY WARRANTY; without even the implied warranty of 
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU 
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+* @file   BearerFactory.hpp
+* @brief  This file contains enums and structures that are used to select and 
+*         instantiate the Receiver and Telemetry bearers 
+*/
+
+#pragma once
+
+#include "RxBase.hpp"
+#include "ITelemetry.hpp"
+#include "Config.hpp"
+#include "InternalConfig.hpp"
+#include "Crsf.hpp"
+#include "SBus.hpp"
+// #include "EspNow.hpp"   // add once finalised; ESPNOW branches below are stubs
+
+/**
+* @class  BearerFactory
+* @brief  Selects and instantiates the receiver and telemetry bearers based
+*         on Config::RECEIVER_TYPE / Config::TELEMETRY_TYPE.
+* @note   Adding a new bearer requires a change here only - no other file
+*         needs to know which receiver types exist.
+*/
+class BearerFactory
+{
+  public:
+    // Adding a new receiver bearer requires: adding it to
+    // ReceiverType and/or TelemetryType in CommonTypes.hpp, then a branch here.
+    static void create(RxBase** outReceiver, ITelemetry** outTelemetry)
+    {
+      if constexpr (Config::RECEIVER_TYPE == ReceiverType::CRSF)
+      {
+        Crsf* crsf = new Crsf();
+        *outReceiver = crsf;
+        *outTelemetry = (Config::TELEMETRY_TYPE == TelemetryType::NONE) ? nullptr : crsf;
+      }
+      else if constexpr (Config::RECEIVER_TYPE == ReceiverType::SBUS)
+      {
+        *outReceiver = new SBus();
+        *outTelemetry = nullptr;   // SBus has no telemetry path; independent
+                                    // bearer support (e.g. ESPNOW) pending
+      }
+    }
+};

--- a/PlainFlightController/BoardConfig.hpp
+++ b/PlainFlightController/BoardConfig.hpp
@@ -45,10 +45,10 @@ struct Board
   const uint8_t LED_ON_BOARD;
   const uint8_t I2C_SDA;
   const uint8_t I2C_SCL;
-  const uint8_t RADIO_RECEIVER_RX;
-  const uint8_t RADIO_RECEIVER_TX;
-  const uint8_t GNSS_RX;
-  const uint8_t GNSS_TX;
+  const uint8_t SERIAL_PORT_1_RX;
+  const uint8_t SERIAL_PORT_1_TX;
+  const uint8_t SERIAL_PORT_2_RX;
+  const uint8_t SERIAL_PORT_2_TX;
   const uint8_t LED_EXTERNAL;
   const uint8_t BATTERY_ADC;
   //Options
@@ -77,10 +77,10 @@ struct Board
     .LED_ON_BOARD       = 21U,//GPIO21
     .I2C_SDA            = 5U, //GPIO5 = D4
     .I2C_SCL            = 6U, //GPIO6 = D5
-    .RADIO_RECEIVER_RX  = 44U,//GPIO44 = D7
-    .RADIO_RECEIVER_TX  = 45U,//GPIO45 = Unmapped pin on the XIAO. Remap if you want to use CRSF telemetry i.e. Try D6 if no external LED used.
-    .GNSS_RX            = 12U,//GPIO11 = On J3 connector
-    .GNSS_TX            = 13U,//GPIO12 = On J3 connector
+    .SERIAL_PORT_1_RX   = 44U,//GPIO44 = D7
+    .SERIAL_PORT_1_TX   = 45U,//GPIO45 = Unmapped pin on the XIAO. Remap if you want to use CRSF telemetry i.e. Try D6 if no external LED used.
+    .SERIAL_PORT_2_RX   = 12U,//GPIO11 = On J3 connector
+    .SERIAL_PORT_2_TX   = 13U,//GPIO12 = On J3 connector
     .LED_EXTERNAL       = 43U,//GPIO1 = D6
     .BATTERY_ADC        = 9U, //GPIO9 = D10
     //Options
@@ -108,10 +108,10 @@ struct Board
     .LED_ON_BOARD       = 21U,  //GPIO21
     .I2C_SDA            = 9U,   //GPIO9
     .I2C_SCL            = 10U,  //GPIO10
-    .RADIO_RECEIVER_RX  = 44U,  //GPIO44
-    .RADIO_RECEIVER_TX  = 43U,  //GPIO43
-    .GNSS_RX            = 11U,  //GPIO11
-    .GNSS_TX            = 12U,  //GPIO12
+    .SERIAL_PORT_1_RX   = 44U,  //GPIO44
+    .SERIAL_PORT_1_TX   = 43U,  //GPIO43
+    .SERIAL_PORT_2_RX   = 11U,  //GPIO11
+    .SERIAL_PORT_2_TX   = 12U,  //GPIO12
     .LED_EXTERNAL       = 14U,  //GPIO14
     .BATTERY_ADC        = 13U,  //GPIO13
     //GPIO 14, 15, 16, 17, 18, 38, 39, 40, 41, 42, 45 spare
@@ -140,10 +140,10 @@ struct Board
     .LED_ON_BOARD       = 38U,  //GPIO38
     .I2C_SDA            = 18U,  //GPIO18
     .I2C_SCL            = 17U,  //GPIO17
-    .RADIO_RECEIVER_RX  = 44U,  //GPIO44
-    .RADIO_RECEIVER_TX  = 43U,  //GPIO43
-    .GNSS_RX            = 11U,  //GPIO11
-    .GNSS_TX            = 12U,  //GPIO12
+    .SERIAL_PORT_1_RX   = 44U,  //GPIO44
+    .SERIAL_PORT_1_TX   = 43U,  //GPIO43
+    .SERIAL_PORT_2_RX   = 11U,  //GPIO11
+    .SERIAL_PORT_2_TX   = 12U,  //GPIO12
     .LED_EXTERNAL       = 14U,  //GPIO14
     .BATTERY_ADC        = 13U,  //GPIO13
     //GPIO 9, 10, 15, 16, 21, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 45, 47, 48 spare
@@ -172,10 +172,10 @@ static constexpr Board WSMC =
   .LED_ON_BOARD       = 21U,  //GPIO21
   .I2C_SDA            = 9U,   //GPIO09
   .I2C_SCL            = 10U,  //GPIO10
-  .RADIO_RECEIVER_RX  = 44U,  //GPIO44
-  .RADIO_RECEIVER_TX  = 43U,  //GPIO43
-  .GNSS_RX            = 11U,  //GPIO11
-  .GNSS_TX            = 12U,  //GPIO12
+  .SERIAL_PORT_1_RX   = 44U,  //GPIO44
+  .SERIAL_PORT_1_TX   = 43U,  //GPIO43
+  .SERIAL_PORT_2_RX   = 11U,  //GPIO11
+  .SERIAL_PORT_2_TX   = 12U,  //GPIO12
   .LED_EXTERNAL       = 16U,  //GPIO16  not used
   .BATTERY_ADC        = 13U,  //GPIO13
   //GPIO 15, 17, 18, 38, 39, 40, 41, 42, 45 spare

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -54,6 +54,7 @@ enum class ReceiverType : uint8_t
 {
   SBUS,
   CRSF
+  // Add future receiver types here
 };
 
 /**
@@ -116,4 +117,18 @@ struct PassThroughStruct
 {
   uint8_t outputPin;
   RcChannelName channel;
+};
+
+enum class SerialPort : uint8_t
+{
+  SERIAL_PORT_1,
+  SERIAL_PORT_2,
+  NOT_APPLICABLE   // Bearer doesn't use a UART, e.g. ESPNOW
+};
+
+enum class TelemetryType : uint8_t
+{
+  NONE,
+  SAME_AS_RECEIVER
+  // Placeholder for alternate telemetry paths where receiver bearer has no telemetry return path (e.g. SBUS)
 };

--- a/PlainFlightController/CommonTypes.hpp
+++ b/PlainFlightController/CommonTypes.hpp
@@ -130,5 +130,5 @@ enum class TelemetryType : uint8_t
 {
   NONE,
   SAME_AS_RECEIVER
-  // Placeholder for alternate telemetry paths where receiver bearer has no telemetry return path (e.g. SBUS)
+  // Placeholder for alternate telemetry paths to support receiver bearer with no telemetry return path (e.g. SBUS)
 };

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -71,12 +71,10 @@ class Config
   static constexpr SerialPort   RECEIVER_SERIAL_PORT         = SerialPort::SERIAL_PORT_1;
 
   // TELEMETRY_TYPE:
-  //   NONE              - no downlink.
+  //   NONE              - no downlink i.e. SBUS.
   //   SAME_AS_RECEIVER  - normal case for any receiver that carries its own
   //                        telemetry return path (e.g. CRSF).
-  // No other options currently implemented - place holder here for an 
-  // independent wireless telemetry bearer, for use with a receiver that 
-  // has no telemetry path of its own (e.g. SBUS).
+  // No other options currently implemented.
   
   static constexpr TelemetryType TELEMETRY_TYPE         = TelemetryType::SAME_AS_RECEIVER;  
 

--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -62,12 +62,23 @@ class Config
 
 
   //==========================================================================
-  // SECTION 2: RECEIVER
-  // Select the protocols matching your radio system.
+  // SECTION 2: RECEIVER & TELEMETRY
+  // Select the protocols matching your radio system and assign a serial port if required
   // Receiver options (CommonTypes.hpp): CRSF, SBUS
   //==========================================================================
 
   static constexpr ReceiverType RECEIVER_TYPE                = ReceiverType::CRSF;
+  static constexpr SerialPort   RECEIVER_SERIAL_PORT         = SerialPort::SERIAL_PORT_1;
+
+  // TELEMETRY_TYPE:
+  //   NONE              - no downlink.
+  //   SAME_AS_RECEIVER  - normal case for any receiver that carries its own
+  //                        telemetry return path (e.g. CRSF).
+  // No other options currently implemented - place holder here for an 
+  // independent wireless telemetry bearer, for use with a receiver that 
+  // has no telemetry path of its own (e.g. SBUS).
+  
+  static constexpr TelemetryType TELEMETRY_TYPE         = TelemetryType::SAME_AS_RECEIVER;  
 
   //==========================================================================
   // SECTION 3: MODEL TYPE
@@ -203,7 +214,6 @@ class Config
   static constexpr bool USE_LOW_VOLTS_CUT_OFF                = false;  // Limit throttle upon low battery voltage.
   static constexpr bool USE_EXTERNAL_LED                     = false;  // Enable external LED output.
   static constexpr bool USE_ACRO_TRAINER                     = false;  // Level mode when pitch & roll sticks centred, rate mode otherwise.
-  static constexpr bool HAS_TELEMETRY                        = true;   // Enable telemetry downlink to the RC transmitter.
 
   // Prop hang / tail-sitter mode (experimental).
   // You need to understand flight controllers well to configure this.
@@ -221,6 +231,7 @@ class Config
   //==========================================================================
 
   static constexpr GnssType     GNSS_TYPE                    = GnssType::NONE;
+  static constexpr SerialPort   GNSS_SERIAL_PORT             = SerialPort::SERIAL_PORT_2;
   static constexpr UbxSeries    GENERATION                   = UbxSeries::UBX_M6_MINUS; // Only relevant for GNSS_TYPE UBX
 
 

--- a/PlainFlightController/Crsf.cpp
+++ b/PlainFlightController/Crsf.cpp
@@ -47,16 +47,18 @@
 
 /**
 * @brief    CRSF constructor.
-* @details  Initialises the UART at CRSF_BAUD (420000 for ELRS) and flushes any
-*           stale bytes so that getDemands() begins with a clean stream.
-* @param    uart   Pointer to the hardware serial port to use.
-* @param    rxPin  GPIO pin number for the UART RX line.
-* @param    txPin  GPIO pin number for the UART TX line.
+* @details  Resolves its UART and pins from Config::RECEIVER_SERIAL_PORT via
+*           InternalConfig, initialises the UART at CRSF_BAUD (420000 for
+*           ELRS), and flushes any stale bytes so getDemands() begins with a
+*           clean stream.
 */
-Crsf::Crsf(HardwareSerial* const uart, const uint8_t rxPin, const uint8_t txPin)
+Crsf::Crsf()
 {
-  m_uart = uart;
-  m_uart->begin(CRSF_BAUD, SERIAL_8N1, rxPin, txPin, false);
+  m_uart = InternalConfig::resolveUart(Config::RECEIVER_SERIAL_PORT);
+  m_uart->begin(CRSF_BAUD, SERIAL_8N1,
+                InternalConfig::resolveRxPin(Config::RECEIVER_SERIAL_PORT),
+                InternalConfig::resolveTxPin(Config::RECEIVER_SERIAL_PORT),
+                false);
   m_uart->flush();
 }
 

--- a/PlainFlightController/Crsf.hpp
+++ b/PlainFlightController/Crsf.hpp
@@ -114,12 +114,11 @@ class Crsf : public RxBase, public ITelemetry
     /**
     * @brief   Constructor.
     * @details Initialises the UART at CRSF_BAUD (420000 baud for ELRS) and
-    *          flushes any stale bytes before the first getDemands() call.
-    * @param   uart    Pointer to the HardwareSerial port to use.
-    * @param   rxPin   GPIO pin number connected to the receiver's TX line.
-    * @param   txPin   GPIO pin number connected to the receiver's RX line.
+    * @details Initialises the UART at CRSF_BAUD (420000 baud for ELRS) using 
+    *          the port selected by Config::RECEIVER_SERIAL_PORT, and flushes 
+    *          any stale bytes before the first getDemands() call.
     */
-    Crsf(HardwareSerial* const uart, const uint8_t rxPin, const uint8_t txPin);
+    Crsf();
 
     /**
     * @brief   Read and decode incoming CRSF stream bytes.

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -30,24 +30,9 @@
 */
 DemandProcessor::DemandProcessor()
 {
-  // Add instantiation code here for new receiver protocols
-  if constexpr (Config::RECEIVER_TYPE == ReceiverType::SBUS)
-  {
-    radioCtrl = new SBus(InternalConfig::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
-  } 
-  else if constexpr (Config::RECEIVER_TYPE == ReceiverType::CRSF)
-  {
-    // Intermediate pointer required to enable implicit upcast to two object types
-    Crsf* crsfObj = new Crsf(InternalConfig::RECEIVER_UART, Config::ESP32S3.RADIO_RECEIVER_RX, Config::ESP32S3.RADIO_RECEIVER_TX);
-    radioCtrl = crsfObj;
-    m_telemetry = crsfObj;
-  }
-  else
-  {
-    ;//Its a MISRA thing.
-  }
-
-  m_normalisedData = radioCtrl->getData();  //Copy across initial Sbus data state i.e. failsafe flag state
+  // Instantiation code receiver protocols
+  BearerFactory::create(&radioCtrl, &m_telemetry);
+  m_normalisedData = radioCtrl->getData();  // Copy across initial data state i.e. failsafe flag state
 }
 
 

--- a/PlainFlightController/DemandProcessor.cpp
+++ b/PlainFlightController/DemandProcessor.cpp
@@ -31,7 +31,7 @@
 DemandProcessor::DemandProcessor()
 {
   // Instantiation code receiver protocols
-  BearerFactory::create(&radioCtrl, &m_telemetry);
+  ReceiverBearer::create(&radioCtrl, &m_telemetry);
   m_normalisedData = radioCtrl->getData();  // Copy across initial data state i.e. failsafe flag state
 }
 

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -27,7 +27,7 @@
 #include "Utilities.hpp"
 #include "RxBase.hpp"
 #include "TelemetryManager.hpp"
-#include "BearerFactory.hpp"  // instantiates receiver and telemetry bearers
+#include "ReceiverBearer.hpp"  // instantiates receiver and telemetry bearers
 #include "Config.hpp"
 #include "Configurator.hpp"
 

--- a/PlainFlightController/DemandProcessor.hpp
+++ b/PlainFlightController/DemandProcessor.hpp
@@ -27,8 +27,7 @@
 #include "Utilities.hpp"
 #include "RxBase.hpp"
 #include "TelemetryManager.hpp"
-#include "SBus.hpp"
-#include "Crsf.hpp"
+#include "BearerFactory.hpp"  // instantiates receiver and telemetry bearers
 #include "Config.hpp"
 #include "Configurator.hpp"
 

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -77,11 +77,13 @@ FlightControl::begin()
 
   batteryMonitor.begin(config.getBatteryScaler());
 
-  if constexpr (Config::HAS_TELEMETRY)
+  if constexpr (InternalConfig::TELEMETRY_ACTIVE)
   {
     if constexpr (Config::GNSS_TYPE != GnssType::NONE)  // The only function of GNSS is for telemetry
     {
-      gnss.beginSafe(*InternalConfig::GNSS_UART, Config::ESP32S3.GNSS_RX, Config::ESP32S3.GNSS_TX);
+      gnss.beginSafe(*InternalConfig::GNSS_UART, 
+                      InternalConfig::resolveRxPin(Config::GNSS_SERIAL_PORT), 
+                      InternalConfig::resolveTxPin(Config::GNSS_SERIAL_PORT));
     }
     telemetryManager.begin(rc.getTelemetry(), 
         InternalConfig::TELEMETRY_BATTERY_PERIOD_MS, 
@@ -163,7 +165,7 @@ FlightControl::operate()
   checkStateChange();
   batteryMonitor.operate();
 
-  if constexpr (Config::HAS_TELEMETRY)
+  if constexpr (InternalConfig::TELEMETRY_ACTIVE)
   {
     // GPS is only gathered and sent when hardware is actually fitted.
     // When GNSS_TYPE == NONE the compiler eliminates this entire block.

--- a/PlainFlightController/InternalConfig.hpp
+++ b/PlainFlightController/InternalConfig.hpp
@@ -66,7 +66,46 @@ namespace InternalConfig
     }
   }
 
-  // Public architectural flags derived from user Config
+static constexpr HardwareSerial* resolveUart(SerialPort port)
+  {
+    switch (port)
+    {
+      case SerialPort::SERIAL_PORT_1: return &Serial0;
+      case SerialPort::SERIAL_PORT_2: return &Serial1;
+      default:                        return nullptr;
+    }
+  }
+
+  static constexpr uint8_t resolveRxPin(SerialPort port)
+  {
+    switch (port)
+    {
+      case SerialPort::SERIAL_PORT_1: return Config::ESP32S3.SERIAL_PORT_1_RX;
+      case SerialPort::SERIAL_PORT_2: return Config::ESP32S3.SERIAL_PORT_2_RX;
+      default:                        return 0U;
+    }
+  }
+
+  static constexpr uint8_t resolveTxPin(SerialPort port)
+  {
+    switch (port)
+    {
+      case SerialPort::SERIAL_PORT_1: return Config::ESP32S3.SERIAL_PORT_1_TX;
+      case SerialPort::SERIAL_PORT_2: return Config::ESP32S3.SERIAL_PORT_2_TX;
+      default:                        return 0U;
+    }
+  }
+
+  static constexpr bool TELEMETRY_ACTIVE = (Config::TELEMETRY_TYPE != TelemetryType::NONE);
+
+  static constexpr HardwareSerial* const GNSS_UART = resolveUart(Config::GNSS_SERIAL_PORT);
+
+  // Serial port conflict check of the only two-UART clash possible.
+  static_assert((Config::GNSS_TYPE == GnssType::NONE)
+                || (Config::GNSS_SERIAL_PORT != Config::RECEIVER_SERIAL_PORT),
+    "Configuration Error: GNSS_SERIAL_PORT clashes with RECEIVER_SERIAL_PORT.");
+
+    // Public architectural flags derived from user Config
   static constexpr bool MODEL_IS_FIXED_WING  = isFixedWing(Config::MODEL_TYPE);
   static constexpr bool MODEL_IS_MULTICOPTER = isMulticopter(Config::MODEL_TYPE);
 
@@ -143,7 +182,5 @@ namespace InternalConfig
 
   // USB serial baud rate and receiver UART port.
   static constexpr uint32_t USB_BAUD                         = 500000U;
-  static constexpr HardwareSerial* const RECEIVER_UART       = &Serial0;
-  static constexpr HardwareSerial* const GNSS_UART           = &Serial1;
 
 }//Namespace InternalConfig end.

--- a/PlainFlightController/ReceiverBearer.hpp
+++ b/PlainFlightController/ReceiverBearer.hpp
@@ -19,7 +19,7 @@
 */
 
 /**
-* @file   BearerFactory.hpp
+* @file   ReceiverBearer.hpp
 * @brief  This file contains enums and structures that are used to select and 
 *         instantiate the Receiver and Telemetry bearers 
 */
@@ -32,7 +32,6 @@
 #include "InternalConfig.hpp"
 #include "Crsf.hpp"
 #include "SBus.hpp"
-// #include "EspNow.hpp"   // add once finalised; ESPNOW branches below are stubs
 
 /**
 * @class  BearerFactory
@@ -41,13 +40,16 @@
 * @note   Adding a new bearer requires a change here only - no other file
 *         needs to know which receiver types exist.
 */
-class BearerFactory
+class ReceiverBearer
 {
   public:
     // Adding a new receiver bearer requires: adding it to
     // ReceiverType and/or TelemetryType in CommonTypes.hpp, then a branch here.
     static void create(RxBase** outReceiver, ITelemetry** outTelemetry)
     {
+      static_assert((Config::RECEIVER_TYPE == ReceiverType::SBUS) || (Config::RECEIVER_TYPE == ReceiverType::CRSF),
+      "Configuration Error: Select RECEIVER_TYPE = SBUS or CRSF.");
+      
       if constexpr (Config::RECEIVER_TYPE == ReceiverType::CRSF)
       {
         Crsf* crsf = new Crsf();
@@ -57,8 +59,7 @@ class BearerFactory
       else if constexpr (Config::RECEIVER_TYPE == ReceiverType::SBUS)
       {
         *outReceiver = new SBus();
-        *outTelemetry = nullptr;   // SBus has no telemetry path; independent
-                                    // bearer support (e.g. ESPNOW) pending
+        *outTelemetry = nullptr;   // SBus has no telemetry path;
       }
     }
 };

--- a/PlainFlightController/SBus.cpp
+++ b/PlainFlightController/SBus.cpp
@@ -37,14 +37,17 @@
 
 /**
 * @brief    SBus constructor.
-* @param    *uart - Pointer to hardware serial port.
-* @param    rxPin - RX pin number.
-* @param    txPin - TX pin number.
+* @details  Resolves its UART and pins from Config::RECEIVER_SERIAL_PORT via
+*           InternalConfig, initialises the UART at SBUS_BAUD, and flushes any
+*           stale bytes so getDemands() begins with a clean stream.
 */
-SBus::SBus(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin)
+SBus::SBus()
 {
-  m_uart = uart;
-  m_uart->begin(SBUS_BAUD, SERIAL_8E2, rxPin, txPin, true);
+  m_uart = InternalConfig::resolveUart(Config::RECEIVER_SERIAL_PORT);
+  m_uart->begin(SBUS_BAUD, SERIAL_8E2,
+                InternalConfig::resolveRxPin(Config::RECEIVER_SERIAL_PORT),
+                InternalConfig::resolveTxPin(Config::RECEIVER_SERIAL_PORT),
+                true);
   m_uart->flush();
 }
 

--- a/PlainFlightController/SBus.hpp
+++ b/PlainFlightController/SBus.hpp
@@ -83,11 +83,11 @@ public:
 
    /**
    * @brief Constructor for SBus receiver.
-   * @param uart Pointer to hardware serial port.
-   * @param rxPin RX pin number.
-   * @param txPin TX pin number.
+   * @details Initialises the UART at SBUS_BAUD using the port selected by
+   *          Config::RECEIVER_SERIAL_PORT, and flushes any stale bytes before
+   *          the first getDemands() call.
    */
-   SBus(HardwareSerial *uart, uint8_t rxPin, uint8_t txPin);
+   SBus();
 
    /**
    * @brief Get new data from SBus receiver.


### PR DESCRIPTION
## Summary

The purpose of this PR is to make the allocation and instantiation of receiver and telemetry scalable to more than the current two types. Receiver and telemetry bearer instantiation are moved out of `DemandProcessor` and into a dedicated `BearerFactory`. Serial port pin assignment moves out of `BoardConfig` and into `Config`, so a board's UART pins are described generically and their use (receiver, GNSS) is declared explicitly at configuration time rather than being implied by pin naming.

## Effect

None for existing builds. With `RECEIVER_TYPE = CRSF` and `TELEMETRY_TYPE = SAME_AS_RECEIVER`, a single `Crsf` instance is created and used for both roles and this matches current behaviour. With `RECEIVER_TYPE = SBUS`, no telemetry bearer is created, also matching current behaviour.
There is a slight change in the way that the receiver and GPS serial ports are specified.  The receiver serial port is now specified immediately below the actual receiver together with the telemetry type.
`static constexpr ReceiverType  RECEIVER_TYPE        = ReceiverType::CRSF;`
`static constexpr SerialPort    RECEIVER_SERIAL_PORT = SerialPort::SERIAL_PORT_1;`
`static constexpr TelemetryType TELEMETRY_TYPE       = TelemetryType::SAME_AS_RECEIVER;`
and the GPS serial port is specified with the type of GPS in a similar fashion.

## Expansion

Comments have been added indicating where additions need to be made to support expansion in the types of receiver and telemetry bearers.