### PR TITLE
Telemetry Bandwidth

### DIFF
--- a/PlainFlightController/Config.hpp
+++ b/PlainFlightController/Config.hpp
@@ -203,7 +203,7 @@ class Config
   static constexpr bool USE_LOW_VOLTS_CUT_OFF                = false;  // Limit throttle upon low battery voltage.
   static constexpr bool USE_EXTERNAL_LED                     = false;  // Enable external LED output.
   static constexpr bool USE_ACRO_TRAINER                     = false;  // Level mode when pitch & roll sticks centred, rate mode otherwise.
-  static constexpr bool HAS_TELEMETRY                        = true;   // Enable telemetry downlink to the RC transmitter.
+  static constexpr bool USE_BATTERY_TELEMETRY                = true;   // Enable telemetry of battery voltage.
 
   // Prop hang / tail-sitter mode (experimental).
   // You need to understand flight controllers well to configure this.

--- a/PlainFlightController/FlightControl.cpp
+++ b/PlainFlightController/FlightControl.cpp
@@ -77,7 +77,7 @@ FlightControl::begin()
 
   batteryMonitor.begin(config.getBatteryScaler());
 
-  if constexpr (Config::HAS_TELEMETRY)
+  if constexpr (Config::USE_BATTERY_TELEMETRY || (Config::GNSS_TYPE != GnssType::NONE))
   {
     if constexpr (Config::GNSS_TYPE != GnssType::NONE)  // The only function of GNSS is for telemetry
     {
@@ -163,19 +163,19 @@ FlightControl::operate()
   checkStateChange();
   batteryMonitor.operate();
 
-  if constexpr (Config::HAS_TELEMETRY)
+  // GPS is only gathered and sent when hardware is actually fitted.
+  // When GNSS_TYPE == NONE the compiler eliminates this entire block.
+  if constexpr (Config::GNSS_TYPE != GnssType::NONE)
   {
-    // GPS is only gathered and sent when hardware is actually fitted.
-    // When GNSS_TYPE == NONE the compiler eliminates this entire block.
-    if constexpr (Config::GNSS_TYPE != GnssType::NONE)
-    {
-      gnss.update();
-      if (gnss.hasNewData()){
-        GnssData d;
-        gnss.getData(d);
-        telemetryManager.updateGnss(d);
-      }
+    gnss.update();
+    if (gnss.hasNewData()){
+      GnssData d;
+      gnss.getData(d);
+      telemetryManager.updateGnss(d);
     }
+  }
+  if constexpr (Config::USE_BATTERY_TELEMETRY)
+  {
     telemetryManager.updateBattery(batteryMonitor.getVoltage());
   }
 


### PR DESCRIPTION
This PR addresses Issue #48.  The `HAS_TELEMETRY` flag in `Config.hpp` is changed to `USE_BATTERY_TELEMETRY`.  Now both Battery and GPS Telemetry can be independently enabled.  Disabling one or the other allows the additional bandwidth to be used for more frequent updates of the other.  Telemetry is disabled by setting `GNSS_TYPE = NONE` and `USE_BATTERY_TELEMETRY = false`